### PR TITLE
Support cmake versions below 3.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ ICICLE is a CUDA implementation of general functions widely used in ZKP. ICICLE 
 
 ## Build and usage
 
-> NOTE: [NVCC] is a prerequisite for building.
+
+### Prerequisites
+
+- [NVCC]
+- cmake 3.24.0 and above (though 3.22.1 has been tested and works as well)
+
+### Steps
 
 1. Define or select a curve for your application; we've provided a [template][CRV_TEMPLATE] for defining a curve
 2. Include the curve in [`curve_config.cuh`][CRV_CONFIG]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ICICLE is a CUDA implementation of general functions widely used in ZKP. ICICLE 
 ### Prerequisites
 
 - [NVCC]
-- cmake 3.24.0 and above (though 3.22.1 has been tested and works as well)
+- cmake 3.18 and above
 
 ### Steps
 

--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -7,7 +7,9 @@ set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 # add the target cuda architectures
 # each additional architecture increases the compilation time and output file size
-if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+if (${CMAKE_VERSION} VERSION_LESS "3.24.0")
+    set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH})
+else()
     set(CMAKE_CUDA_ARCHITECTURES native) # on 3.24+, on earlier it is ignored, and the target is not passed
 endif ()
 project(icicle LANGUAGES CUDA CXX)


### PR DESCRIPTION
This PR modifies `icicle/CMakeLists.txt` to set `CMAKE_CUDA_ARCHITECTURES` to `${CUDA_ARCH}` if the cmake version is less than 3.24.0, and `native` otherwise. This change has been successfully tested with cmake 3.22.1 but I can't confirm if even earlier versions of cmake work.

## Linked Issues

Resolves #159. Thanks to @jeremyfelder for coming up with the solution!
