### PR TITLE
fix typos in logs

### DIFF
--- a/goicicle/curves/bls12377/msm_test.go
+++ b/goicicle/curves/bls12377/msm_test.go
@@ -179,7 +179,7 @@ func BenchmarkCommit(b *testing.B) {
 				e := Commit(out_d, scalars_d, points_d, msmSize, 10)
 
 				if e != 0 {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -226,7 +226,7 @@ func BenchmarkMSM(b *testing.B) {
 				_, e := Msm(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -288,7 +288,7 @@ func BenchmarkMsmG2BLS12_377(b *testing.B) {
 				_, e := MsmG2(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})

--- a/goicicle/curves/bls12381/msm_test.go
+++ b/goicicle/curves/bls12381/msm_test.go
@@ -179,7 +179,7 @@ func BenchmarkCommit(b *testing.B) {
 				e := Commit(out_d, scalars_d, points_d, msmSize, 10)
 
 				if e != 0 {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -226,7 +226,7 @@ func BenchmarkMSM(b *testing.B) {
 				_, e := Msm(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -288,7 +288,7 @@ func BenchmarkMsmG2BLS12_381(b *testing.B) {
 				_, e := MsmG2(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})

--- a/goicicle/curves/bn254/msm_test.go
+++ b/goicicle/curves/bn254/msm_test.go
@@ -179,7 +179,7 @@ func BenchmarkCommit(b *testing.B) {
 				e := Commit(out_d, scalars_d, points_d, msmSize, 10)
 
 				if e != 0 {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -226,7 +226,7 @@ func BenchmarkMSM(b *testing.B) {
 				_, e := Msm(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -288,7 +288,7 @@ func BenchmarkMsmG2BN254(b *testing.B) {
 				_, e := MsmG2(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})

--- a/goicicle/curves/bw6761/msm_test.go
+++ b/goicicle/curves/bw6761/msm_test.go
@@ -186,7 +186,7 @@ func BenchmarkCommit(b *testing.B) {
 				goicicle.CudaMemCpyDtoH[G1ProjectivePoint](outHost, out_d, 288)
 				assert.True(b, outHost[0].IsOnCurve())
 				if e != 0 {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -233,7 +233,7 @@ func BenchmarkMSM(b *testing.B) {
 				_, e := Msm(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -295,7 +295,7 @@ func BenchmarkMsmG2BW6761(b *testing.B) {
 				_, e := MsmG2(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})

--- a/goicicle/templates/msm/msm_test.go.tmpl
+++ b/goicicle/templates/msm/msm_test.go.tmpl
@@ -161,7 +161,7 @@ func BenchmarkCommit(b *testing.B) {
 				e := Commit(out_d, scalars_d, points_d, msmSize, 10)
 
 				if e != 0 {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -208,7 +208,7 @@ func BenchmarkMSM(b *testing.B) {
 				_, e := Msm(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})
@@ -270,7 +270,7 @@ func BenchmarkMsmG2{{.CurveNameUpperCase}}(b *testing.B) {
 				_, e := MsmG2(out, points, scalars, 0)
 
 				if e != nil {
-					panic("Error occured")
+					panic("Error occurred")
 				}
 			}
 		})

--- a/icicle/appUtils/ntt/ntt.cuh
+++ b/icicle/appUtils/ntt/ntt.cuh
@@ -287,7 +287,7 @@ ntt_template_kernel(E* arr, uint32_t n, S* twiddles, uint32_t n_twiddles, uint32
  * @param batch_size The size of the batch; the length of `d_inout` is `n` * `batch_size`.
  * @param inverse true for iNTT
  * @param is_coset true for multiplication by coset
- * @param coset should be array of lenght n - or in case of lesser than n, right-padded with zeroes
+ * @param coset should be array of length n - or in case of lesser than n, right-padded with zeroes
  * @param stream CUDA stream
  * @param is_sync_needed do perform sync of the supplied CUDA stream at the end of processing
  */


### PR DESCRIPTION
fix typos


    test logs: `occured`-> `occurred`
    icicle/appUtils/ntt/ntt.cuh: `lenght` -> `length`