### PR TITLE
Two curve NTT correctness issue hotfix

### DIFF
--- a/icicle/appUtils/ntt/ntt.cuh
+++ b/icicle/appUtils/ntt/ntt.cuh
@@ -8,7 +8,7 @@
 const uint32_t MAX_NUM_THREADS = 512;
 const uint32_t MAX_THREADS_BATCH = 512;          // TODO: allows 100% occupancy for scalar NTT for sm_86..sm_89
 const uint32_t MAX_SHARED_MEM_ELEMENT_SIZE = 32; // TODO: occupancy calculator, hardcoded for sm_86..sm_89
-const uint32_t MAX_SHARED_MEM = MAX_SHARED_MEM_ELEMENT_SIZE * 1024;
+const uint32_t MAX_SHARED_MEM = MAX_SHARED_MEM_ELEMENT_SIZE * MAX_NUM_THREADS;
 
 /**
  * Computes the twiddle factors.

--- a/icicle/primitives/affine.cuh
+++ b/icicle/primitives/affine.cuh
@@ -11,12 +11,13 @@ public:
 
   static HOST_DEVICE_INLINE Affine neg(const Affine& point) { return {point.x, FF::neg(point.y)}; }
 
-  static HOST_DEVICE_INLINE Affine to_montgomery(const Affine& point) 
+  static HOST_DEVICE_INLINE Affine to_montgomery(const Affine& point)
   {
     return {FF::to_montgomery(point.x), FF::to_montgomery(point.y)};
   }
 
-  static HOST_DEVICE_INLINE Affine from_montgomery(const Affine& point) {
+  static HOST_DEVICE_INLINE Affine from_montgomery(const Affine& point)
+  {
     return {FF::from_montgomery(point.x), FF::from_montgomery(point.y)};
   }
 

--- a/icicle/primitives/affine.cuh
+++ b/icicle/primitives/affine.cuh
@@ -11,6 +11,15 @@ public:
 
   static HOST_DEVICE_INLINE Affine neg(const Affine& point) { return {point.x, FF::neg(point.y)}; }
 
+  static HOST_DEVICE_INLINE Affine to_montgomery(const Affine& point) 
+  {
+    return {FF::to_montgomery(point.x), FF::to_montgomery(point.y)};
+  }
+
+  static HOST_DEVICE_INLINE Affine from_montgomery(const Affine& point) {
+    return {FF::from_montgomery(point.x), FF::from_montgomery(point.y)};
+  }
+
   friend HOST_DEVICE_INLINE bool operator==(const Affine& xs, const Affine& ys)
   {
     return (xs.x == ys.x) && (xs.y == ys.y);

--- a/icicle/primitives/field.cuh
+++ b/icicle/primitives/field.cuh
@@ -65,10 +65,6 @@ public:
 
   static constexpr HOST_DEVICE_INLINE Field modulus() { return Field{CONFIG::modulus}; }
 
-  static constexpr HOST_DEVICE_INLINE Field montgomery_r() { return Field{CONFIG::montgomery_r}; }
-
-  static constexpr HOST_DEVICE_INLINE Field montgomery_r_inv() { return Field{CONFIG::montgomery_r_inv}; }
-
   // private:
   typedef storage<TLC> ff_storage;
   typedef storage<2 * TLC> ff_wide_storage;
@@ -714,7 +710,7 @@ public:
     hex_string << std::hex << std::setfill('0');
 
     for (int i = 0; i < TLC; i++) {
-      hex_string << std::setw(8) << xs.limbs_storage.limbs[i];
+      hex_string << std::setw(8) << xs.limbs_storage.limbs[TLC - i - 1];
     }
 
     os << "0x" << hex_string.str();
@@ -744,6 +740,15 @@ public:
     Wide rs = {};
     multiply_raw(xs.limbs_storage, ys.limbs_storage, rs.limbs_storage);
     return rs;
+  }
+
+  static constexpr HOST_DEVICE_INLINE Field to_montgomery(const Field& xs) 
+  {
+    return xs * Field{CONFIG::montgomery_r};
+  }
+
+  static constexpr HOST_DEVICE_INLINE Field from_montgomery(const Field& xs) {
+    return xs * Field{CONFIG::montgomery_r_inv};
   }
 
   static constexpr DEVICE_INLINE uint32_t

--- a/icicle/primitives/field.cuh
+++ b/icicle/primitives/field.cuh
@@ -742,12 +742,10 @@ public:
     return rs;
   }
 
-  static constexpr HOST_DEVICE_INLINE Field to_montgomery(const Field& xs) 
-  {
-    return xs * Field{CONFIG::montgomery_r};
-  }
+  static constexpr HOST_DEVICE_INLINE Field to_montgomery(const Field& xs) { return xs * Field{CONFIG::montgomery_r}; }
 
-  static constexpr HOST_DEVICE_INLINE Field from_montgomery(const Field& xs) {
+  static constexpr HOST_DEVICE_INLINE Field from_montgomery(const Field& xs)
+  {
     return xs * Field{CONFIG::montgomery_r_inv};
   }
 

--- a/icicle/primitives/projective.cuh
+++ b/icicle/primitives/projective.cuh
@@ -22,12 +22,13 @@ public:
 
   static HOST_DEVICE_INLINE Projective from_affine(const Affine<FF>& point) { return {point.x, point.y, FF::one()}; }
 
-  static HOST_DEVICE_INLINE Projective to_montgomery(const Projective& point) 
+  static HOST_DEVICE_INLINE Projective to_montgomery(const Projective& point)
   {
     return {FF::to_montgomery(point.x), FF::to_montgomery(point.y), FF::to_montgomery(point.z)};
   }
 
-  static HOST_DEVICE_INLINE Projective from_montgomery(const Projective& point) {
+  static HOST_DEVICE_INLINE Projective from_montgomery(const Projective& point)
+  {
     return {FF::from_montgomery(point.x), FF::from_montgomery(point.y), FF::from_montgomery(point.z)};
   }
 

--- a/icicle/primitives/projective.cuh
+++ b/icicle/primitives/projective.cuh
@@ -22,6 +22,15 @@ public:
 
   static HOST_DEVICE_INLINE Projective from_affine(const Affine<FF>& point) { return {point.x, point.y, FF::one()}; }
 
+  static HOST_DEVICE_INLINE Projective to_montgomery(const Projective& point) 
+  {
+    return {FF::to_montgomery(point.x), FF::to_montgomery(point.y), FF::to_montgomery(point.z)};
+  }
+
+  static HOST_DEVICE_INLINE Projective from_montgomery(const Projective& point) {
+    return {FF::from_montgomery(point.x), FF::from_montgomery(point.y), FF::from_montgomery(point.z)};
+  }
+
   static HOST_DEVICE_INLINE Projective generator() { return {GENERATOR_X, GENERATOR_Y, FF::one()}; }
 
   static HOST_DEVICE_INLINE Projective neg(const Projective& point) { return {point.x, FF::neg(point.y), point.z}; }

--- a/icicle/utils/mont.cuh
+++ b/icicle/utils/mont.cuh
@@ -1,15 +1,21 @@
 #pragma once
 
-#include "../appUtils/vector_manipulation/ve_mod_mult.cuh"
+#define MAX_THREADS_PER_BLOCK 256
 
-template <typename E>
-int convert_montgomery(E* d_inout, size_t n_elments, bool is_into, cudaStream_t stream)
+template <typename E, bool is_into>
+__global__ void montgomery_kernel(E* inout, int n)
+{
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < n) { inout[tid] = is_into ? E::to_montgomery(inout[tid]) : E::from_montgomery(inout[tid]); }
+}
+
+template <typename E, bool is_into>
+int convert_montgomery(E* d_inout, int n, cudaStream_t stream)
 {
   // Set the grid and block dimensions
   int num_threads = MAX_THREADS_PER_BLOCK;
-  int num_blocks = (n_elments + num_threads - 1) / num_threads;
-  E mont = is_into ? E::montgomery_r() : E::montgomery_r_inv();
-  template_normalize_kernel<<<num_blocks, num_threads, 0, stream>>>(d_inout, n_elments, mont);
+  int num_blocks = (n + num_threads - 1) / num_threads;
+  montgomery_kernel<E, is_into><<<num_blocks, num_threads, 0, stream>>>(d_inout, n);
 
   return 0; // TODO: void with propper error handling
 }
@@ -17,11 +23,11 @@ int convert_montgomery(E* d_inout, size_t n_elments, bool is_into, cudaStream_t 
 template <typename E>
 int to_montgomery(E* d_inout, unsigned n, cudaStream_t stream)
 {
-  return convert_montgomery(d_inout, n, true, stream);
+  return convert_montgomery<E, true>(d_inout, n, stream);
 }
 
 template <typename E>
 int from_montgomery(E* d_inout, unsigned n, cudaStream_t stream)
 {
-  return convert_montgomery(d_inout, n, false, stream);
+  return convert_montgomery<E, false>(d_inout, n, stream);
 }


### PR DESCRIPTION
This PR resolves the problem occurring in gnark groth16 circuits that use more than one curve simultaneously. More specifically, verification fails due to `krs2` MSM being incorrect, in turn caused by `computeH` function returning incorrect result. On closer inspection it turned out that `template_normalize_kernel` [here](https://github.com/ingonyama-zk/icicle/blob/main/icicle/appUtils/ntt/ntt.cuh#L333) just doesn't launch. It does so silently, without throwing any errors or visible memory leaks. It does seem that the problem has to do with compilation because simply using the same kernel with a different name helps as well as only using a single curve. The "fix" in this PR just replaces a second use-case of `template_normalize_kernel` with a more correct Montgomery treatment cherry-picked from our new API branch. I will try to get more info about this error in the following days while for now this fix should suffice.
PS: guess it's one more point for unified compilation for different wrapper languages - hopefully we'll have fewer strange hard-to-debug C++ compilation bugs that way lol...