### PR TITLE
Add missed bump to dev

### DIFF
--- a/examples/rust/msm/Cargo.toml
+++ b/examples/rust/msm/Cargo.toml
@@ -4,10 +4,10 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0" }
-icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0" }
-icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0", features = [ "g2" ] }
-icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0" }
+icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0" }
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0" }
+icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0", features = [ "g2" ] }
+icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0" }
 ark-bn254 = { version = "0.4.0", optional = true}
 ark-bls12-377 = { version = "0.4.0", optional = true}
 ark-ec = { version = "0.4.0", optional = true}

--- a/examples/rust/ntt/Cargo.toml
+++ b/examples/rust/ntt/Cargo.toml
@@ -4,10 +4,10 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0" }
-icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0", features = ["arkworks"] }
-icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0", features = ["arkworks"] }
-icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.0.0", features = ["arkworks"] }
+icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0" }
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0", features = ["arkworks"] }
+icicle-bn254 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0", features = ["arkworks"] }
+icicle-bls12-377 = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v1.1.0", features = ["arkworks"] }
 
 ark-ff = { version = "0.4.0" }
 ark-poly = "0.4.0"

--- a/wrappers/rust/icicle-core/Cargo.toml
+++ b/wrappers/rust/icicle-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icicle-core"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 description = "A library for GPU ZK acceleration by Ingonyama"

--- a/wrappers/rust/icicle-cuda-runtime/Cargo.toml
+++ b/wrappers/rust/icicle-cuda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icicle-cuda-runtime"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 description = "Ingonyama's Rust wrapper of CUDA runtime"

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/Cargo.toml
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icicle-bls12-377"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 description = "Rust wrapper for the CUDA implementation of BLS12-377 pairing friendly elliptic curve by Ingonyama"

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/Cargo.toml
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icicle-bls12-381"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 description = "Rust wrapper for the CUDA implementation of BLS12-381 pairing friendly elliptic curve by Ingonyama"

--- a/wrappers/rust/icicle-curves/icicle-bn254/Cargo.toml
+++ b/wrappers/rust/icicle-curves/icicle-bn254/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icicle-bn254"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 description = "Rust wrapper for the CUDA implementation of BN254 pairing friendly elliptic curve by Ingonyama"

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/Cargo.toml
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icicle-bw6-761"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 description = "Rust wrapper for the CUDA implementation of BW6-761 pairing friendly elliptic curve by Ingonyama"


### PR DESCRIPTION
## Describe the changes

This PR fixes the examples issue on `dev` regarding versions not being available
