### PR TITLE
Fix curve crates not building when used as dependency

### DIFF
--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -111,7 +111,7 @@ if (NOT BUILD_TESTS)
     COMMAND ${CMAKE_OBJCOPY} ARGS --redefine-sym InitializeDomain=${CURVE}InitializeDomain ${PROJECT_BINARY_DIR}/CMakeFiles/icicle.dir/appUtils/ntt/ntt.cu.o
     # COMMAND ${CMAKE_OBJCOPY} ARGS --prefix-symbols=${CURVE}_ ${PROJECT_BINARY_DIR}/CMakeFiles/icicle.dir/appUtils/ntt/ntt.cu.o
     # COMMAND ${CMAKE_OBJCOPY} ARGS --prefix-symbols=${CURVE}_ ${PROJECT_BINARY_DIR}/CMakeFiles/icicle.dir/appUtils/lde/lde.cu.o
-    COMMAND ${CMAKE_AR} ARGS -rcs ${LIBRARY_OUTPUT_DIRECTORY}/libingo_${CURVE}.a 
+    COMMAND ${CMAKE_AR} ARGS -rcs ${PROJECT_BINARY_DIR}/libingo_${CURVE}.a 
     ${PROJECT_BINARY_DIR}/CMakeFiles/icicle.dir/utils/error_handler.cu.o
     ${PROJECT_BINARY_DIR}/CMakeFiles/icicle.dir/utils/vec_ops.cu.o
     ${PROJECT_BINARY_DIR}/CMakeFiles/icicle.dir/primitives/field.cu.o

--- a/wrappers/rust/icicle-curves/icicle-bn254/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/build.rs
@@ -8,17 +8,14 @@ fn main() {
     let cargo_dir = var("CARGO_MANIFEST_DIR").unwrap();
     let profile = var("PROFILE").unwrap();
 
-    let target_output_dir = format!("{}/../../target/{}", cargo_dir, profile);
-
-    Config::new("../../../../icicle")
+    let out_dir = Config::new("../../../../icicle")
                 .define("BUILD_TESTS", "OFF") //TODO: feature
                 .define("CURVE", "bn254")
-                .define("LIBRARY_OUTPUT_DIRECTORY", &target_output_dir)
                 .define("CMAKE_BUILD_TYPE", "Release")
                 .build_target("icicle")
                 .build();
 
-    println!("cargo:rustc-link-search={}", &target_output_dir);
+    println!("cargo:rustc-link-search={}/build", out_dir.display());
 
     println!("cargo:rustc-link-lib=ingo_bn254");
     println!("cargo:rustc-link-lib=stdc++");


### PR DESCRIPTION
## Describe the changes

This PR moves `ingo_<curve>` archive output to the same directory as the original library output allowing rust build scripts to find it when a curve crate is used as a dependency
