### PR TITLE
Update overview.md

### DIFF
--- a/docs/docs/icicle/overview.md
+++ b/docs/docs/icicle/overview.md
@@ -2,7 +2,8 @@
 
 [![GitHub Release](https://img.shields.io/github/v/release/ingonyama-zk/icicle)](https://github.com/ingonyama-zk/icicle/releases)
 
-![Static Badge](https://img.shields.io/badge/Machines%20running%20ICICLE-544-blue)
+![Static Badge](https://img.shields.io/badge/Dependent%20Repositories-21-blue)
+
 
 
 


### PR DESCRIPTION
Changing to "dependent repositories" badge instead of the "Machines using"


