### PR TITLE
Fix curve config location and link to some namespace struct members

### DIFF
--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 # add the target cuda architectures

--- a/icicle/curves/bls12_381/params.cuh
+++ b/icicle/curves/bls12_381/params.cuh
@@ -190,11 +190,4 @@ namespace PARAMS_BLS12_381{
                                                                           0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
   static constexpr storage<fq_config::limbs_count> weierstrass_b_g2_im = {0x00000004, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
                                                                           0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
-
-  constexpr storage<fq_config::limbs_count> fq_config::m;
-  constexpr storage<fq_config::limbs_count> fq_config::modulus;
-  constexpr storage<2*fq_config::limbs_count> fq_config::modulus_wide;
-  constexpr storage<fp_config::limbs_count> fp_config::m;
-  constexpr storage<fp_config::limbs_count> fp_config::modulus;
-  constexpr storage<2*fp_config::limbs_count> fp_config::modulus_wide;
 }

--- a/icicle/curves/bls12_381/params.cuh
+++ b/icicle/curves/bls12_381/params.cuh
@@ -190,4 +190,11 @@ namespace PARAMS_BLS12_381{
                                                                           0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
   static constexpr storage<fq_config::limbs_count> weierstrass_b_g2_im = {0x00000004, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
                                                                           0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000};
+
+  constexpr storage<fq_config::limbs_count> fq_config::m;
+  constexpr storage<fq_config::limbs_count> fq_config::modulus;
+  constexpr storage<2*fq_config::limbs_count> fq_config::modulus_wide;
+  constexpr storage<fp_config::limbs_count> fp_config::m;
+  constexpr storage<fp_config::limbs_count> fp_config::modulus;
+  constexpr storage<2*fp_config::limbs_count> fp_config::modulus_wide;
 }

--- a/icicle/primitives/test_kernels.cuh
+++ b/icicle/primitives/test_kernels.cuh
@@ -1,18 +1,18 @@
 #pragma once
 
 // TODO: change the curve depending on env variable
-#include "../curves/bls12_381.cuh"
+#include "../curves/bls12_381/curve_config.cuh"
 #include "projective.cuh"
 #include "extension_field.cuh"
 
-typedef Field<fp_config> scalar_field;
-typedef Field<fq_config> base_field;
+typedef Field<PARAMS_BLS12_381::fp_config> scalar_field;
+typedef Field<PARAMS_BLS12_381::fq_config> base_field;
 typedef Affine<base_field> affine;
-static constexpr base_field b = base_field{ weierstrass_b };
+static constexpr base_field b = base_field{ PARAMS_BLS12_381::weierstrass_b };
 typedef Projective<base_field, scalar_field, b> proj;
-typedef ExtensionField<fq_config> base_extension_field;
+typedef ExtensionField<PARAMS_BLS12_381::fq_config> base_extension_field;
 typedef Affine<base_extension_field> g2_affine;
-static constexpr base_extension_field b2 = base_extension_field{ base_field {b_re},  base_field {b_im}};
+static constexpr base_extension_field b2 = base_extension_field{ base_field {PARAMS_BLS12_381::weierstrass_b_g2_re },  base_field {PARAMS_BLS12_381::weierstrass_b_g2_im }};
 typedef Projective<base_extension_field, scalar_field, b2> g2_proj;
 
 


### PR DESCRIPTION
This PR fixes the compilation of the Google tests.
The header with the curve configuration was not pointing on the correct path. 
Some static struct members needed a definition for solving linking problems.

Resolves #103 
