### PR TITLE
Add concurrency group to examples workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -17,6 +17,10 @@ on:
       - main
       - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:  
   test-examples:
     runs-on: [self-hosted, Linux, X64, icicle] # ubuntu-latest


### PR DESCRIPTION
## Describe the changes

This PR adds a concurrency group to the examples CI workflow to ensure only one instance of it is running per branch.
This will allow checks on each following commit to run immediately instead of waiting for a previous (and outdated) commit's check to finish