### PR TITLE
Fix the need for a dummy bindings.rs file included in the repo

### DIFF
--- a/.github/workflows/main-format.yml
+++ b/.github/workflows/main-format.yml
@@ -18,7 +18,12 @@ jobs:
       uses: actions/checkout@v3
     - name: Check rustfmt
       working-directory: ./wrappers/rust
-      run: if [[ $(cargo fmt --check) ]]; then echo "Please run cargo fmt"; exit 1; fi
+      # "-name tagret -prune" removes searching in any directory named "target"
+      # Formatting by single file is necessary due to generated files not being present
+      # before building the project.
+      # e.g. icicle-cuda-runtime/src/bindings.rs is generated and icicle-cuda-runtime/src/lib.rs includes that module
+      # causing rustfmt to fail.
+      run: if [[ $(find . -name target -prune -o -iname *.rs -print | xargs cargo fmt --check --) ]]; then echo "Please run cargo fmt"; exit 1; fi
     # - name: Check clippy
     #   run: cargo clippy --no-deps --all-features --all-targets
 

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -8,3 +8,6 @@ use_field_init_shorthand = true
 use_try_shorthand = true
 
 # Unstable Configs
+# This is required to enable checking single files without checking their imports/submodules
+# However, this also breaks running "cargo fmt" at the workspace level
+skip_children = true

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -12,6 +12,7 @@ then
     echo ""
     echo "If you only want to see what formatting is required please run:"
     echo "find ./ \( -path ./icicle/build -prune -o -path ./**/target -prune \) -iname *.h -or -iname *.cuh -or -iname *.cu -or -iname *.c -or -iname *.cpp | xargs clang-format --dry-run -style=file"
+    echo ""
     status=1
 fi
 
@@ -20,15 +21,17 @@ if [[ $(go list ./... | xargs go fmt) ]];
 then
     echo "🚨 There are Golang files that need formatting."
     echo "Please commit the formatted files"
+    echo ""
     status=1
 fi
 
 # Run cargo fmt on Rust files
 cd wrappers/rust
-if [[ $(cargo fmt --check) ]];
+if [[ $(find . -name target -prune -o -iname *.rs -print | xargs cargo fmt --check --) ]];
 then
     echo "🚨 There are Rust files that need formatting."
-    echo "Please format the Rust files using 'cargo fmt' from the wrappers/rust directory"
+    echo "Please format the Rust files using the following command:"
+    echo "find . -name target -prune -o -iname *.rs -print | xargs cargo fmt --check --"
     status=1
 fi
 

--- a/wrappers/rust/icicle-cuda-runtime/src/bindings.rs
+++ b/wrappers/rust/icicle-cuda-runtime/src/bindings.rs
@@ -1,2 +1,0 @@
-// Empty mod file - This is necessary for cargo fmt to operate correctly in CI
-// All content in this file will be overwritten when building the crate


### PR DESCRIPTION
## Describe the changes

This PR removes the need to add bindings.rs to the repo. 
Since it is a generated file, it should not be tracked in the repo. These changes allow for running cargo fmt on single files under the `wrappers/rust` directory
