### PR TITLE
Fix/windows build failing

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -65,6 +65,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Download and Install Cuda
       if: needs.check-changed-files.outputs.rust == 'true' || needs.check-changed-files.outputs.cpp_cuda == 'true'
+      id: cuda-toolkit
       uses: Jimver/cuda-toolkit@v0.2.11
       with:
         cuda: '12.0.0'
@@ -75,7 +76,7 @@ jobs:
       working-directory: ./wrappers/rust
       if: needs.check-changed-files.outputs.rust == 'true' || needs.check-changed-files.outputs.cpp_cuda == 'true'
       env:
-        CUDA_PATH: ${{steps.cuda-toolkit.outputs.CUDA_PATH}}
+        CUDA_PATH: ${{ steps.cuda-toolkit.outputs.CUDA_PATH }}
       # Building from the root workspace will build all members of the workspace by default
       run: cargo build --release --verbose
 

--- a/icicle/appUtils/ntt/ntt.cu
+++ b/icicle/appUtils/ntt/ntt.cu
@@ -386,7 +386,8 @@ namespace ntt {
     // but it's a singleton that is supposed to be initialized once per program lifetime
     if (!Domain<S>::twiddles) {
       S omega = primitive_root;
-      for (int i = 0; i < S::TWO_ADICITY; i++)
+      unsigned omegas_count = S::get_omegas_count();
+      for (int i = 0; i < omegas_count; i++)
         omega = S::sqr(omega);
       if (omega != S::one()) {
         std::cerr << "Primitive root provided to the InitDomain function is not in the subgroup" << '\n';
@@ -501,17 +502,6 @@ namespace ntt {
       false,         // is_async
     };
     return config;
-  }
-
-  /**
-   * Extern "C" version of [DefaultNTTConfig](@ref DefaultNTTConfig) function with the following
-   * value of template parameter (where the curve is given by `-DCURVE` env variable during build):
-   *  - `S` is the [scalar field](@ref scalar_t) of the curve;
-   * @return Default [NTTConfig](@ref NTTConfig).
-   */
-  extern "C" NTTConfig<curve_config::scalar_t> CONCAT_EXPAND(CURVE, GetDefaultNTTConfig)()
-  {
-    return DefaultNTTConfig<curve_config::scalar_t>();
   }
 
   /**

--- a/icicle/primitives/field.cuh
+++ b/icicle/primitives/field.cuh
@@ -84,7 +84,8 @@ public:
     return Field{inv.storages[logn - 1]};
   }
 
-  static constexpr HOST_INLINE unsigned get_omegas_count() {
+  static constexpr HOST_INLINE unsigned get_omegas_count()
+  {
     if constexpr (has_member_name<CONFIG>()) {
       return CONFIG::omegas_count;
     } else {
@@ -93,7 +94,8 @@ public:
   }
 
   template <typename T>
-  static constexpr bool has_member_name() { 
+  static constexpr bool has_member_name()
+  {
     // if (std::is_same<unsigned, decltype(T::omegas_count)>) {
     if (sizeof(T::omegas_count) > 0) {
       return true;

--- a/icicle/primitives/field.cuh
+++ b/icicle/primitives/field.cuh
@@ -38,7 +38,6 @@ class Field
 public:
   static constexpr unsigned TLC = CONFIG::limbs_count;
   static constexpr unsigned NBITS = CONFIG::modulus_bit_count;
-  static constexpr unsigned TWO_ADICITY = CONFIG::omegas_count;
 
   static constexpr HOST_DEVICE_INLINE Field zero() { return Field{CONFIG::zero}; }
 
@@ -83,6 +82,24 @@ public:
     if (logn > CONFIG::omegas_count) THROW_ICICLE_ERR(IcicleError_t::InvalidArgument, "Field: Invalid inv index");
     storage_array<CONFIG::omegas_count, TLC> const inv = CONFIG::inv;
     return Field{inv.storages[logn - 1]};
+  }
+
+  static constexpr HOST_INLINE unsigned get_omegas_count() {
+    if constexpr (has_member_name<CONFIG>()) {
+      return CONFIG::omegas_count;
+    } else {
+      return 0;
+    }
+  }
+
+  template <typename T>
+  static constexpr bool has_member_name() { 
+    // if (std::is_same<unsigned, decltype(T::omegas_count)>) {
+    if (sizeof(T::omegas_count) > 0) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   // private:

--- a/icicle/primitives/field.cuh
+++ b/icicle/primitives/field.cuh
@@ -86,7 +86,7 @@ public:
 
   static constexpr HOST_INLINE unsigned get_omegas_count()
   {
-    if constexpr (has_member_name<CONFIG>()) {
+    if constexpr (has_member_omegas_count<CONFIG>()) {
       return CONFIG::omegas_count;
     } else {
       return 0;
@@ -94,14 +94,9 @@ public:
   }
 
   template <typename T>
-  static constexpr bool has_member_name()
+  static constexpr bool has_member_omegas_count()
   {
-    // if (std::is_same<unsigned, decltype(T::omegas_count)>) {
-    if (sizeof(T::omegas_count) > 0) {
-      return true;
-    } else {
-      return false;
-    }
+    return sizeof(T::omegas_count) > 0;
   }
 
   // private:

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -1,4 +1,4 @@
-use icicle_cuda_runtime::device_context::DeviceContext;
+use icicle_cuda_runtime::device_context::{DeviceContext, get_default_device_context};
 use icicle_cuda_runtime::memory::HostOrDeviceSlice;
 
 use crate::{error::IcicleResult, traits::FieldImpl};
@@ -57,6 +57,21 @@ pub struct NTTConfig<'a, S> {
     /// Whether to run the NTT asynchronously. If set to `true`, the NTT function will be non-blocking and you'd need to synchronize
     /// it explicitly by running `stream.synchronize()`. If set to false, the NTT function will block the current CPU thread.
     pub is_async: bool,
+}
+
+impl<'a, S: FieldImpl> NTTConfig<'a, S> {
+    pub fn default_config() -> Self {
+        let ctx = get_default_device_context();
+        NTTConfig {
+            ctx,
+            coset_gen: S::one(),
+            batch_size: 1,
+            ordering: Ordering::kNN,
+            are_inputs_on_device: false,
+            are_outputs_on_device: false,
+            is_async: false,
+        }
+    }
 }
 
 #[doc(hidden)]
@@ -149,9 +164,6 @@ macro_rules! impl_ntt {
                 output: *mut $field,
             ) -> CudaError;
 
-            #[link_name = concat!($field_prefix, "GetDefaultNTTConfig")]
-            fn default_ntt_config() -> NTTConfig<'static, $field>;
-
             #[link_name = concat!($field_prefix, "InitializeDomain")]
             fn initialize_ntt_domain(primitive_root: $field, ctx: &DeviceContext) -> CudaError;
         }
@@ -180,7 +192,7 @@ macro_rules! impl_ntt {
             }
 
             fn get_default_ntt_config() -> NTTConfig<'static, $field> {
-                unsafe { default_ntt_config() }
+                NTTConfig::<$field>::default_config()
             }
         }
     };

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -1,4 +1,4 @@
-use icicle_cuda_runtime::device_context::{DeviceContext, get_default_device_context};
+use icicle_cuda_runtime::device_context::{get_default_device_context, DeviceContext};
 use icicle_cuda_runtime::memory::HostOrDeviceSlice;
 
 use crate::{error::IcicleResult, traits::FieldImpl};

--- a/wrappers/rust/icicle-cuda-runtime/build.rs
+++ b/wrappers/rust/icicle-cuda-runtime/build.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 fn cuda_include_path() -> &'static str {
     #[cfg(target_os = "windows")]
     {
-        concat!(env!("CUDA_PATH"), "/include")
+        concat!(env!("CUDA_PATH"), "\\include")
     }
 
     #[cfg(target_os = "linux")]
@@ -17,7 +17,7 @@ fn cuda_include_path() -> &'static str {
 fn cuda_lib_path() -> &'static str {
     #[cfg(target_os = "windows")]
     {
-        concat!(env!("CUDA_PATH"), "/lib/x64")
+        concat!(env!("CUDA_PATH"), "\\lib\\x64")
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Describe the changes

This PR fixes the rust build for windows by:
- Making the curve config's ntt size conditionally accessed when creating fields
- Removing the extern C function that returned a UDT containing non-POD types and replacing it with a `default_config` function on the Rust bindings side
