### PR TITLE
Fix for local machines GoogleTest and CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 **/__pycache__/
 **/.DS_Store
 **/Cargo.lock
+**/icicle/build/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ nvcc -o build/<ENTER_DIR_NAME> ./icicle/appUtils/ntt/ntt.cu ./icicle/appUtils/ms
 
 ### Testing the CUDA code
 
-We are using [googletest] library for testing. To build and run the test suite for finite field and elliptic curve arithmetic, run from the `icicle` folder:
+We are using [googletest] library for testing. To build and run [the test suite](./icicle/README.md) for finite field and elliptic curve arithmetic, run from the `icicle` folder:
 
 ```sh
 mkdir -p build

--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
-project(icicle)
+cmake_minimum_required(VERSION 3.16)
 
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 17)
@@ -9,9 +8,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 # add the target cuda architectures
 # each additional architecture increases the compilation time and output file size
 if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES 80)
+    set(CMAKE_CUDA_ARCHITECTURES native) # on 3.24+, on earlier it is ignored, and the target is not passed
 endif ()
-project(bellman-cuda LANGUAGES CUDA CXX)
+project(icicle LANGUAGES CUDA CXX)
 
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
 set(CMAKE_CUDA_FLAGS_RELEASE "")

--- a/icicle/README.md
+++ b/icicle/README.md
@@ -32,6 +32,12 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
 ```
 
+Then you can select with the following command
+
+```sh
+sudo update-alternatives --config gcc
+```
+
 ### 3 - Check for conflicting binaries in PATH
 
 Make sure that there are no conflicting binaries in the PATH environment variable. For example, if `/home/linuxbrew/.linuxbrew/bin` precedes `/usr/bin/` in the PATH, it will override the `update-alternatives` settings.

--- a/icicle/README.md
+++ b/icicle/README.md
@@ -1,0 +1,75 @@
+# Tests
+
+```sh
+mkdir -p build; cmake -S . -B build; cmake --build build; cd build && ctest; cd ..
+```
+
+## Prerequisites on Ubuntu
+
+Before proceeding, make sure the following software installed:
+
+1. CMake at least version 3.16, which can be downloaded from [cmake.org](https://cmake.org/files/)
+   It is recommended to have the latest version installed.
+2. [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu) version 12.0 or newer.
+3. GCC - version 9 or newer recommended.
+
+## Troubleshooting
+
+In case you encounter problems during the build, please follow the points below to troubleshoot:
+
+### 1 - Check CMake log files
+
+If there are issues with the CMake configuration, please check the logs which are located in the `./build/CMakeFiles` directory. Depending on the version of CMake, the log file may have a different name. For example, for CMake version 3.20, one of log files is called `CMakeConfigureLog.yaml`.
+
+### 2 - Check for conflicting GCC versions
+
+Make sure that there are no conflicting versions of GCC installed. You can use the following commands to install and switch between different versions:
+
+```sh
+sudo update-alternatives --install /usr/bin/gcc gcc /home/linuxbrew/.linuxbrew/bin/gcc-12 12
+sudo update-alternatives --install /usr/bin/g++ g++ /home/linuxbrew/.linuxbrew/bin/g++-12 12
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+```
+
+### 3 - Check for conflicting binaries in PATH
+
+Make sure that there are no conflicting binaries in the PATH environment variable. For example, if `/home/linuxbrew/.linuxbrew/bin` precedes `/usr/bin/` in the PATH, it will override the `update-alternatives` settings.
+
+### 4 - Add nvvm path to PATH
+
+If you encounter the error `cicc not found`, make sure to add the nvvm path to PATH. For example, for CUDA version 12.1, the nvvm path is `/usr/local/cuda-12.1/nvvm/bin`.
+
+### 5 - Add CUDA libraries to the project
+
+If you encounter the error `Failed to extract nvcc implicit link line`, add the following code to the CMakeLists.txt file after enabling CUDA:
+
+```c
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+   enable_language(CUDA)
+   find_package(CUDAToolkit)
+   target_link_libraries(project CUDA::cudart)
+   target_link_libraries(project CUDA::cuda_driver)
+else()
+   message(STATUS "No CUDA compiler found")
+endif()
+```
+
+### 6 - Fix update alternatives
+
+If the `update-alternatives` settings are broken, you can try to fix them with the following command:
+
+`yes '' | update-alternatives --force --all`
+
+### 7 - ..bin/crt/link.stub: No such file or directory
+
+If you encounter the error, check if the `$CUDA_HOME/bin/crt/link.stub` file is available.
+
+Othrewise create a symlink. For example, if the CUDA toolkit is installed with apt-get to the default path, you can create a symlink with the following command:
+
+`ln -sf /usr/local/cuda-12.1/bin/crt/link.stub /usr/lib/nvidia-cuda-toolkit/bin/crt/link.stub`
+
+Alternatively, you can replace the old CUDA root with a symlink to the new CUDA installation with the following command:
+
+`ln -sf /usr/local/cuda-12.1/ /usr/lib/nvidia-cuda-toolkit/`


### PR DESCRIPTION
1. Fixes CMake errors on local dev machines
2. Improves on hardcoded CUDA_ARH (fix for #67)
3. Adds troubleshooting section

Tested on 
- Cmake 
  -    3.16
  -    latest 3.26.3 
-  GCC-8, 9, 10
-  CUDA 
    -    12.0, 
    -    12.1 (update 1)
-  Hardware
    -  RTX 3090Ti
    -  Laptop 3050Ti
    -  2080Ti
