### PR TITLE
Cleanup golang curves

### DIFF
--- a/wrappers/golang/core/msm_test.go
+++ b/wrappers/golang/core/msm_test.go
@@ -56,14 +56,18 @@ func TestMSMCheckHostSlices(t *testing.T) {
 	points := HostSliceFromElements[internal.MockAffine](rawAffinePoints)
 
 	output := make(HostSlice[internal.MockProjective], 1)
-	assert.NotPanics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalars, points, &cfg, output) })
+	assert.NotPanics(t, func() {
+		MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalars, points, &cfg, output)
+	})
 	assert.False(t, cfg.areScalarsOnDevice)
 	assert.False(t, cfg.arePointsOnDevice)
 	assert.False(t, cfg.areResultsOnDevice)
 	assert.Equal(t, int32(1), cfg.batchSize)
 
 	output2 := make(HostSlice[internal.MockProjective], 3)
-	assert.Panics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalars, points, &cfg, output2) })
+	assert.Panics(t, func() {
+		MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalars, points, &cfg, output2)
+	})
 }
 
 func TestMSMCheckDeviceSlices(t *testing.T) {
@@ -93,14 +97,18 @@ func TestMSMCheckDeviceSlices(t *testing.T) {
 	points.CopyToDevice(&pointsOnDevice, true)
 
 	output := make(HostSlice[internal.MockProjective], 1)
-	assert.NotPanics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalarsOnDevice, pointsOnDevice, &cfg, output) })
+	assert.NotPanics(t, func() {
+		MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalarsOnDevice, pointsOnDevice, &cfg, output)
+	})
 	assert.True(t, cfg.areScalarsOnDevice)
 	assert.True(t, cfg.arePointsOnDevice)
 	assert.False(t, cfg.areResultsOnDevice)
 	assert.Equal(t, int32(1), cfg.batchSize)
 
 	output2 := make(HostSlice[internal.MockProjective], 3)
-	assert.Panics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalarsOnDevice, pointsOnDevice, &cfg, output2) })
+	assert.Panics(t, func() {
+		MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalarsOnDevice, pointsOnDevice, &cfg, output2)
+	})
 }
 
 // TODO add check for batches and batchSize

--- a/wrappers/golang/core/msm_test.go
+++ b/wrappers/golang/core/msm_test.go
@@ -56,14 +56,14 @@ func TestMSMCheckHostSlices(t *testing.T) {
 	points := HostSliceFromElements[internal.MockAffine](rawAffinePoints)
 
 	output := make(HostSlice[internal.MockProjective], 1)
-	assert.NotPanics(t, func() { MsmCheck(scalars, points, &cfg, output) })
+	assert.NotPanics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalars, points, &cfg, output) })
 	assert.False(t, cfg.areScalarsOnDevice)
 	assert.False(t, cfg.arePointsOnDevice)
 	assert.False(t, cfg.areResultsOnDevice)
 	assert.Equal(t, int32(1), cfg.batchSize)
 
 	output2 := make(HostSlice[internal.MockProjective], 3)
-	assert.Panics(t, func() { MsmCheck(scalars, points, &cfg, output2) })
+	assert.Panics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalars, points, &cfg, output2) })
 }
 
 func TestMSMCheckDeviceSlices(t *testing.T) {
@@ -93,14 +93,14 @@ func TestMSMCheckDeviceSlices(t *testing.T) {
 	points.CopyToDevice(&pointsOnDevice, true)
 
 	output := make(HostSlice[internal.MockProjective], 1)
-	assert.NotPanics(t, func() { MsmCheck(scalarsOnDevice, pointsOnDevice, &cfg, output) })
+	assert.NotPanics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalarsOnDevice, pointsOnDevice, &cfg, output) })
 	assert.True(t, cfg.areScalarsOnDevice)
 	assert.True(t, cfg.arePointsOnDevice)
 	assert.False(t, cfg.areResultsOnDevice)
 	assert.Equal(t, int32(1), cfg.batchSize)
 
 	output2 := make(HostSlice[internal.MockProjective], 3)
-	assert.Panics(t, func() { MsmCheck(scalarsOnDevice, pointsOnDevice, &cfg, output2) })
+	assert.Panics(t, func() { MsmCheck[internal.MockField, internal.MockAffine, internal.MockProjective](scalarsOnDevice, pointsOnDevice, &cfg, output2) })
 }
 
 // TODO add check for batches and batchSize

--- a/wrappers/golang/core/ntt.go
+++ b/wrappers/golang/core/ntt.go
@@ -2,8 +2,8 @@ package core
 
 import (
 	"fmt"
-	"unsafe"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 type NTTDir int8

--- a/wrappers/golang/core/ntt_test.go
+++ b/wrappers/golang/core/ntt_test.go
@@ -35,7 +35,7 @@ func TestNTTCheckHostScalars(t *testing.T) {
 
 	var cosetGen internal.MockField
 	cosetGen.FromLimbs(randLimbs)
-	cfg := GetDefaultNTTConfig(&cosetGen)
+	cfg := GetDefaultNTTConfig(cosetGen)
 
 	rawInput := make([]internal.MockField, 10)
 	var emptyField internal.MockField
@@ -47,7 +47,7 @@ func TestNTTCheckHostScalars(t *testing.T) {
 
 	input := HostSliceFromElements[internal.MockField](rawInput)
 	output := HostSliceFromElements[internal.MockField](rawInput)
-	assert.NotPanics(t, func() { NttCheck(input, &cfg, output) })
+	assert.NotPanics(t, func() { NttCheck[internal.MockField, internal.MockField](input, &cfg, output) })
 	assert.False(t, cfg.areInputsOnDevice)
 	assert.False(t, cfg.areOutputsOnDevice)
 
@@ -56,7 +56,7 @@ func TestNTTCheckHostScalars(t *testing.T) {
 		rawInputLarger[i] = emptyField
 	}
 	output2 := HostSliceFromElements[internal.MockField](rawInputLarger)
-	assert.Panics(t, func() { NttCheck(input, &cfg, output2) })
+	assert.Panics(t, func() { NttCheck[internal.MockField, internal.MockField](input, &cfg, output2) })
 }
 
 func TestNTTCheckDeviceScalars(t *testing.T) {
@@ -84,13 +84,13 @@ func TestNTTCheckDeviceScalars(t *testing.T) {
 	var output DeviceSlice
 	output.Malloc(numFields*fieldBytesSize, fieldBytesSize)
 
-	assert.NotPanics(t, func() { NttCheck(input, &cfg, output) })
+	assert.NotPanics(t, func() { NttCheck[internal.MockField, internal.MockField](input, &cfg, output) })
 	assert.True(t, cfg.areInputsOnDevice)
 	assert.True(t, cfg.areOutputsOnDevice)
 
 	var output2 DeviceSlice
 	output2.Malloc((numFields+1)*fieldBytesSize, fieldBytesSize)
-	assert.Panics(t, func() { NttCheck(input, &cfg, output2) })
+	assert.Panics(t, func() { NttCheck[internal.MockField, internal.MockField](input, &cfg, output2) })
 }
 
 // TODO add check for batches and batchSize

--- a/wrappers/golang/core/vec_ops.go
+++ b/wrappers/golang/core/vec_ops.go
@@ -2,8 +2,8 @@ package core
 
 import (
 	"fmt"
-	"unsafe"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 type VecOps int
@@ -71,7 +71,7 @@ func VecOpCheck[S HostSliceInterface](a, b, out HostOrDeviceSlice, cfg *VecOpsCo
 	cfg.isAOnDevice = a.IsOnDevice()
 	cfg.isBOnDevice = b.IsOnDevice()
 	cfg.isResultOnDevice = out.IsOnDevice()
-	
+
 	var aPointer, bPointer, outPointer unsafe.Pointer
 	if a.IsOnDevice() {
 		aPointer = a.(DeviceSlice).AsPointer()

--- a/wrappers/golang/curves/bls12377/g2_msm.go
+++ b/wrappers/golang/curves/bls12377/g2_msm.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
@@ -17,33 +16,12 @@ func G2GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
-	}
-	cPoints := (*C.g2_affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
-	}
-	cResults := (*C.g2_projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, G2Affine, G2Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.g2_affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.g2_projective_t)(resultsP)
 
 	__ret := C.bls12_377G2MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bls12377/msm.go
+++ b/wrappers/golang/curves/bls12377/msm.go
@@ -7,7 +7,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
@@ -15,33 +14,12 @@ func GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
-	}
-	cPoints := (*C.affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
-	}
-	cResults := (*C.projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, Affine, Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.projective_t)(resultsP)
 
 	__ret := C.bls12_377MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bls12377/ntt.go
+++ b/wrappers/golang/curves/bls12377/ntt.go
@@ -23,25 +23,12 @@ func GetDefaultNttConfig() core.NTTConfig[[SCALAR_LIMBS]uint32] {
 }
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
-	core.NttCheck[T](scalars, cfg, results)
+	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T, ScalarField](scalars, cfg, results)
 
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
 	cScalars := (*C.scalar_t)(scalarsPointer)
-	cSize := (C.int)(scalars.Len() / int(cfg.BatchSize))
+	cSize := (C.int)(size)
 	cDir := (C.int)(dir)
-	cCfg := (*C.NTTConfig)(unsafe.Pointer(cfg))
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
-	}
+	cCfg := (*C.NTTConfig)(cfgPointer)
 	cResults := (*C.scalar_t)(resultsPointer)
 
 	__ret := C.bls12_377NTTCuda(cScalars, cSize, cDir, cCfg, cResults)

--- a/wrappers/golang/curves/bls12377/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vec_ops.go
@@ -5,36 +5,18 @@ package bls12377
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
-	core.VecOpCheck(a, b, out, &config)
-	var cA, cB, cOut *C.scalar_t
+	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck[ScalarField](a, b, out, &config)
 
-	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
-	} else {
-		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
-	} else {
-		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
-	} else {
-		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
-	}
-
-	cConfig := (*C.VecOpsConfig)(unsafe.Pointer(&config))
-	cSize := (C.int)(a.Len())
+	cA := (*C.scalar_t)(aPointer)
+	cB := (*C.scalar_t)(bPointer)
+	cOut := (*C.scalar_t)(outPointer)
+	cConfig := (*C.VecOpsConfig)(cfgPointer)
+	cSize := (C.int)(size)
 
 	switch op {
 	case core.Sub:

--- a/wrappers/golang/curves/bls12381/g2_msm.go
+++ b/wrappers/golang/curves/bls12381/g2_msm.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
@@ -17,33 +16,12 @@ func G2GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
-	}
-	cPoints := (*C.g2_affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
-	}
-	cResults := (*C.g2_projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, G2Affine, G2Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.g2_affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.g2_projective_t)(resultsP)
 
 	__ret := C.bls12_381G2MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bls12381/msm.go
+++ b/wrappers/golang/curves/bls12381/msm.go
@@ -7,7 +7,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
@@ -15,33 +14,12 @@ func GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
-	}
-	cPoints := (*C.affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
-	}
-	cResults := (*C.projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, Affine, Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.projective_t)(resultsP)
 
 	__ret := C.bls12_381MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bls12381/ntt.go
+++ b/wrappers/golang/curves/bls12381/ntt.go
@@ -23,25 +23,12 @@ func GetDefaultNttConfig() core.NTTConfig[[SCALAR_LIMBS]uint32] {
 }
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
-	core.NttCheck[T](scalars, cfg, results)
+	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T, ScalarField](scalars, cfg, results)
 
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
 	cScalars := (*C.scalar_t)(scalarsPointer)
-	cSize := (C.int)(scalars.Len() / int(cfg.BatchSize))
+	cSize := (C.int)(size)
 	cDir := (C.int)(dir)
-	cCfg := (*C.NTTConfig)(unsafe.Pointer(cfg))
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
-	}
+	cCfg := (*C.NTTConfig)(cfgPointer)
 	cResults := (*C.scalar_t)(resultsPointer)
 
 	__ret := C.bls12_381NTTCuda(cScalars, cSize, cDir, cCfg, cResults)

--- a/wrappers/golang/curves/bls12381/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vec_ops.go
@@ -5,36 +5,18 @@ package bls12381
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
-	core.VecOpCheck(a, b, out, &config)
-	var cA, cB, cOut *C.scalar_t
+	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck[ScalarField](a, b, out, &config)
 
-	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
-	} else {
-		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
-	} else {
-		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
-	} else {
-		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
-	}
-
-	cConfig := (*C.VecOpsConfig)(unsafe.Pointer(&config))
-	cSize := (C.int)(a.Len())
+	cA := (*C.scalar_t)(aPointer)
+	cB := (*C.scalar_t)(bPointer)
+	cOut := (*C.scalar_t)(outPointer)
+	cConfig := (*C.VecOpsConfig)(cfgPointer)
+	cSize := (C.int)(size)
 
 	switch op {
 	case core.Sub:

--- a/wrappers/golang/curves/bn254/g2_msm.go
+++ b/wrappers/golang/curves/bn254/g2_msm.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
@@ -17,33 +16,12 @@ func G2GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
-	}
-	cPoints := (*C.g2_affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
-	}
-	cResults := (*C.g2_projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, G2Affine, G2Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.g2_affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.g2_projective_t)(resultsP)
 
 	__ret := C.bn254G2MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bn254/msm.go
+++ b/wrappers/golang/curves/bn254/msm.go
@@ -7,7 +7,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
@@ -15,33 +14,12 @@ func GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[Affine])[0])
-	}
-	cPoints := (*C.affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[Projective])[0])
-	}
-	cResults := (*C.projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, Affine, Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.projective_t)(resultsP)
 
 	__ret := C.bn254MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bn254/ntt.go
+++ b/wrappers/golang/curves/bn254/ntt.go
@@ -23,25 +23,12 @@ func GetDefaultNttConfig() core.NTTConfig[[SCALAR_LIMBS]uint32] {
 }
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
-	core.NttCheck[T](scalars, cfg, results)
+	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T, ScalarField](scalars, cfg, results)
 
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
 	cScalars := (*C.scalar_t)(scalarsPointer)
-	cSize := (C.int)(scalars.Len() / int(cfg.BatchSize))
+	cSize := (C.int)(size)
 	cDir := (C.int)(dir)
-	cCfg := (*C.NTTConfig)(unsafe.Pointer(cfg))
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
-	}
+	cCfg := (*C.NTTConfig)(cfgPointer)
 	cResults := (*C.scalar_t)(resultsPointer)
 
 	__ret := C.bn254NTTCuda(cScalars, cSize, cDir, cCfg, cResults)

--- a/wrappers/golang/curves/bn254/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vec_ops.go
@@ -5,36 +5,18 @@ package bn254
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
-	core.VecOpCheck(a, b, out, &config)
-	var cA, cB, cOut *C.scalar_t
+	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck[ScalarField](a, b, out, &config)
 
-	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
-	} else {
-		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
-	} else {
-		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
-	} else {
-		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
-	}
-
-	cConfig := (*C.VecOpsConfig)(unsafe.Pointer(&config))
-	cSize := (C.int)(a.Len())
+	cA := (*C.scalar_t)(aPointer)
+	cB := (*C.scalar_t)(bPointer)
+	cOut := (*C.scalar_t)(outPointer)
+	cConfig := (*C.VecOpsConfig)(cfgPointer)
+	cSize := (C.int)(size)
 
 	switch op {
 	case core.Sub:

--- a/wrappers/golang/curves/bw6761/g2_msm.go
+++ b/wrappers/golang/curves/bw6761/g2_msm.go
@@ -9,7 +9,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
@@ -17,33 +16,12 @@ func G2GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[G2Affine])[0])
-	}
-	cPoints := (*C.g2_affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[G2Projective])[0])
-	}
-	cResults := (*C.g2_projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, G2Affine, G2Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.g2_affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.g2_projective_t)(resultsP)
 
 	__ret := C.bw6_761G2MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/curves/bw6761/ntt.go
+++ b/wrappers/golang/curves/bw6761/ntt.go
@@ -23,25 +23,12 @@ func GetDefaultNttConfig() core.NTTConfig[[SCALAR_LIMBS]uint32] {
 }
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
-	core.NttCheck[T](scalars, cfg, results)
+	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T, ScalarField](scalars, cfg, results)
 
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
 	cScalars := (*C.scalar_t)(scalarsPointer)
-	cSize := (C.int)(scalars.Len() / int(cfg.BatchSize))
+	cSize := (C.int)(size)
 	cDir := (C.int)(dir)
-	cCfg := (*C.NTTConfig)(unsafe.Pointer(cfg))
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
-	}
+	cCfg := (*C.NTTConfig)(cfgPointer)
 	cResults := (*C.scalar_t)(resultsPointer)
 
 	__ret := C.bw6_761NTTCuda(cScalars, cSize, cDir, cCfg, cResults)

--- a/wrappers/golang/curves/bw6761/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vec_ops.go
@@ -5,36 +5,18 @@ package bw6761
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
-	core.VecOpCheck(a, b, out, &config)
-	var cA, cB, cOut *C.scalar_t
+	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck[ScalarField](a, b, out, &config)
 
-	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
-	} else {
-		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
-	} else {
-		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
-	} else {
-		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
-	}
-
-	cConfig := (*C.VecOpsConfig)(unsafe.Pointer(&config))
-	cSize := (C.int)(a.Len())
+	cA := (*C.scalar_t)(aPointer)
+	cB := (*C.scalar_t)(bPointer)
+	cOut := (*C.scalar_t)(outPointer)
+	cConfig := (*C.VecOpsConfig)(cfgPointer)
+	cSize := (C.int)(size)
 
 	switch op {
 	case core.Sub:

--- a/wrappers/golang/internal/generator/templates/msm.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm.go.tmpl
@@ -11,7 +11,6 @@ import "C"
 import (
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
-	"unsafe"
 )
 
 func {{if .IsG2}}G2{{end}}GetDefaultMSMConfig() core.MSMConfig {
@@ -19,33 +18,12 @@ func {{if .IsG2}}G2{{end}}GetDefaultMSMConfig() core.MSMConfig {
 }
 
 func {{if .IsG2}}G2{{end}}Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
-	core.MsmCheck(scalars, points, cfg, results)
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
-	cScalars := (*C.scalar_t)(scalarsPointer)
-
-	var pointsPointer unsafe.Pointer
-	if points.IsOnDevice() {
-		pointsPointer = points.(core.DeviceSlice).AsPointer()
-	} else {
-		pointsPointer = unsafe.Pointer(&points.(core.HostSlice[{{if .IsG2}}G2{{end}}Affine])[0])
-	}
-	cPoints := (*C.{{if .IsG2}}g2_{{end}}affine_t)(pointsPointer)
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[{{if .IsG2}}G2{{end}}Projective])[0])
-	}
-	cResults := (*C.{{if .IsG2}}g2_{{end}}projective_t)(resultsPointer)
-
-	cSize := (C.int)(scalars.Len() / results.Len())
-	cCfg := (*C.MSMConfig)(unsafe.Pointer(cfg))
+	scalarsP, pointsP, cfgP, size, resultsP := core.MsmCheck[ScalarField, {{if .IsG2}}G2{{end}}Affine, {{if .IsG2}}G2{{end}}Projective](scalars, points, cfg, results)
+	cScalars := (*C.scalar_t)(scalarsP)
+	cPoints := (*C.{{if .IsG2}}g2_{{end}}affine_t)(pointsP)
+	cCfg := (*C.MSMConfig)(cfgP)
+	cSize := (C.int)(size)
+	cResults := (*C.{{if .IsG2}}g2_{{end}}projective_t)(resultsP)
 
 	__ret := C.{{.Curve}}{{if .IsG2}}G2{{end}}MSMCuda(cScalars, cPoints, cSize, cCfg, cResults)
 	err := (cr.CudaError)(__ret)

--- a/wrappers/golang/internal/generator/templates/ntt.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/ntt.go.tmpl
@@ -23,25 +23,12 @@ func GetDefaultNttConfig() core.NTTConfig[[SCALAR_LIMBS]uint32] {
 }
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
-	core.NttCheck[T](scalars, cfg, results)
+	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T, ScalarField](scalars, cfg, results)
 
-	var scalarsPointer unsafe.Pointer
-	if scalars.IsOnDevice() {
-		scalarsPointer = scalars.(core.DeviceSlice).AsPointer()
-	} else {
-		scalarsPointer = unsafe.Pointer(&scalars.(core.HostSlice[ScalarField])[0])
-	}
 	cScalars := (*C.scalar_t)(scalarsPointer)
-	cSize := (C.int)(scalars.Len() / int(cfg.BatchSize))
+	cSize := (C.int)(size)
 	cDir := (C.int)(dir)
-	cCfg := (*C.NTTConfig)(unsafe.Pointer(cfg))
-
-	var resultsPointer unsafe.Pointer
-	if results.IsOnDevice() {
-		resultsPointer = results.(core.DeviceSlice).AsPointer()
-	} else {
-		resultsPointer = unsafe.Pointer(&results.(core.HostSlice[ScalarField])[0])
-	}
+	cCfg := (*C.NTTConfig)(cfgPointer)
 	cResults := (*C.scalar_t)(resultsPointer)
 
 	__ret := C.{{.Curve}}NTTCuda(cScalars, cSize, cDir, cCfg, cResults)

--- a/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
@@ -5,36 +5,18 @@ package {{.PackageName}}
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
-	core.VecOpCheck(a, b, out, &config)
-	var cA, cB, cOut *C.scalar_t
+	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck[ScalarField](a, b, out, &config)
 
-	if a.IsOnDevice() {
-		cA = (*C.scalar_t)(a.(core.DeviceSlice).AsPointer())
-	} else {
-		cA = (*C.scalar_t)(unsafe.Pointer(&a.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if b.IsOnDevice() {
-		cB = (*C.scalar_t)(b.(core.DeviceSlice).AsPointer())
-	} else {
-		cB = (*C.scalar_t)(unsafe.Pointer(&b.(core.HostSlice[ScalarField])[0]))
-	}
-
-	if out.IsOnDevice() {
-		cOut = (*C.scalar_t)(out.(core.DeviceSlice).AsPointer())
-	} else {
-		cOut = (*C.scalar_t)(unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0]))
-	}
-
-	cConfig := (*C.VecOpsConfig)(unsafe.Pointer(&config))
-	cSize := (C.int)(a.Len())
+	cA := (*C.scalar_t)(aPointer)
+	cB := (*C.scalar_t)(bPointer)
+	cOut := (*C.scalar_t)(outPointer)
+	cConfig := (*C.VecOpsConfig)(cfgPointer)
+	cSize := (C.int)(size)
 
 	switch op {
 	case core.Sub:


### PR DESCRIPTION
## Describe the changes

This PR moves non-curve specific functionality to the core package for MSM, NTT, and VecOps.
