### PR TITLE
MSM for large sizes

### DIFF
--- a/icicle/appUtils/msm/Makefile
+++ b/icicle/appUtils/msm/Makefile
@@ -1,0 +1,4 @@
+test_msm:
+	mkdir -p work
+	nvcc -o work/test_msm -I. tests/msm_test.cu
+	work/test_msm

--- a/icicle/appUtils/msm/msm.cu
+++ b/icicle/appUtils/msm/msm.cu
@@ -88,7 +88,6 @@ template <typename P, typename A>
 __global__ void accumulate_buckets_kernel(P *buckets, unsigned *bucket_offsets, unsigned *bucket_sizes, unsigned *single_bucket_indices, unsigned *point_indices, A *points, unsigned nof_buckets, unsigned *nof_buckets_to_compute, unsigned msm_idx_shift){
   
   unsigned tid = (blockIdx.x * blockDim.x) + threadIdx.x;
-  if (tid ==0) printf("nof buckets to comp: %u", *nof_buckets_to_compute);
   if (tid>=*nof_buckets_to_compute){ 
     return;
   }
@@ -108,7 +107,6 @@ __global__ void big_triangle_sum_kernel(P* buckets, P* final_sums, unsigned nof_
 
   unsigned tid = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (tid>=nof_bms) return;
-  // printf("%u",tid);
   P line_sum = buckets[(tid+1)*(1<<c)-1];
   final_sums[tid] = line_sum;
   for (unsigned i = (1<<c)-2; i >0; i--)

--- a/icicle/appUtils/msm/msm.cuh
+++ b/icicle/appUtils/msm/msm.cuh
@@ -17,4 +17,6 @@ void large_msm(S* scalars, A* points, unsigned size, P* result, bool on_device);
 template <typename S, typename P, typename A>
 void short_msm(S *h_scalars, A *h_points, unsigned size, P* h_final_result, bool on_device);
 
+template <typename A, typename S, typename P>
+void reference_msm(S* scalars, A* a_points, unsigned size);
 #endif

--- a/icicle/appUtils/msm/tests/msm_test.cu
+++ b/icicle/appUtils/msm/tests/msm_test.cu
@@ -1,0 +1,256 @@
+#include <iostream>
+#include <chrono>
+#include <vector>
+#include "msm.cu"
+#include "../../utils/cuda_utils.cuh"
+#include "../../primitives/projective.cuh"
+#include "../../primitives/field.cuh"
+#include "../../curves/bls12_381/curve_config.cuh"
+
+using namespace BLS12_381;
+
+struct fake_point
+{
+  unsigned val = 0;
+
+  __host__ __device__ inline fake_point operator+(fake_point fp) {
+        return {val+fp.val};
+    }
+
+  __host__ __device__ fake_point zero() {
+        fake_point p;
+        return p;
+    }
+
+};
+
+std::ostream& operator<<(std::ostream &strm, const fake_point &a) {
+  return strm <<a.val;
+}
+
+struct fake_scalar
+{
+  unsigned val = 0;
+  unsigned bitsize = 32;
+
+  // __host__ __device__ unsigned get_scalar_digit(unsigned digit_num, unsigned digit_width){
+
+  //   return (val>>(digit_num*digit_width))&((1<<digit_width)-1);
+
+  // }
+  __host__ __device__ int get_scalar_digit(int digit_num, int digit_width){
+
+    return (val>>(digit_num*digit_width))&((1<<digit_width)-1);
+
+  }
+
+  __host__ __device__ inline fake_point operator*(fake_point fp) {
+      
+      fake_point p1;
+      fake_point p2;
+      unsigned x = val;
+      if (x == 0) return fake_point().zero();
+
+      unsigned i = 1;
+      unsigned c_bit = (x & (1<<(bitsize-1)))>>(bitsize-1);
+      while (c_bit==0 && i<bitsize){
+        i++;
+        c_bit = (x & (1<<(bitsize-i)))>>(bitsize-i);
+      }
+      p1 = fp;
+      p2 = p1+p1;
+      while (i<bitsize){
+        i++;
+        c_bit = (x & (1<<(bitsize-i)))>>(bitsize-i);
+        if (c_bit){
+          p1 = p1 + p2;
+          p2 = p2 + p2;
+        }
+        else {
+          p2 = p1 + p2;
+          p1 = p1 + p1;
+        }
+      }
+      
+      return p1;
+  }
+
+};
+
+class Dummy_Scalar {
+  public:
+    static constexpr unsigned NBITS = 32;
+
+    unsigned x;
+
+    friend HOST_INLINE std::ostream& operator<<(std::ostream& os, const Dummy_Scalar& scalar) {
+      os << scalar.x;
+      return os;
+    }
+
+    HOST_DEVICE_INLINE unsigned get_scalar_digit(unsigned digit_num, unsigned digit_width) {
+      return (x>>(digit_num*digit_width))&((1<<digit_width)-1);
+    }
+
+    friend HOST_DEVICE_INLINE Dummy_Scalar operator+(Dummy_Scalar p1, const Dummy_Scalar& p2) {   
+      return {p1.x+p2.x};
+    }
+
+    friend HOST_DEVICE_INLINE bool operator==(const Dummy_Scalar& p1, const Dummy_Scalar& p2) {
+      return (p1.x == p2.x);
+    }
+
+    friend HOST_DEVICE_INLINE bool operator==(const Dummy_Scalar& p1, const unsigned p2) {
+      return (p1.x == p2);
+    }
+
+    // static HOST_DEVICE_INLINE Dummy_Scalar neg(const Dummy_Scalar &scalar) { 
+    //   return {Dummy_Scalar::neg(point.x)};
+    // }
+    static HOST_INLINE Dummy_Scalar rand_host() {
+      return {(unsigned)rand()};
+    }
+};
+
+class Dummy_Projective {
+
+  public:
+    Dummy_Scalar x;
+
+    static HOST_DEVICE_INLINE Dummy_Projective zero() {
+      return {0};
+    }
+
+    static HOST_DEVICE_INLINE Dummy_Projective to_affine(const Dummy_Projective &point) {
+      return {point.x};
+    }
+
+    static HOST_DEVICE_INLINE Dummy_Projective from_affine(const Dummy_Projective &point) {
+      return {point.x};
+    }
+
+    // static HOST_DEVICE_INLINE Dummy_Projective neg(const Dummy_Projective &point) { 
+    //   return {Dummy_Scalar::neg(point.x)};
+    // }
+
+    friend HOST_DEVICE_INLINE Dummy_Projective operator+(Dummy_Projective p1, const Dummy_Projective& p2) {   
+      return {p1.x+p2.x};
+    }
+
+    // friend HOST_DEVICE_INLINE Dummy_Projective operator-(Dummy_Projective p1, const Dummy_Projective& p2) {   
+    //   return p1 + neg(p2);
+    // }
+
+    friend HOST_INLINE std::ostream& operator<<(std::ostream& os, const Dummy_Projective& point) {
+      os << point.x;
+      return os;
+    }
+
+    friend HOST_DEVICE_INLINE Dummy_Projective operator*(Dummy_Scalar scalar, const Dummy_Projective& point) {   
+      Dummy_Projective res = zero();
+  #ifdef CUDA_ARCH
+  #pragma unroll
+  #endif
+      for (int i = 0; i < Dummy_Scalar::NBITS; i++) {
+        if (i > 0) {
+          res = res + res;
+        }
+        if (scalar.get_scalar_digit(Dummy_Scalar::NBITS - i - 1, 1)) {
+          res = res + point;
+        }
+      }
+      return res;
+    }
+
+    friend HOST_DEVICE_INLINE bool operator==(const Dummy_Projective& p1, const Dummy_Projective& p2) {
+      return (p1.x == p2.x);
+    }
+
+    static HOST_DEVICE_INLINE bool is_zero(const Dummy_Projective &point) {
+      return point.x == 0;
+    }
+
+    static HOST_INLINE Dummy_Projective rand_host() {
+      return {(unsigned)rand()};
+    }
+};
+
+//switch between dummy and real:
+
+typedef scalar_t test_scalar;
+typedef projective_t test_projective;
+typedef affine_t test_affine;
+
+// typedef Dummy_Scalar test_scalar;
+// typedef Dummy_Projective test_projective;
+// typedef Dummy_Projective test_affine;
+
+int main()
+{
+  unsigned batch_size = 4;
+  unsigned msm_size = 1<<15;
+  unsigned N = batch_size*msm_size;
+
+  test_scalar *scalars = new test_scalar[N];
+  test_affine *points = new test_affine[N];
+  
+  for (unsigned i=0;i<N;i++){
+    scalars[i] = (i%msm_size < 10)? test_scalar::rand_host() : scalars[i-10];
+    points[i] = (i%msm_size < 10)? test_projective::to_affine(test_projective::rand_host()): points[i-10];
+    // scalars[i] = test_scalar::rand_host();
+    // points[i] = test_projective::to_affine(test_projective::rand_host());
+  }
+  std::cout<<"finished generating"<<std::endl;
+
+  // projective_t *short_res = (projective_t*)malloc(sizeof(projective_t));
+  // test_projective *large_res = (test_projective*)malloc(sizeof(test_projective));
+  test_projective large_res[batch_size];
+  test_projective batched_large_res[batch_size];
+  // fake_point *large_res = (fake_point*)malloc(sizeof(fake_point));
+  // fake_point batched_large_res[256];
+
+
+  // short_msm<scalar_t, projective_t, affine_t>(scalars, points, N, short_res);
+  for (unsigned i=0;i<batch_size;i++){
+    large_msm<test_scalar, test_projective, test_affine>(scalars+msm_size*i, points+msm_size*i, msm_size, large_res+i, false);
+    // std::cout<<"final result large"<<std::endl;
+    // std::cout<<test_projective::to_affine(*large_res)<<std::endl;
+  }
+  auto begin = std::chrono::high_resolution_clock::now();
+  batched_large_msm<test_scalar, test_projective, test_affine>(scalars, points, batch_size, msm_size, batched_large_res, false);
+  // large_msm<test_scalar, test_projective, test_affine>(scalars, points, msm_size, large_res, false);
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
+  printf("Time measured: %.3f seconds.\n", elapsed.count() * 1e-9);
+  std::cout<<test_projective::to_affine(large_res[0])<<std::endl;
+
+  // reference_msm<test_affine, test_scalar, test_projective>(scalars, points, msm_size);
+
+  std::cout<<"final results batched large"<<std::endl;
+  bool success = true;
+  for (unsigned i = 0; i < batch_size; i++)
+  {
+    std::cout<<test_projective::to_affine(batched_large_res[i])<<std::endl;
+    if (test_projective::to_affine(large_res[i])==test_projective::to_affine(batched_large_res[i])){
+      std::cout<<"good"<<std::endl;
+    }
+    else{
+      std::cout<<"miss"<<std::endl;
+      std::cout<<test_projective::to_affine(large_res[i])<<std::endl;
+      success = false;
+    }
+  }
+  if (success){
+    std::cout<<"success!"<<std::endl;
+  }
+  
+  // std::cout<<batched_large_res[0]<<std::endl;
+  // std::cout<<batched_large_res[1]<<std::endl;
+  // std::cout<<projective_t::to_affine(batched_large_res[0])<<std::endl;
+  // std::cout<<projective_t::to_affine(batched_large_res[1])<<std::endl;
+
+  // std::cout<<"final result short"<<std::endl;
+  // std::cout<<pr<<std::endl;
+
+  return 0;
+}

--- a/icicle/curves/bls12_377/msm.cu
+++ b/icicle/curves/bls12_377/msm.cu
@@ -12,13 +12,7 @@ int msm_cuda_bls12_377(BLS12_377::projective_t *out, BLS12_377::affine_t points[
 {
     try
     {
-        if (count>256){
-            large_msm<BLS12_377::scalar_t, BLS12_377::projective_t, BLS12_377::affine_t>(scalars, points, count, out, false);
-        }
-        else{
-            short_msm<BLS12_377::scalar_t, BLS12_377::projective_t, BLS12_377::affine_t>(scalars, points, count, out, false);
-        }
-
+        large_msm<BLS12_377::scalar_t, BLS12_377::projective_t, BLS12_377::affine_t>(scalars, points, count, out, false);
         return CUDA_SUCCESS;
     }
     catch (const std::runtime_error &ex)

--- a/icicle/curves/bls12_381/msm.cu
+++ b/icicle/curves/bls12_381/msm.cu
@@ -12,13 +12,7 @@ int msm_cuda_bls12_381(BLS12_381::projective_t *out, BLS12_381::affine_t points[
 {
     try
     {
-        if (count>256){
-            large_msm<BLS12_381::scalar_t, BLS12_381::projective_t, BLS12_381::affine_t>(scalars, points, count, out, false);
-        }
-        else{
-            short_msm<BLS12_381::scalar_t, BLS12_381::projective_t, BLS12_381::affine_t>(scalars, points, count, out, false);
-        }
-
+        large_msm<BLS12_381::scalar_t, BLS12_381::projective_t, BLS12_381::affine_t>(scalars, points, count, out, false);
         return CUDA_SUCCESS;
     }
     catch (const std::runtime_error &ex)

--- a/icicle/curves/bn254/msm.cu
+++ b/icicle/curves/bn254/msm.cu
@@ -12,13 +12,7 @@ int msm_cuda_bn254(BN254::projective_t *out, BN254::affine_t points[],
 {
     try
     {
-        if (count>256){
-            large_msm<BN254::scalar_t, BN254::projective_t, BN254::affine_t>(scalars, points, count, out, false);
-        }
-        else{
-            short_msm<BN254::scalar_t, BN254::projective_t, BN254::affine_t>(scalars, points, count, out, false);
-        }
-
+        large_msm<BN254::scalar_t, BN254::projective_t, BN254::affine_t>(scalars, points, count, out, false);
         return CUDA_SUCCESS;
     }
     catch (const std::runtime_error &ex)

--- a/icicle/curves/curve_template/msm.cu
+++ b/icicle/curves/curve_template/msm.cu
@@ -12,13 +12,7 @@ int msm_cuda_CURVE_NAME_L(CURVE_NAME_U::projective_t *out, CURVE_NAME_U::affine_
 {
     try
     {
-        if (count>256){
-            large_msm<CURVE_NAME_U::scalar_t, CURVE_NAME_U::projective_t, CURVE_NAME_U::affine_t>(scalars, points, count, out, false);
-        }
-        else{
-            short_msm<CURVE_NAME_U::scalar_t, CURVE_NAME_U::projective_t, CURVE_NAME_U::affine_t>(scalars, points, count, out, false);
-        }
-
+        large_msm<CURVE_NAME_U::scalar_t, CURVE_NAME_U::projective_t, CURVE_NAME_U::affine_t>(scalars, points, count, out, false);
         return CUDA_SUCCESS;
     }
     catch (const std::runtime_error &ex)


### PR DESCRIPTION
- Fixed bugs in 2 kernels of the MSM, the kernels had threads that were accessing out-of-bound memory.
- The value of C is now chosen more optimally - as a function of the MSM size.
- Added a CUDA test file for debugging the MSM. Classes of dummy points and scalars can be used.
- MSM tested up to 2^24 against arkworks.