### PR TITLE
Add Nix Shell Environment Configuration for CUDA

### DIFF
--- a/icicle/README.md
+++ b/icicle/README.md
@@ -89,3 +89,16 @@ Make sure `libssl` is installed.
 sudo apt-get update
 sudo apt-get install libssl1.0.0 libssl-dev
 ```
+
+## Running with Nix
+
+If you have Nix or NixOs installed on your machine, you can create a development shell to load all build dependencies and set the required environmental variables.
+
+From the ```/icicle/icicle```  directory run the following command. 
+
+```
+nix-shell --pure cuda-shell.nix
+```
+
+This will install everything you need to build and run ICICLE Core.
+

--- a/icicle/cuda-shell.nix
+++ b/icicle/cuda-shell.nix
@@ -1,0 +1,28 @@
+# Run with `nix-shell cuda-shell.nix`
+{ pkgs ? import <nixpkgs> {} }:
+let
+  gcc10 = pkgs.overrideCC pkgs.stdenv pkgs.gcc10;
+in
+pkgs.mkShell {
+   name = "cuda-env-shell";
+   buildInputs = [ gcc10 ]  ++ (with pkgs; [
+     git gitRepo gnupg autoconf curl
+     procps gnumake util-linux m4 gperf unzip
+     cudatoolkit linuxPackages.nvidia_x11
+     libGLU libGL
+     xorg.libXi xorg.libXmu freeglut
+     xorg.libXext xorg.libX11 xorg.libXv xorg.libXrandr zlib
+     ncurses5
+     cmake
+   ]);
+   cc = gcc10;
+   shellHook = ''
+     export PATH="$PATH:${pkgs.cudatoolkit}/bin:${pkgs.cudatoolkit}/nvvm/bin"
+     export LD_LIBRARY_PATH=${pkgs.cudatoolkit}/lib:${pkgs.linuxPackages.nvidia_x11}/lib
+     export CUDA_PATH=${pkgs.cudatoolkit}
+     export CPATH="${pkgs.cudatoolkit}/include"
+     export LIBRARY_PATH="$LIBRARY_PATH:/lib:${pkgs.linuxPackages.nvidia_x11}/lib"
+     export CMAKE_CUDA_COMPILER=$CUDA_PATH/bin/nvcc
+     export CXX="${pkgs.gcc10}/bin/c++"
+   '';
+}


### PR DESCRIPTION
This PR introduces a Nix Shell configuration for easing the development of the ICICLE Core using Nix or NixOS. 

Changes:

1. Added instructions on how to use Nix Shell to create a development environment with all required dependencies and environmental variables.
2. Created `cuda-shell.nix` to configure Nix Shell with necessary CUDA related packages and environmental variables. Specifically, setting the `PATH`, `LD_LIBRARY_PATH`, `CUDA_PATH`, `CPATH`, `LIBRARY_PATH`, and `CMAKE_CUDA_COMPILER` associated with the CUDA toolkit.

This configuration allows us to build and run ICICLE Core more efficiently in Nix environment.
