### PR TITLE
Update examles/rust/msm dockerfile to  fix bug 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install Golang
 ENV GOLANG_VERSION 1.21.1
-RUN curl -L https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar -xz -C /usr/local
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Set the working directory in the container

--- a/examples/rust/msm/.devcontainer/Dockerfile
+++ b/examples/rust/msm/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /icicle-example
 
 # Copy the content of the local directory to the working directory
-COPY . .
+COPY ./../../../ .
 
 # Specify the default command for the container
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Describe the changes

There is a conflict between https://github.com/ingonyama-zk/icicle/blob/main/examples/rust/msm/Cargo.toml#L7 and  https://github.com/ingonyama-zk/icicle/blob/main/examples/rust/msm/.devcontainer/Dockerfile#L24, it leads to an error happen when executing `cargo run --release` at docker
