### PR TITLE
CI: Remove caching and move linux to self-hosted

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,9 +1,9 @@
-name: Build
+name: Build Dev
 
 on:
   pull_request:
     branches:
-      - main
+      - dev
     paths:
       - icicle/**
       - src/**


### PR DESCRIPTION
## Describe the changes

This PR:
- Removes the use of github caching (which wasn't working properly)
- Moves linux build job to a self hosted runner
- Uses a network download with specific packages for Windows to shorten times
- Splits `main` and `dev` actions to ensure build badges are correctly shown

## Linked Issues

Resolves #119
