### PR TITLE
FEAT: MultiGPU for golang bindings

### DIFF
--- a/wrappers/golang/core/msm.go
+++ b/wrappers/golang/core/msm.go
@@ -56,7 +56,8 @@ type MSMConfig struct {
 }
 
 func GetDefaultMSMConfig() MSMConfig {
-	ctx, _ := cr.GetDefaultDeviceContext()
+	deviceId, _ := cr.GetDevice()
+	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
 	return MSMConfig{
 		ctx,   // Ctx
 		0,     // pointsSize

--- a/wrappers/golang/core/msm.go
+++ b/wrappers/golang/core/msm.go
@@ -56,8 +56,7 @@ type MSMConfig struct {
 }
 
 func GetDefaultMSMConfig() MSMConfig {
-	deviceId, _ := cr.GetDevice()
-	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
+	ctx, _ := cr.GetDefaultDeviceContext()
 	return MSMConfig{
 		ctx,   // Ctx
 		0,     // pointsSize

--- a/wrappers/golang/core/msm_test.go
+++ b/wrappers/golang/core/msm_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestMSMDefaultConfig(t *testing.T) {
-	deviceId, _ := cr.GetDevice()
-	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
+	ctx, _ := cr.GetDefaultDeviceContext()
 	expected := MSMConfig{
 		ctx,   // Ctx
 		0,     // pointsSize

--- a/wrappers/golang/core/msm_test.go
+++ b/wrappers/golang/core/msm_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestMSMDefaultConfig(t *testing.T) {
-	ctx, _ := cr.GetDefaultDeviceContext()
+	deviceId, _ := cr.GetDevice()
+	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
 	expected := MSMConfig{
 		ctx,   // Ctx
 		0,     // pointsSize

--- a/wrappers/golang/core/ntt.go
+++ b/wrappers/golang/core/ntt.go
@@ -41,8 +41,7 @@ type NTTConfig[T any] struct {
 }
 
 func GetDefaultNTTConfig[T any](cosetGen T) NTTConfig[T] {
-	deviceId, _ := cr.GetDevice()
-	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
+	ctx, _ := cr.GetDefaultDeviceContext()
 	return NTTConfig[T]{
 		ctx,      // Ctx
 		cosetGen, // CosetGen

--- a/wrappers/golang/core/ntt.go
+++ b/wrappers/golang/core/ntt.go
@@ -41,7 +41,8 @@ type NTTConfig[T any] struct {
 }
 
 func GetDefaultNTTConfig[T any](cosetGen T) NTTConfig[T] {
-	ctx, _ := cr.GetDefaultDeviceContext()
+	deviceId, _ := cr.GetDevice()
+	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
 	return NTTConfig[T]{
 		ctx,      // Ctx
 		cosetGen, // CosetGen

--- a/wrappers/golang/core/slice.go
+++ b/wrappers/golang/core/slice.go
@@ -83,6 +83,16 @@ func (d *DeviceSlice) Free() cr.CudaError {
 	return err
 }
 
+func (d *DeviceSlice) FreeAsync(stream cr.Stream) cr.CudaError {
+	d.CheckDevice()
+	err := cr.FreeAsync(d.inner, stream)
+	if err == cr.CudaSuccess {
+		d.length, d.capacity, d.deviceId = 0, 0, 0
+		d.inner = nil
+	}
+	return err
+}
+
 type HostSliceInterface interface {
 	Size() int
 }

--- a/wrappers/golang/core/slice.go
+++ b/wrappers/golang/core/slice.go
@@ -47,6 +47,7 @@ func (d DeviceSlice) GetDeviceId() int {
 	return cr.GetDeviceFromPointer(d.inner)
 }
 
+// CheckDevice is used to ensure that the DeviceSlice about to be used resides on the currently set device
 func (d DeviceSlice) CheckDevice() {
 	if currentDeviceId, err := cr.GetDevice(); err != cr.CudaSuccess || d.GetDeviceId() != currentDeviceId {
 		panic("Attempt to use DeviceSlice on a different device")

--- a/wrappers/golang/core/vec_ops.go
+++ b/wrappers/golang/core/vec_ops.go
@@ -36,7 +36,8 @@ type VecOpsConfig struct {
  * @return Default value of [VecOpsConfig](@ref VecOpsConfig).
  */
 func DefaultVecOpsConfig() VecOpsConfig {
-	ctx, _ := cr.GetDefaultDeviceContext()
+	deviceId, _ := cr.GetDevice()
+	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
 	config := VecOpsConfig{
 		ctx,   // ctx
 		false, // isAOnDevice

--- a/wrappers/golang/core/vec_ops.go
+++ b/wrappers/golang/core/vec_ops.go
@@ -36,8 +36,7 @@ type VecOpsConfig struct {
  * @return Default value of [VecOpsConfig](@ref VecOpsConfig).
  */
 func DefaultVecOpsConfig() VecOpsConfig {
-	deviceId, _ := cr.GetDevice()
-	ctx := cr.GetDefaultDeviceContextForDevice(deviceId)
+	ctx, _ := cr.GetDefaultDeviceContext()
 	config := VecOpsConfig{
 		ctx,   // ctx
 		false, // isAOnDevice

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -9,6 +9,7 @@ package cuda_runtime
 */
 import "C"
 import (
+	"fmt"
 	"runtime"
 	"unsafe"
 )
@@ -31,7 +32,7 @@ func (d DeviceContext) GetDeviceId() int {
 func GetDefaultDeviceContext() (DeviceContext, CudaError) {
 	device, err := GetDevice()
 	if err != CudaSuccess {
-		panic("Could not get current device")
+		panic(fmt.Sprintf("Could not get current device due to %v", err))
 	}
 	var defaultStream Stream
 	var defaultMempool MemPool

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -87,15 +87,15 @@ func GetDeviceFromPointer(ptr unsafe.Pointer) int {
 //					 		size := 1 << power
 //
 //					 		// This will always print "Inner goroutine device: 0"
-//	           // go func ()  {
-//					 		// 	device, _ := cr.GetDevice()
-//					 		// 	fmt.Println("Inner goroutine device: ", device)
-//					 		// }()
+//							// go func ()  {
+//							// 	device, _ := cr.GetDevice()
+//							// 	fmt.Println("Inner goroutine device: ", device)
+//							// }()
 //					 		// To force the above goroutine to same device as the wrapping function:
-//	           // RunOnDevice(i, func(arg ...any) {
-//					 		// 	device, _ := cr.GetDevice()
-//					 		// 	fmt.Println("Inner goroutine device: ", device)
-//					 		// })
+//							// RunOnDevice(i, func(arg ...any) {
+//							// 	device, _ := cr.GetDevice()
+//							// 	fmt.Println("Inner goroutine device: ", device)
+//							// })
 //
 //					 		scalars := GenerateScalars(size)
 //					 		points := GenerateAffinePoints(size)

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -24,6 +24,10 @@ type DeviceContext struct {
 	Mempool MemPool // Assuming the type is provided by a CUDA binding crate
 }
 
+func (d DeviceContext) GetDeviceId() int {
+	return int(d.deviceId)
+}
+
 func GetDefaultDeviceContext() (DeviceContext, CudaError) {
 	device, err := GetDevice()
 	if err != CudaSuccess {

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -9,6 +9,7 @@ package cuda_runtime
 */
 import "C"
 import (
+	"runtime"
 	"unsafe"
 )
 
@@ -58,4 +59,64 @@ func GetDevice() (int, CudaError) {
 	cDevice := (*C.int)(unsafe.Pointer(&device))
 	err := C.cudaGetDevice(cDevice)
 	return device, (CudaError)(err)
+}
+
+// RunOnDevice forces the provided function to run all GPU related calls within it
+// on the same host thread and therefore the same GPU device.
+//
+// NOTE: Goroutines launched within funcToRun are not bound to the
+// same host thread as funcToRun and therefore not to the same GPU device. 
+// If that is a requirement, RunOnDevice should be called for each with the
+// same deviceId as the original call.
+//
+// As an example:
+//
+//    		cr.RunOnDevice(i, func(args ...any) {
+//				 	defer wg.Done()
+//				 	cfg := GetDefaultMSMConfig()
+//				 	stream, _ := cr.CreateStream()
+//				 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+//				 		size := 1 << power
+//
+//				 		// This will always print "Inner goroutine device: 0"
+//            // go func ()  {
+//				 		// 	device, _ := cr.GetDevice()
+//				 		// 	fmt.Println("Inner goroutine device: ", device)
+//				 		// }()
+//				 		// To force the above goroutine to same device as the wrapping function:
+//            // RunOnDevice(i, func(arg ...any) {
+//				 		// 	device, _ := cr.GetDevice()
+//				 		// 	fmt.Println("Inner goroutine device: ", device)
+//				 		// })
+//
+//				 		scalars := GenerateScalars(size)
+//				 		points := GenerateAffinePoints(size)
+//				
+//				 		var p Projective
+//				 		var out core.DeviceSlice
+//				 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+//				 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+//				 		cfg.Ctx.Stream = &stream
+//				 		cfg.IsAsync = true
+//				
+//				 		e = Msm(scalars, points, &cfg, out)
+//				 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+//				
+//				 		outHost := make(core.HostSlice[Projective], 1)
+//				
+//				 		cr.SynchronizeStream(&stream)
+//				 		outHost.CopyFromDevice(&out)
+//				 		out.Free()
+//				 		// Check with gnark-crypto
+//				 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+//				 	}
+//				}, i)
+//
+func RunOnDevice(deviceId int, funcToRun func(args ...any), args ...any) {
+	go func(id int) {
+		defer runtime.UnlockOSThread()
+		runtime.LockOSThread()
+		SetDevice(id)
+		funcToRun(args...)
+	}(deviceId)
 }

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -65,53 +65,52 @@ func GetDevice() (int, CudaError) {
 // on the same host thread and therefore the same GPU device.
 //
 // NOTE: Goroutines launched within funcToRun are not bound to the
-// same host thread as funcToRun and therefore not to the same GPU device. 
+// same host thread as funcToRun and therefore not to the same GPU device.
 // If that is a requirement, RunOnDevice should be called for each with the
 // same deviceId as the original call.
 //
 // As an example:
 //
-//    		cr.RunOnDevice(i, func(args ...any) {
-//				 	defer wg.Done()
-//				 	cfg := GetDefaultMSMConfig()
-//				 	stream, _ := cr.CreateStream()
-//				 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
-//				 		size := 1 << power
+//	   		cr.RunOnDevice(i, func(args ...any) {
+//					 	defer wg.Done()
+//					 	cfg := GetDefaultMSMConfig()
+//					 	stream, _ := cr.CreateStream()
+//					 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+//					 		size := 1 << power
 //
-//				 		// This will always print "Inner goroutine device: 0"
-//            // go func ()  {
-//				 		// 	device, _ := cr.GetDevice()
-//				 		// 	fmt.Println("Inner goroutine device: ", device)
-//				 		// }()
-//				 		// To force the above goroutine to same device as the wrapping function:
-//            // RunOnDevice(i, func(arg ...any) {
-//				 		// 	device, _ := cr.GetDevice()
-//				 		// 	fmt.Println("Inner goroutine device: ", device)
-//				 		// })
+//					 		// This will always print "Inner goroutine device: 0"
+//	           // go func ()  {
+//					 		// 	device, _ := cr.GetDevice()
+//					 		// 	fmt.Println("Inner goroutine device: ", device)
+//					 		// }()
+//					 		// To force the above goroutine to same device as the wrapping function:
+//	           // RunOnDevice(i, func(arg ...any) {
+//					 		// 	device, _ := cr.GetDevice()
+//					 		// 	fmt.Println("Inner goroutine device: ", device)
+//					 		// })
 //
-//				 		scalars := GenerateScalars(size)
-//				 		points := GenerateAffinePoints(size)
-//				
-//				 		var p Projective
-//				 		var out core.DeviceSlice
-//				 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
-//				 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
-//				 		cfg.Ctx.Stream = &stream
-//				 		cfg.IsAsync = true
-//				
-//				 		e = Msm(scalars, points, &cfg, out)
-//				 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
-//				
-//				 		outHost := make(core.HostSlice[Projective], 1)
-//				
-//				 		cr.SynchronizeStream(&stream)
-//				 		outHost.CopyFromDevice(&out)
-//				 		out.Free()
-//				 		// Check with gnark-crypto
-//				 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
-//				 	}
-//				}, i)
+//					 		scalars := GenerateScalars(size)
+//					 		points := GenerateAffinePoints(size)
 //
+//					 		var p Projective
+//					 		var out core.DeviceSlice
+//					 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+//					 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+//					 		cfg.Ctx.Stream = &stream
+//					 		cfg.IsAsync = true
+//
+//					 		e = Msm(scalars, points, &cfg, out)
+//					 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+//
+//					 		outHost := make(core.HostSlice[Projective], 1)
+//
+//					 		cr.SynchronizeStream(&stream)
+//					 		outHost.CopyFromDevice(&out)
+//					 		out.Free()
+//					 		// Check with gnark-crypto
+//					 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+//					 	}
+//					}, i)
 func RunOnDevice(deviceId int, funcToRun func(args ...any), args ...any) {
 	go func(id int) {
 		defer runtime.UnlockOSThread()

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -20,18 +20,23 @@ type DeviceContext struct {
 	DeviceId uint
 
 	/// Mempool to use. Default value: 0.
-	// TODO: use cuda_bindings.CudaMemPool as type
-	Mempool uint // Assuming the type is provided by a CUDA binding crate
+	Mempool MemPool // Assuming the type is provided by a CUDA binding crate
 }
 
 func GetDefaultDeviceContext() (DeviceContext, CudaError) {
+	defaultContext := GetDefaultDeviceContextForDevice(0)
+	return defaultContext, CudaSuccess
+}
+
+func GetDefaultDeviceContextForDevice(deviceId int) DeviceContext {
 	var defaultStream Stream
+	var defaultMempool MemPool
 
 	return DeviceContext{
 		&defaultStream,
-		0,
-		0,
-	}, CudaSuccess
+		uint(deviceId),
+		defaultMempool,
+	}
 }
 
 func SetDevice(device int) CudaError {
@@ -46,4 +51,11 @@ func GetDeviceCount() (int, CudaError) {
 	cCount := (*C.int)(unsafe.Pointer(&count))
 	err := C.cudaGetDeviceCount(cCount)
 	return count, (CudaError)(err)
+}
+
+func GetDevice() (int, CudaError) {
+	var device int
+	cDevice := (*C.int)(unsafe.Pointer(&device))
+	err := C.cudaGetDevice(cDevice)
+	return device, (CudaError)(err)
 }

--- a/wrappers/golang/cuda_runtime/memory.go
+++ b/wrappers/golang/cuda_runtime/memory.go
@@ -12,6 +12,8 @@ import (
 	"unsafe"
 )
 
+type MemPool = CudaMemPool
+
 func Malloc(size uint) (unsafe.Pointer, CudaError) {
 	if size == 0 {
 		return nil, CudaErrorMemoryAllocation

--- a/wrappers/golang/cuda_runtime/types.go
+++ b/wrappers/golang/cuda_runtime/types.go
@@ -17,3 +17,6 @@ type CudaEvent C.cudaEvent_t
 
 // CudaMemPool as declared in include/driver_types.h:2928
 type CudaMemPool C.cudaMemPool_t
+
+// CudaMemPool as declared in include/driver_types.h:2928
+type CudaPointerAttributes = C.struct_cudaPointerAttributes

--- a/wrappers/golang/curves/bls12377/curve.go
+++ b/wrappers/golang/curves/bls12377/curve.go
@@ -146,10 +146,12 @@ func convertAffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.Cud
 }
 
 func AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, true)
 }
 
 func AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, false)
 }
 
@@ -165,9 +167,11 @@ func convertProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) cr
 }
 
 func ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, true)
 }
 
 func ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bls12377/g2_curve.go
+++ b/wrappers/golang/curves/bls12377/g2_curve.go
@@ -148,10 +148,12 @@ func convertG2AffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.C
 }
 
 func G2AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, true)
 }
 
 func G2AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, false)
 }
 
@@ -167,9 +169,11 @@ func convertG2ProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) 
 }
 
 func G2ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, true)
 }
 
 func G2ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bls12377/g2_msm.go
+++ b/wrappers/golang/curves/bls12377/g2_msm.go
@@ -20,7 +20,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -28,7 +30,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
 	}
@@ -36,7 +40,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
 	}

--- a/wrappers/golang/curves/bls12377/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12377/g2_msm_test.go
@@ -203,7 +203,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 
 				cr.SynchronizeStream(&stream)
 				// Check with gnark-crypto
-				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+				assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 			}
 		})
 	}

--- a/wrappers/golang/curves/bls12377/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12377/g2_msm_test.go
@@ -85,19 +85,19 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -182,18 +182,18 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bls12377/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12377/g2_msm_test.go
@@ -176,7 +176,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -187,14 +187,14 @@ func TestMSMG2MultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
-				
+
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[G2Projective], 1)

--- a/wrappers/golang/curves/bls12377/msm.go
+++ b/wrappers/golang/curves/bls12377/msm.go
@@ -18,7 +18,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -26,7 +28,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
 	}
@@ -34,7 +38,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
 	}

--- a/wrappers/golang/curves/bls12377/msm_test.go
+++ b/wrappers/golang/curves/bls12377/msm_test.go
@@ -147,7 +147,7 @@ func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -158,14 +158,14 @@ func TestMSMMultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
-				
+
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[Projective], 1)

--- a/wrappers/golang/curves/bls12377/msm_test.go
+++ b/wrappers/golang/curves/bls12377/msm_test.go
@@ -56,19 +56,19 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -153,18 +153,18 @@ func TestMSMMultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bls12377/ntt.go
+++ b/wrappers/golang/curves/bls12377/ntt.go
@@ -27,7 +27,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -38,7 +40,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
 	}

--- a/wrappers/golang/curves/bls12377/scalar_field.go
+++ b/wrappers/golang/curves/bls12377/scalar_field.go
@@ -106,9 +106,11 @@ func convertScalarsMontgomery(scalars *core.DeviceSlice, isInto bool) cr.CudaErr
 }
 
 func ToMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, true)
 }
 
 func FromMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, false)
 }

--- a/wrappers/golang/curves/bls12377/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vec_ops.go
@@ -16,19 +16,25 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	var cA, cB, cOut *C.scalar_t
 
 	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
+		aDevice := a.(core.DeviceSlice)
+		aDevice.CheckDevice()
+		cA = (*C.scalar_t)(aDevice.AsPointer())
 	} else {
 		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
+		bDevice := b.(core.DeviceSlice)
+		bDevice.CheckDevice()
+		cB = (*C.scalar_t)(bDevice.AsPointer())
 	} else {
 		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
+		outDevice := out.(core.DeviceSlice)
+		outDevice.CheckDevice()
+		cOut = (*C.scalar_t)(outDevice.AsPointer())
 	} else {
 		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
 	}

--- a/wrappers/golang/curves/bls12381/curve.go
+++ b/wrappers/golang/curves/bls12381/curve.go
@@ -146,10 +146,12 @@ func convertAffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.Cud
 }
 
 func AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, true)
 }
 
 func AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, false)
 }
 
@@ -165,9 +167,11 @@ func convertProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) cr
 }
 
 func ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, true)
 }
 
 func ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bls12381/g2_curve.go
+++ b/wrappers/golang/curves/bls12381/g2_curve.go
@@ -148,10 +148,12 @@ func convertG2AffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.C
 }
 
 func G2AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, true)
 }
 
 func G2AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, false)
 }
 
@@ -167,9 +169,11 @@ func convertG2ProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) 
 }
 
 func G2ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, true)
 }
 
 func G2ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bls12381/g2_msm.go
+++ b/wrappers/golang/curves/bls12381/g2_msm.go
@@ -20,7 +20,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -28,7 +30,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
 	}
@@ -36,7 +40,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
 	}

--- a/wrappers/golang/curves/bls12381/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12381/g2_msm_test.go
@@ -203,7 +203,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 
 				cr.SynchronizeStream(&stream)
 				// Check with gnark-crypto
-				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+				assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 			}
 		})
 	}

--- a/wrappers/golang/curves/bls12381/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12381/g2_msm_test.go
@@ -3,8 +3,11 @@
 package bls12381
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
@@ -82,24 +85,27 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[G2Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
 
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 	}
@@ -164,4 +170,42 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 	}
+}
+
+func TestMSMG2MultiDevice(t *testing.T) {
+	numDevices, _ := cr.GetDeviceCount()
+	fmt.Println("There are ", numDevices, " devices available")
+	wg := sync.WaitGroup{}
+	
+	for i := 0; i < numDevices; i++ {
+		wg.Add(1)
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
+			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+				size := 1 << power
+				scalars := GenerateScalars(size)
+				points := G2GenerateAffinePoints(size)
+				
+				var p G2Projective
+				var out core.DeviceSlice
+				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+				cfg.Ctx.Stream = &stream
+				cfg.IsAsync = true
+				
+				e = G2Msm(scalars, points, &cfg, out)
+				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+				outHost := make(core.HostSlice[G2Projective], 1)
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
+
+				cr.SynchronizeStream(&stream)
+				// Check with gnark-crypto
+				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/wrappers/golang/curves/bls12381/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12381/g2_msm_test.go
@@ -85,19 +85,19 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -182,18 +182,18 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bls12381/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12381/g2_msm_test.go
@@ -176,7 +176,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -187,14 +187,14 @@ func TestMSMG2MultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
-				
+
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[G2Projective], 1)

--- a/wrappers/golang/curves/bls12381/msm.go
+++ b/wrappers/golang/curves/bls12381/msm.go
@@ -18,7 +18,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -26,7 +28,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
 	}
@@ -34,7 +38,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
 	}

--- a/wrappers/golang/curves/bls12381/msm_test.go
+++ b/wrappers/golang/curves/bls12381/msm_test.go
@@ -1,8 +1,11 @@
 package bls12381
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
@@ -53,24 +56,27 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
 
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 	}
@@ -135,4 +141,42 @@ func TestMSMSkewedDistribution(t *testing.T) {
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 	}
+}
+
+func TestMSMMultiDevice(t *testing.T) {
+	numDevices, _ := cr.GetDeviceCount()
+	fmt.Println("There are ", numDevices, " devices available")
+	wg := sync.WaitGroup{}
+	
+	for i := 0; i < numDevices; i++ {
+		wg.Add(1)
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
+			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+				size := 1 << power
+				scalars := GenerateScalars(size)
+				points := GenerateAffinePoints(size)
+				
+				var p Projective
+				var out core.DeviceSlice
+				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+				cfg.Ctx.Stream = &stream
+				cfg.IsAsync = true
+				
+				e = Msm(scalars, points, &cfg, out)
+				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+				outHost := make(core.HostSlice[Projective], 1)
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
+
+				cr.SynchronizeStream(&stream)
+				// Check with gnark-crypto
+				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/wrappers/golang/curves/bls12381/msm_test.go
+++ b/wrappers/golang/curves/bls12381/msm_test.go
@@ -147,7 +147,7 @@ func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -158,14 +158,14 @@ func TestMSMMultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
-				
+
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[Projective], 1)

--- a/wrappers/golang/curves/bls12381/msm_test.go
+++ b/wrappers/golang/curves/bls12381/msm_test.go
@@ -56,19 +56,19 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -153,18 +153,18 @@ func TestMSMMultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bls12381/ntt.go
+++ b/wrappers/golang/curves/bls12381/ntt.go
@@ -27,7 +27,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -38,7 +40,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
 	}

--- a/wrappers/golang/curves/bls12381/scalar_field.go
+++ b/wrappers/golang/curves/bls12381/scalar_field.go
@@ -106,9 +106,11 @@ func convertScalarsMontgomery(scalars *core.DeviceSlice, isInto bool) cr.CudaErr
 }
 
 func ToMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, true)
 }
 
 func FromMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, false)
 }

--- a/wrappers/golang/curves/bls12381/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vec_ops.go
@@ -16,19 +16,25 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	var cA, cB, cOut *C.scalar_t
 
 	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
+		aDevice := a.(core.DeviceSlice)
+		aDevice.CheckDevice()
+		cA = (*C.scalar_t)(aDevice.AsPointer())
 	} else {
 		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
+		bDevice := b.(core.DeviceSlice)
+		bDevice.CheckDevice()
+		cB = (*C.scalar_t)(bDevice.AsPointer())
 	} else {
 		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
+		outDevice := out.(core.DeviceSlice)
+		outDevice.CheckDevice()
+		cOut = (*C.scalar_t)(outDevice.AsPointer())
 	} else {
 		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
 	}

--- a/wrappers/golang/curves/bn254/curve.go
+++ b/wrappers/golang/curves/bn254/curve.go
@@ -146,10 +146,12 @@ func convertAffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.Cud
 }
 
 func AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, true)
 }
 
 func AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, false)
 }
 
@@ -165,9 +167,11 @@ func convertProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) cr
 }
 
 func ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, true)
 }
 
 func ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bn254/g2_curve.go
+++ b/wrappers/golang/curves/bn254/g2_curve.go
@@ -148,10 +148,12 @@ func convertG2AffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.C
 }
 
 func G2AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, true)
 }
 
 func G2AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, false)
 }
 
@@ -167,9 +169,11 @@ func convertG2ProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) 
 }
 
 func G2ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, true)
 }
 
 func G2ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bn254/g2_msm.go
+++ b/wrappers/golang/curves/bn254/g2_msm.go
@@ -20,6 +20,7 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
+		scalars.CheckDevice()
 		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
@@ -28,6 +29,7 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
+		points.CheckDevice()
 		pointsPointer = points.(core.DeviceSlice).AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
@@ -36,6 +38,7 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
+		results.CheckDevice()
 		resultsPointer = results.(core.DeviceSlice).AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])

--- a/wrappers/golang/curves/bn254/g2_msm.go
+++ b/wrappers/golang/curves/bn254/g2_msm.go
@@ -20,8 +20,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalars.CheckDevice()
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -29,8 +30,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		points.CheckDevice()
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
 	}
@@ -38,8 +40,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		results.CheckDevice()
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
 	}

--- a/wrappers/golang/curves/bn254/g2_msm_test.go
+++ b/wrappers/golang/curves/bn254/g2_msm_test.go
@@ -203,7 +203,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 
 				cr.SynchronizeStream(&stream)
 				// Check with gnark-crypto
-				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+				assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 			}
 		})
 	}

--- a/wrappers/golang/curves/bn254/g2_msm_test.go
+++ b/wrappers/golang/curves/bn254/g2_msm_test.go
@@ -3,8 +3,11 @@
 package bn254
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
@@ -82,24 +85,27 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[G2Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
 
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 	}
@@ -164,4 +170,42 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 	}
+}
+
+func TestMSMG2MultiDevice(t *testing.T) {
+	numDevices, _ := cr.GetDeviceCount()
+	fmt.Println("There are ", numDevices, " devices available")
+	wg := sync.WaitGroup{}
+	
+	for i := 0; i < numDevices; i++ {
+		wg.Add(1)
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
+			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+				size := 1 << power
+				scalars := GenerateScalars(size)
+				points := G2GenerateAffinePoints(size)
+				
+				var p G2Projective
+				var out core.DeviceSlice
+				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+				cfg.Ctx.Stream = &stream
+				cfg.IsAsync = true
+				
+				e = G2Msm(scalars, points, &cfg, out)
+				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+				outHost := make(core.HostSlice[G2Projective], 1)
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
+
+				cr.SynchronizeStream(&stream)
+				// Check with gnark-crypto
+				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/wrappers/golang/curves/bn254/g2_msm_test.go
+++ b/wrappers/golang/curves/bn254/g2_msm_test.go
@@ -85,19 +85,19 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -182,18 +182,18 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bn254/g2_msm_test.go
+++ b/wrappers/golang/curves/bn254/g2_msm_test.go
@@ -176,7 +176,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -187,14 +187,14 @@ func TestMSMG2MultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
-				
+
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[G2Projective], 1)

--- a/wrappers/golang/curves/bn254/msm.go
+++ b/wrappers/golang/curves/bn254/msm.go
@@ -18,7 +18,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -26,7 +28,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
 	}
@@ -34,7 +38,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
 	}

--- a/wrappers/golang/curves/bn254/msm_test.go
+++ b/wrappers/golang/curves/bn254/msm_test.go
@@ -75,7 +75,7 @@ func TestMSM(t *testing.T) {
 		outHost := make(core.HostSlice[Projective], 1)
 		outHost.CopyFromDeviceAsync(&out, stream)
 		out.FreeAsync(stream)
-		
+
 		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
@@ -168,13 +168,11 @@ func TestMSMMultiDevice(t *testing.T) {
 				
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
-				
 				outHost := make(core.HostSlice[Projective], 1)
-			
-				cr.SynchronizeStream(&stream)
-				outHost.CopyFromDevice(&out)
-				out.Free()
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
 
+				cr.SynchronizeStream(&stream)
 				// Check with gnark-crypto
 				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 			}

--- a/wrappers/golang/curves/bn254/msm_test.go
+++ b/wrappers/golang/curves/bn254/msm_test.go
@@ -147,7 +147,7 @@ func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -158,14 +158,14 @@ func TestMSMMultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
-				
+
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[Projective], 1)

--- a/wrappers/golang/curves/bn254/msm_test.go
+++ b/wrappers/golang/curves/bn254/msm_test.go
@@ -56,19 +56,19 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -153,18 +153,18 @@ func TestMSMMultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bn254/msm_test.go
+++ b/wrappers/golang/curves/bn254/msm_test.go
@@ -56,24 +56,27 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
-
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
+		
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 	}
@@ -145,30 +148,29 @@ func TestMSMMultiDevice(t *testing.T) {
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
 	
-	for i := 0; i < numDevices; i ++ {
-		cr.SetDevice(i)
-		cfg := GetDefaultMSMConfig()
+	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
-		go func() {
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
-
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
-
-				stream, _ := cr.CreateStream()
+				
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-
+				
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
-
+				
 				outHost := make(core.HostSlice[Projective], 1)
-
+			
 				cr.SynchronizeStream(&stream)
 				outHost.CopyFromDevice(&out)
 				out.Free()
@@ -176,8 +178,7 @@ func TestMSMMultiDevice(t *testing.T) {
 				// Check with gnark-crypto
 				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 			}
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/wrappers/golang/curves/bn254/ntt.go
+++ b/wrappers/golang/curves/bn254/ntt.go
@@ -27,7 +27,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -38,7 +40,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
 	}

--- a/wrappers/golang/curves/bn254/scalar_field.go
+++ b/wrappers/golang/curves/bn254/scalar_field.go
@@ -106,9 +106,11 @@ func convertScalarsMontgomery(scalars *core.DeviceSlice, isInto bool) cr.CudaErr
 }
 
 func ToMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, true)
 }
 
 func FromMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, false)
 }

--- a/wrappers/golang/curves/bn254/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vec_ops.go
@@ -16,19 +16,25 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	var cA, cB, cOut *C.scalar_t
 
 	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
+		aDevice := a.(core.DeviceSlice)
+		aDevice.CheckDevice()
+		cA = (*C.scalar_t)(aDevice.AsPointer())
 	} else {
 		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
+		bDevice := b.(core.DeviceSlice)
+		bDevice.CheckDevice()
+		cB = (*C.scalar_t)(bDevice.AsPointer())
 	} else {
 		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
+		outDevice := out.(core.DeviceSlice)
+		outDevice.CheckDevice()
+		cOut = (*C.scalar_t)(outDevice.AsPointer())
 	} else {
 		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
 	}

--- a/wrappers/golang/curves/bw6761/curve.go
+++ b/wrappers/golang/curves/bw6761/curve.go
@@ -146,10 +146,12 @@ func convertAffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.Cud
 }
 
 func AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, true)
 }
 
 func AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertAffinePointsMontgomery(points, false)
 }
 
@@ -165,9 +167,11 @@ func convertProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) cr
 }
 
 func ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, true)
 }
 
 func ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bw6761/g2_curve.go
+++ b/wrappers/golang/curves/bw6761/g2_curve.go
@@ -148,10 +148,12 @@ func convertG2AffinePointsMontgomery(points *core.DeviceSlice, isInto bool) cr.C
 }
 
 func G2AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, true)
 }
 
 func G2AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2AffinePointsMontgomery(points, false)
 }
 
@@ -167,9 +169,11 @@ func convertG2ProjectivePointsMontgomery(points *core.DeviceSlice, isInto bool) 
 }
 
 func G2ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, true)
 }
 
 func G2ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convertG2ProjectivePointsMontgomery(points, false)
 }

--- a/wrappers/golang/curves/bw6761/g2_msm.go
+++ b/wrappers/golang/curves/bw6761/g2_msm.go
@@ -20,7 +20,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -28,7 +30,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
 	}
@@ -36,7 +40,9 @@ func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *c
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
 	}

--- a/wrappers/golang/curves/bw6761/g2_msm_test.go
+++ b/wrappers/golang/curves/bw6761/g2_msm_test.go
@@ -58,19 +58,19 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -155,18 +155,18 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bw6761/g2_msm_test.go
+++ b/wrappers/golang/curves/bw6761/g2_msm_test.go
@@ -176,7 +176,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 
 				cr.SynchronizeStream(&stream)
 				// Check with gnark-crypto
-				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+				assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 			}
 		})
 	}

--- a/wrappers/golang/curves/bw6761/g2_msm_test.go
+++ b/wrappers/golang/curves/bw6761/g2_msm_test.go
@@ -149,7 +149,7 @@ func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -160,14 +160,14 @@ func TestMSMG2MultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := G2GenerateAffinePoints(size)
-				
+
 				var p G2Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = G2Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[G2Projective], 1)

--- a/wrappers/golang/curves/bw6761/g2_msm_test.go
+++ b/wrappers/golang/curves/bw6761/g2_msm_test.go
@@ -3,8 +3,11 @@
 package bw6761
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
@@ -55,24 +58,27 @@ func testAgainstGnarkCryptoMsmG2(scalars core.HostSlice[ScalarField], points cor
 
 func TestMSMG2(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := G2GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p G2Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = G2Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[G2Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
 
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 	}
@@ -137,4 +143,42 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsmG2(scalars, points, outHost[0]))
 	}
+}
+
+func TestMSMG2MultiDevice(t *testing.T) {
+	numDevices, _ := cr.GetDeviceCount()
+	fmt.Println("There are ", numDevices, " devices available")
+	wg := sync.WaitGroup{}
+	
+	for i := 0; i < numDevices; i++ {
+		wg.Add(1)
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
+			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+				size := 1 << power
+				scalars := GenerateScalars(size)
+				points := G2GenerateAffinePoints(size)
+				
+				var p G2Projective
+				var out core.DeviceSlice
+				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+				cfg.Ctx.Stream = &stream
+				cfg.IsAsync = true
+				
+				e = G2Msm(scalars, points, &cfg, out)
+				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+				outHost := make(core.HostSlice[G2Projective], 1)
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
+
+				cr.SynchronizeStream(&stream)
+				// Check with gnark-crypto
+				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/wrappers/golang/curves/bw6761/msm.go
+++ b/wrappers/golang/curves/bw6761/msm.go
@@ -18,7 +18,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -26,7 +28,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
 	}
@@ -34,7 +38,9 @@ func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *cor
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
 	}

--- a/wrappers/golang/curves/bw6761/msm_test.go
+++ b/wrappers/golang/curves/bw6761/msm_test.go
@@ -1,8 +1,11 @@
 package bw6761
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
@@ -53,24 +56,27 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
 
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 	}
@@ -135,4 +141,42 @@ func TestMSMSkewedDistribution(t *testing.T) {
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
 	}
+}
+
+func TestMSMMultiDevice(t *testing.T) {
+	numDevices, _ := cr.GetDeviceCount()
+	fmt.Println("There are ", numDevices, " devices available")
+	wg := sync.WaitGroup{}
+	
+	for i := 0; i < numDevices; i++ {
+		wg.Add(1)
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
+			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+				size := 1 << power
+				scalars := GenerateScalars(size)
+				points := GenerateAffinePoints(size)
+				
+				var p Projective
+				var out core.DeviceSlice
+				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+				cfg.Ctx.Stream = &stream
+				cfg.IsAsync = true
+				
+				e = Msm(scalars, points, &cfg, out)
+				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+				outHost := make(core.HostSlice[Projective], 1)
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
+
+				cr.SynchronizeStream(&stream)
+				// Check with gnark-crypto
+				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/wrappers/golang/curves/bw6761/msm_test.go
+++ b/wrappers/golang/curves/bw6761/msm_test.go
@@ -147,7 +147,7 @@ func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -158,14 +158,14 @@ func TestMSMMultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
-				
+
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[Projective], 1)

--- a/wrappers/golang/curves/bw6761/msm_test.go
+++ b/wrappers/golang/curves/bw6761/msm_test.go
@@ -56,19 +56,19 @@ func testAgainstGnarkCryptoMsm(scalars core.HostSlice[ScalarField], points core.
 
 func TestMSM(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -153,18 +153,18 @@ func TestMSMMultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/curves/bw6761/ntt.go
+++ b/wrappers/golang/curves/bw6761/ntt.go
@@ -27,7 +27,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -38,7 +40,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
 	}

--- a/wrappers/golang/curves/bw6761/scalar_field.go
+++ b/wrappers/golang/curves/bw6761/scalar_field.go
@@ -106,9 +106,11 @@ func convertScalarsMontgomery(scalars *core.DeviceSlice, isInto bool) cr.CudaErr
 }
 
 func ToMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, true)
 }
 
 func FromMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, false)
 }

--- a/wrappers/golang/curves/bw6761/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vec_ops.go
@@ -16,19 +16,25 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	var cA, cB, cOut *C.scalar_t
 
 	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
+		aDevice := a.(core.DeviceSlice)
+		aDevice.CheckDevice()
+		cA = (*C.scalar_t)(aDevice.AsPointer())
 	} else {
 		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
+		bDevice := b.(core.DeviceSlice)
+		bDevice.CheckDevice()
+		cB = (*C.scalar_t)(bDevice.AsPointer())
 	} else {
 		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
+		outDevice := out.(core.DeviceSlice)
+		outDevice.CheckDevice()
+		cOut = (*C.scalar_t)(outDevice.AsPointer())
 	} else {
 		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
 	}

--- a/wrappers/golang/internal/generator/templates/curve.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/curve.go.tmpl
@@ -150,10 +150,12 @@ func convert{{if .IsG2}}G2{{end}}AffinePointsMontgomery(points *core.DeviceSlice
 }
 
 func {{if .IsG2}}G2{{end}}AffineToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convert{{if .IsG2}}G2{{end}}AffinePointsMontgomery(points, true)
 }
 
 func {{if .IsG2}}G2{{end}}AffineFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convert{{if .IsG2}}G2{{end}}AffinePointsMontgomery(points, false)
 }
 
@@ -169,10 +171,12 @@ func convert{{if .IsG2}}G2{{end}}ProjectivePointsMontgomery(points *core.DeviceS
 }
 
 func {{if .IsG2}}G2{{end}}ProjectiveToMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convert{{if .IsG2}}G2{{end}}ProjectivePointsMontgomery(points, true)
 }
 
 func {{if .IsG2}}G2{{end}}ProjectiveFromMontgomery(points *core.DeviceSlice) cr.CudaError {
+	points.CheckDevice()
 	return convert{{if .IsG2}}G2{{end}}ProjectivePointsMontgomery(points, false)
 }
 {{end}}

--- a/wrappers/golang/internal/generator/templates/msm.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm.go.tmpl
@@ -22,7 +22,9 @@ func {{if .IsG2}}G2{{end}}Msm(scalars core.HostOrDeviceSlice, points core.HostOr
 	core.MsmCheck(scalars, points, cfg, results)
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -30,7 +32,9 @@ func {{if .IsG2}}G2{{end}}Msm(scalars core.HostOrDeviceSlice, points core.HostOr
 
 	var pointsPointer unsafe.Pointer
 	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
+		pointsDevice := points.(core.DeviceSlice)
+		pointsDevice.CheckDevice()
+		pointsPointer = pointsDevice.AsPointer()
 	} else {
 		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[{{if .IsG2}}G2{{end}}Affine])[0])
 	}
@@ -38,7 +42,9 @@ func {{if .IsG2}}G2{{end}}Msm(scalars core.HostOrDeviceSlice, points core.HostOr
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[{{if .IsG2}}G2{{end}}Projective])[0])
 	}

--- a/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
@@ -196,7 +196,7 @@ func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
 	wg := sync.WaitGroup{}
-	
+
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
 		cr.RunOnDevice(i, func(args ...any) {
@@ -207,14 +207,14 @@ func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := {{if .IsG2}}G2{{end}}GenerateAffinePoints(size)
-				
+
 				var p {{if .IsG2}}G2{{end}}Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
 				cfg.IsAsync = true
-				
+
 				e = {{if .IsG2}}G2{{end}}Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 				outHost := make(core.HostSlice[{{if .IsG2}}G2{{end}}Projective], 1)

--- a/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
@@ -5,8 +5,11 @@
 package {{.PackageName}}
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
@@ -102,24 +105,27 @@ func testAgainstGnarkCryptoMsm{{if .IsG2}}G2{{end}}(scalars core.HostSlice[Scala
 
 func TestMSM{{if .IsG2}}G2{{end}}(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
+	stream, _ := cr.CreateStream()
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := {{if .IsG2}}G2{{end}}GenerateAffinePoints(size)
 
-		stream, _ := cr.CreateStream()
 		var p {{if .IsG2}}G2{{end}}Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
+		cfg.IsAsync = true
+
 		e = {{if .IsG2}}G2{{end}}Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 		outHost := make(core.HostSlice[{{if .IsG2}}G2{{end}}Projective], 1)
-		outHost.CopyFromDevice(&out)
-		out.Free()
+		outHost.CopyFromDeviceAsync(&out, stream)
+		out.FreeAsync(stream)
 
+		cr.SynchronizeStream(&stream)
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm{{if .IsG2}}G2{{end}}(scalars, points, outHost[0]))
 	}
@@ -184,4 +190,42 @@ func TestMSM{{if .IsG2}}G2{{end}}SkewedDistribution(t *testing.T) {
 		// Check with gnark-crypto
 		assert.True(t, testAgainstGnarkCryptoMsm{{if .IsG2}}G2{{end}}(scalars, points, outHost[0]))
 	}
+}
+
+func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
+	numDevices, _ := cr.GetDeviceCount()
+	fmt.Println("There are ", numDevices, " devices available")
+	wg := sync.WaitGroup{}
+	
+	for i := 0; i < numDevices; i++ {
+		wg.Add(1)
+		cr.RunOnDevice(i, func(args ...any) {
+			defer wg.Done()
+			cfg := GetDefaultMSMConfig()
+			stream, _ := cr.CreateStream()
+			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
+				size := 1 << power
+				scalars := GenerateScalars(size)
+				points := {{if .IsG2}}G2{{end}}GenerateAffinePoints(size)
+				
+				var p {{if .IsG2}}G2{{end}}Projective
+				var out core.DeviceSlice
+				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
+				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
+				cfg.Ctx.Stream = &stream
+				cfg.IsAsync = true
+				
+				e = {{if .IsG2}}G2{{end}}Msm(scalars, points, &cfg, out)
+				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
+				outHost := make(core.HostSlice[{{if .IsG2}}G2{{end}}Projective], 1)
+				outHost.CopyFromDeviceAsync(&out, stream)
+				out.FreeAsync(stream)
+
+				cr.SynchronizeStream(&stream)
+				// Check with gnark-crypto
+				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
@@ -105,19 +105,19 @@ func testAgainstGnarkCryptoMsm{{if .IsG2}}G2{{end}}(scalars core.HostSlice[Scala
 
 func TestMSM{{if .IsG2}}G2{{end}}(t *testing.T) {
 	cfg := GetDefaultMSMConfig()
-	stream, _ := cr.CreateStream()
+	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
 		scalars := GenerateScalars(size)
 		points := {{if .IsG2}}G2{{end}}GenerateAffinePoints(size)
 
+		stream, _ := cr.CreateStream()
 		var p {{if .IsG2}}G2{{end}}Projective
 		var out core.DeviceSlice
 		_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 		assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 		cfg.Ctx.Stream = &stream
-		cfg.IsAsync = true
 
 		e = {{if .IsG2}}G2{{end}}Msm(scalars, points, &cfg, out)
 		assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
@@ -202,18 +202,18 @@ func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
 		cr.RunOnDevice(i, func(args ...any) {
 			defer wg.Done()
 			cfg := GetDefaultMSMConfig()
-			stream, _ := cr.CreateStream()
+			cfg.IsAsync = true
 			for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 				size := 1 << power
 				scalars := GenerateScalars(size)
 				points := {{if .IsG2}}G2{{end}}GenerateAffinePoints(size)
 
+				stream, _ := cr.CreateStream()
 				var p {{if .IsG2}}G2{{end}}Projective
 				var out core.DeviceSlice
 				_, e := out.MallocAsync(p.Size(), p.Size(), stream)
 				assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 				cfg.Ctx.Stream = &stream
-				cfg.IsAsync = true
 
 				e = {{if .IsG2}}G2{{end}}Msm(scalars, points, &cfg, out)
 				assert.Equal(t, e, cr.CudaSuccess, "Msm failed")

--- a/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
@@ -223,7 +223,7 @@ func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
 
 				cr.SynchronizeStream(&stream)
 				// Check with gnark-crypto
-				assert.True(t, testAgainstGnarkCryptoMsm(scalars, points, outHost[0]))
+				assert.True(t, testAgainstGnarkCryptoMsm{{if .IsG2}}G2{{end}}(scalars, points, outHost[0]))
 			}
 		})
 	}

--- a/wrappers/golang/internal/generator/templates/ntt.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/ntt.go.tmpl
@@ -27,7 +27,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var scalarsPointer unsafe.Pointer
 	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
+		scalarsDevice := scalars.(core.DeviceSlice)
+		scalarsDevice.CheckDevice()
+		scalarsPointer = scalarsDevice.AsPointer()
 	} else {
 		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
 	}
@@ -38,7 +40,9 @@ func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTCo
 
 	var resultsPointer unsafe.Pointer
 	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
+		resultsDevice := results.(core.DeviceSlice)
+		resultsDevice.CheckDevice()
+		resultsPointer = resultsDevice.AsPointer()
 	} else {
 		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
 	}

--- a/wrappers/golang/internal/generator/templates/scalar_field.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/scalar_field.go.tmpl
@@ -33,9 +33,11 @@ func convertScalarsMontgomery(scalars *core.DeviceSlice, isInto bool) cr.CudaErr
 }
 
 func ToMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, true)
 }
 
 func FromMontgomery(scalars *core.DeviceSlice) cr.CudaError {
+	scalars.CheckDevice()
 	return convertScalarsMontgomery(scalars, false)
 }{{- end}}

--- a/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
@@ -16,19 +16,25 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	var cA, cB, cOut *C.scalar_t
 
 	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
+		aDevice := a.(core.DeviceSlice)
+		aDevice.CheckDevice()
+		cA = (*C.scalar_t)(aDevice.AsPointer())
 	} else {
 		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
+		bDevice := b.(core.DeviceSlice)
+		bDevice.CheckDevice()
+		cB = (*C.scalar_t)(bDevice.AsPointer())
 	} else {
 		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
 	}
 
 	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
+		outDevice := out.(core.DeviceSlice)
+		outDevice.CheckDevice()
+		cOut = (*C.scalar_t)(outDevice.AsPointer())
 	} else {
 		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
 	}


### PR DESCRIPTION
## Describe the changes

This PR adds multi gpu support in the golang bindings.

Tha main changes are to DeviceSlice which now includes a `deviceId` attribute specifying which device the underlying data resides on and checks for correct deviceId and current device when using DeviceSlices in any operation.

In Go, most concurrency can be done via Goroutines (described as lightweight threads - in reality, more of a threadpool manager), however, there is no guarantee that a goroutine stays on a specific host thread. Therefore, a function `RunOnDevice` was added to the cuda_runtime package which locks a goroutine into a specific host thread, sets a current GPU device, runs a provided function, and unlocks the goroutine from the host thread after the provided function finishes. While the goroutine is locked to the hsot thread, the Go runtime will not assign other goroutines to that host thread
