### PR TITLE
Host functionality, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ ICICLE is a CUDA implementation of general functions widely used in ZKP. ICICLE 
 
 ```sh
 mkdir -p build
-nvcc -o build/<ENTER_DIR_NAME> icicle/lib.cu -arch=native
+nvcc -o build/<ENTER_DIR_NAME> ./icicle/appUtils/ntt/ntt.cu ./icicle/appUtils/msm/msm.cu ./icicle/appUtils/vector_manipulation/ve_mod_mult.cu ./icicle/primitives/projective.cu -arch=native
+```
+
+### Testing the CUDA code
+
+We are using [googletest] library for testing. To build and run the test suite for finite field and elliptic curve arithmetic, run from the `icicle` folder:
+
+```sh
+mkdir -p build
+cmake -S . -B build
+cmake --build build
+cd build && ctest
 ```
 
 ### Rust Bindings
@@ -87,4 +98,6 @@ See [LICENSE-MIT][LMIT] for details.
 [B_SCRIPT]: ./build.rs
 [FDI]: https://github.com/ingonyama-zk/fast-danksharding
 [LMIT]: ./LICENSE
+[googletest]: https://github.com/google/googletest/
+
 <!-- End Links -->

--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.14)
+project(icicle)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+# add the target cuda architectures
+# each additional architecture increases the compilation time and output file size
+if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES 80)
+endif ()
+project(bellman-cuda LANGUAGES CUDA CXX)
+
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
+set(CMAKE_CUDA_FLAGS_RELEASE "")
+set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -g -G -O0")
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+add_executable(
+  primitives_test
+  primitives/test.cu
+)
+target_link_libraries(
+  primitives_test
+  GTest::gtest_main
+)
+
+include(GoogleTest)
+set_target_properties(primitives_test PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+
+gtest_discover_tests(primitives_test)

--- a/icicle/appUtils/msm/msm.cu
+++ b/icicle/appUtils/msm/msm.cu
@@ -5,7 +5,7 @@
 #include <cub/device/device_scan.cuh>
 #include "../../utils/cuda_utils.cuh"
 #include "../../primitives/projective.cuh"
-#include "../../primitives/base_curve.cuh"
+#include "../../primitives/field.cuh"
 #include "../../curves/curve_config.cuh"
 #include "msm.cuh"
 

--- a/icicle/appUtils/vector_manipulation/ve_mod_mult.cu
+++ b/icicle/appUtils/vector_manipulation/ve_mod_mult.cu
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <iostream>
-#include "../../primitives/base_curve.cuh"
+#include "../../primitives/field.cuh"
 #include "../../utils/storage.cuh"
 #include "../../primitives/projective.cuh"
 #include "../../curves/curve_config.cuh"

--- a/icicle/appUtils/vector_manipulation/ve_mod_mult.cuh
+++ b/icicle/appUtils/vector_manipulation/ve_mod_mult.cuh
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdexcept>
 #include <cuda.h>
-#include "../../primitives/base_curve.cuh"
+#include "../../primitives/field.cuh"
 #include "../../curves/curve_config.cuh"
 #include "../../primitives/projective.cuh"
 

--- a/icicle/curves/bls12_381.cuh
+++ b/icicle/curves/bls12_381.cuh
@@ -166,5 +166,12 @@ struct fq_config {
   static constexpr storage<limbs_count> zero = {0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
 };
 
+struct group_generator {
+  static constexpr storage<fq_config::limbs_count> generator_x = {0x00000004, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 
+                                                                  0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
+  static constexpr storage<fq_config::limbs_count> generator_y = {0x4abe706c, 0x5ea93e35, 0x00e1de5d, 0x6346b8ed, 0x92848344, 0xda9dd85e, 
+                                                                  0xc9926b26, 0xc760f988, 0xf3763e9b, 0xb33cffc3, 0xd40d6212, 0x0a989bad};
+};
+
 static constexpr unsigned weierstrass_b = 4;
 

--- a/icicle/curves/curve_config.cuh
+++ b/icicle/curves/curve_config.cuh
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "../primitives/base_curve.cuh"
+#include "../primitives/field.cuh"
 #include "../primitives/projective.cuh"
-
 
 #include "bls12_381.cuh"
 // #include "bn254.cuh"
@@ -11,5 +10,5 @@
 typedef Field<fp_config> scalar_field_t;
 typedef scalar_field_t scalar_t;
 typedef Field<fq_config> point_field_t;
-typedef Projective<point_field_t, weierstrass_b> projective_t;
+typedef Projective<point_field_t, scalar_field_t, group_generator, weierstrass_b> projective_t;
 typedef Affine<point_field_t> affine_t;

--- a/icicle/curves/curve_template.cuh
+++ b/icicle/curves/curve_template.cuh
@@ -6,6 +6,14 @@
 // y^2 = weierstrass_a * x^3 + weierstrass_b 
 static constexpr unsigned weierstrass_b = 4;
 
+// a generator of the elliptic curve group
+struct group_generator {
+  static constexpr storage<fq_config::limbs_count> generator_x = {0x00000004, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 
+                                                                  0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
+  static constexpr storage<fq_config::limbs_count> generator_y = {0x4abe706c, 0x5ea93e35, 0x00e1de5d, 0x6346b8ed, 0x92848344, 0xda9dd85e, 
+                                                                  0xc9926b26, 0xc760f988, 0xf3763e9b, 0xb33cffc3, 0xd40d6212, 0x0a989bad};
+};
+
 /// SCALAR FIELD
 struct fp_config {
   // field structure size = 8 * 32 bit

--- a/icicle/primitives/affine.cuh
+++ b/icicle/primitives/affine.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "base_curve.cuh"
+#include "field.cuh"
 
 template <class FF>
 class Affine {  
@@ -16,7 +16,7 @@ class Affine {
       return (xs.x == ys.x) && (xs.y == ys.y);
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const Affine& point) {
+    friend HOST_INLINE std::ostream& operator<<(std::ostream& os, const Affine& point) {
       os << "x: " << point.x << "; y: " << point.y;
       return os;
     }

--- a/icicle/primitives/test.cu
+++ b/icicle/primitives/test.cu
@@ -1,0 +1,76 @@
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+// TODO: change the curve depending on env variable
+#include "../curves/bls12_381.cuh"
+#include "projective.cuh"
+#include "field.cuh"
+
+
+typedef Field<fp_config> scalar_field;
+typedef Field<fq_config> base_field;
+typedef Projective<base_field, scalar_field, group_generator, weierstrass_b> proj;
+
+template <class T>
+int device_populate_random(T* d_elements, unsigned n) {
+    T h_elements[n];
+    for (unsigned i = 0; i < n; i++)
+        h_elements[i] = T::rand_host();
+    return cudaMemcpy(d_elements, h_elements, sizeof(T) * n, cudaMemcpyHostToDevice);
+}
+
+template <class T>
+int device_set(T* d_elements, T el, unsigned n) {
+    T h_elements[n];
+    for (unsigned i = 0; i < n; i++)
+        h_elements[i] = el;
+    return cudaMemcpy(d_elements, h_elements, sizeof(T) * n, cudaMemcpyHostToDevice);
+}
+
+class PrimitivesTest : public ::testing::Test {
+protected:
+  static const unsigned n = 1 << 5;
+
+  proj *points1{};
+  proj *points2{};
+  proj *zeroes{};
+  proj *res1{};
+  proj *res2{};
+
+  PrimitivesTest() {
+    assert(!cudaDeviceReset());
+    assert(!cudaMallocManaged(&points1, n * sizeof(proj)));
+    assert(!cudaMallocManaged(&points2, n * sizeof(proj)));
+    assert(!cudaMallocManaged(&zeroes, n * sizeof(proj)));
+    assert(!cudaMallocManaged(&res1, n * sizeof(proj)));
+    assert(!cudaMallocManaged(&res2, n * sizeof(proj)));
+  }
+
+  ~PrimitivesTest() override {
+    cudaFree(points1);
+    cudaFree(points2);
+    cudaFree(zeroes);
+    cudaFree(res1);
+    cudaFree(res2);
+    cudaDeviceReset();
+  }
+
+  void SetUp() override {
+    ASSERT_EQ(device_populate_random<proj>(points1, n), cudaSuccess);
+    ASSERT_EQ(device_populate_random<proj>(points2, n), cudaSuccess);
+    ASSERT_EQ(device_set<proj>(zeroes, proj::zero(), n), cudaSuccess);
+    ASSERT_EQ(cudaMemset(res1, 0, n * sizeof(proj)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(res2, 0, n * sizeof(proj)), cudaSuccess);
+  }
+};
+
+TEST_F(PrimitivesTest, RandomPointsAreOnCurve) {
+  for (unsigned i = 0; i < n; i++)
+    ASSERT_PRED1(proj::is_on_curve, points1[i]);
+}
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
EC and FF functionality is now implemented for both host and device except:

- `cout` is only overloaded for host, as well as generation of random points and scalars;
- Square root is not implemented. I'm unaware of any use-cases except random point generation, which is alternatively done by multiplying the generator point by a random scalar.

A skeleton of a testing suite based on googletests is implemented with only 1 test for now. Also, some minor renaming and changes to README.