### PR TITLE
(1) MSM scalars and points params are const and (2) missing NTTAlgorithm in golang NTTConfig

### DIFF
--- a/icicle/appUtils/msm/msm.cuh
+++ b/icicle/appUtils/msm/msm.cuh
@@ -107,7 +107,7 @@ namespace msm {
    *
    */
   template <typename S, typename A, typename P>
-  cudaError_t MSM(S* scalars, A* points, int msm_size, MSMConfig& config, P* results);
+  cudaError_t MSM(const S* scalars, const A* points, int msm_size, MSMConfig& config, P* results);
 
   /**
    * A function that precomputes MSM bases by extending them with their shifted copies.

--- a/icicle/appUtils/msm/tests/msm_test.cu
+++ b/icicle/appUtils/msm/tests/msm_test.cu
@@ -30,7 +30,7 @@ public:
     return os;
   }
 
-  HOST_DEVICE_INLINE unsigned get_scalar_digit(unsigned digit_num, unsigned digit_width)
+  HOST_DEVICE_INLINE unsigned get_scalar_digit(unsigned digit_num, unsigned digit_width) const
   {
     return (x >> (digit_num * digit_width)) & ((1 << digit_width) - 1);
   }

--- a/icicle/primitives/field.cuh
+++ b/icicle/primitives/field.cuh
@@ -680,7 +680,7 @@ public:
 
   HOST_DEVICE_INLINE uint32_t* export_limbs() { return (uint32_t*)limbs_storage.limbs; }
 
-  HOST_DEVICE_INLINE unsigned get_scalar_digit(unsigned digit_num, unsigned digit_width)
+  HOST_DEVICE_INLINE unsigned get_scalar_digit(unsigned digit_num, unsigned digit_width) const
   {
     const uint32_t limb_lsb_idx = (digit_num * digit_width) / 32;
     const uint32_t shift_bits = (digit_num * digit_width) % 32;

--- a/icicle/utils/mont.cuh
+++ b/icicle/utils/mont.cuh
@@ -9,14 +9,14 @@ namespace mont {
 #define MAX_THREADS_PER_BLOCK 256
 
     template <typename E, bool is_into>
-    __global__ void MontgomeryKernel(E* input, int n, E* output)
+    __global__ void MontgomeryKernel(const E* input, int n, E* output)
     {
       int tid = blockIdx.x * blockDim.x + threadIdx.x;
       if (tid < n) { output[tid] = is_into ? E::ToMontgomery(input[tid]) : E::FromMontgomery(input[tid]); }
     }
 
     template <typename E, bool is_into>
-    cudaError_t ConvertMontgomery(E* d_input, int n, cudaStream_t stream, E* d_output)
+    cudaError_t ConvertMontgomery(const E* d_input, int n, cudaStream_t stream, E* d_output)
     {
       // Set the grid and block dimensions
       int num_threads = MAX_THREADS_PER_BLOCK;
@@ -29,13 +29,13 @@ namespace mont {
   } // namespace
 
   template <typename E>
-  cudaError_t ToMontgomery(E* d_input, int n, cudaStream_t stream, E* d_output)
+  cudaError_t ToMontgomery(const E* d_input, int n, cudaStream_t stream, E* d_output)
   {
     return ConvertMontgomery<E, true>(d_input, n, stream, d_output);
   }
 
   template <typename E>
-  cudaError_t FromMontgomery(E* d_input, int n, cudaStream_t stream, E* d_output)
+  cudaError_t FromMontgomery(const E* d_input, int n, cudaStream_t stream, E* d_output)
   {
     return ConvertMontgomery<E, false>(d_input, n, stream, d_output);
   }

--- a/wrappers/golang/build.sh
+++ b/wrappers/golang/build.sh
@@ -23,5 +23,5 @@ mkdir -p build
 for CURVE in "${BUILD_CURVES[@]}"
 do
   cmake -DCURVE=$CURVE -DG2_DEFINED=$G2_DEFINED -DCMAKE_BUILD_TYPE=Release -S . -B build
-  cmake --build build
+  cmake --build build -j8
 done

--- a/wrappers/golang/core/ntt.go
+++ b/wrappers/golang/core/ntt.go
@@ -24,6 +24,14 @@ const (
 	KMN Ordering = 5
 )
 
+type NttAlgorithm uint32
+
+const (
+	Auto       NttAlgorithm = iota
+	Radix2     NttAlgorithm = 1
+	MixedRadix NttAlgorithm = 2
+)
+
 type NTTConfig[T any] struct {
 	/// Details related to the device such as its id and stream id. See [DeviceContext](@ref device_context::DeviceContext).
 	Ctx cr.DeviceContext
@@ -40,6 +48,9 @@ type NTTConfig[T any] struct {
 	/// Whether to run the NTT asynchronously. If set to `true`, the NTT function will be non-blocking and you'd need to synchronize
 	/// it explicitly by running `stream.synchronize()`. If set to false, the NTT function will block the current CPU thread.
 	IsAsync bool
+	/// Explicitly select the NTT algorithm.
+	/// Default value: Auto (the implementation selects radix-2 or mixed-radix algorithm based on heuristics).
+	NttAlgorithm NttAlgorithm
 }
 
 func GetDefaultNTTConfig[T any](cosetGen T) NTTConfig[T] {
@@ -53,6 +64,7 @@ func GetDefaultNTTConfig[T any](cosetGen T) NTTConfig[T] {
 		false,    // areInputsOnDevice
 		false,    // areOutputsOnDevice
 		false,    // IsAsync
+		Auto,     // NttAlgorithm
 	}
 }
 

--- a/wrappers/golang/core/ntt_test.go
+++ b/wrappers/golang/core/ntt_test.go
@@ -24,6 +24,7 @@ func TestNTTDefaultConfig(t *testing.T) {
 		false,    // areInputsOnDevice
 		false,    // areOutputsOnDevice
 		false,    // IsAsync
+		Auto,     // NttAlgorithm
 	}
 
 	actual := GetDefaultNTTConfig(cosetGen)

--- a/wrappers/golang/curves/bls12377/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12377/g2_msm_test.go
@@ -217,6 +217,7 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -250,4 +251,5 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bls12377/include/g2_msm.h
+++ b/wrappers/golang/curves/bls12377/include/g2_msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bls12_377G2MSMCuda(scalar_t* scalars, g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
+cudaError_t bls12_377G2MSMCuda(const scalar_t* scalars,const  g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
 cudaError_t bls12_377G2PrecomputeMSMBases(g2_affine_t* points, int count, int precompute_factor, int _c, bool bases_on_device, DeviceContext* ctx, g2_affine_t* out);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bls12377/include/msm.h
+++ b/wrappers/golang/curves/bls12377/include/msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bls12_377MSMCuda(scalar_t* scalars, affine_t* points, int count, MSMConfig* config, projective_t* out);
+cudaError_t bls12_377MSMCuda(const scalar_t* scalars, const affine_t* points, int count, MSMConfig* config, projective_t* out);
 cudaError_t bls12_377PrecomputeMSMBases(affine_t* points, int bases_size, int precompute_factor, int _c, bool are_bases_on_device, DeviceContext* ctx, affine_t* output_bases);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bls12377/msm_test.go
+++ b/wrappers/golang/curves/bls12377/msm_test.go
@@ -188,6 +188,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -221,4 +222,5 @@ func TestMSMMultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bls12381/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12381/g2_msm_test.go
@@ -217,6 +217,7 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -250,4 +251,5 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bls12381/include/g2_msm.h
+++ b/wrappers/golang/curves/bls12381/include/g2_msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bls12_381G2MSMCuda(scalar_t* scalars, g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
+cudaError_t bls12_381G2MSMCuda(const scalar_t* scalars,const  g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
 cudaError_t bls12_381G2PrecomputeMSMBases(g2_affine_t* points, int count, int precompute_factor, int _c, bool bases_on_device, DeviceContext* ctx, g2_affine_t* out);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bls12381/include/msm.h
+++ b/wrappers/golang/curves/bls12381/include/msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bls12_381MSMCuda(scalar_t* scalars, affine_t* points, int count, MSMConfig* config, projective_t* out);
+cudaError_t bls12_381MSMCuda(const scalar_t* scalars, const affine_t* points, int count, MSMConfig* config, projective_t* out);
 cudaError_t bls12_381PrecomputeMSMBases(affine_t* points, int bases_size, int precompute_factor, int _c, bool are_bases_on_device, DeviceContext* ctx, affine_t* output_bases);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bls12381/msm_test.go
+++ b/wrappers/golang/curves/bls12381/msm_test.go
@@ -188,6 +188,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -221,4 +222,5 @@ func TestMSMMultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bn254/g2_msm_test.go
+++ b/wrappers/golang/curves/bn254/g2_msm_test.go
@@ -217,6 +217,7 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -250,4 +251,5 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bn254/include/g2_msm.h
+++ b/wrappers/golang/curves/bn254/include/g2_msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bn254G2MSMCuda(scalar_t* scalars, g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
+cudaError_t bn254G2MSMCuda(const scalar_t* scalars,const  g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
 cudaError_t bn254G2PrecomputeMSMBases(g2_affine_t* points, int count, int precompute_factor, int _c, bool bases_on_device, DeviceContext* ctx, g2_affine_t* out);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bn254/include/msm.h
+++ b/wrappers/golang/curves/bn254/include/msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bn254MSMCuda(scalar_t* scalars, affine_t* points, int count, MSMConfig* config, projective_t* out);
+cudaError_t bn254MSMCuda(const scalar_t* scalars, const affine_t* points, int count, MSMConfig* config, projective_t* out);
 cudaError_t bn254PrecomputeMSMBases(affine_t* points, int bases_size, int precompute_factor, int _c, bool are_bases_on_device, DeviceContext* ctx, affine_t* output_bases);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bn254/msm_test.go
+++ b/wrappers/golang/curves/bn254/msm_test.go
@@ -188,6 +188,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -221,4 +222,5 @@ func TestMSMMultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bw6761/g2_msm_test.go
+++ b/wrappers/golang/curves/bw6761/g2_msm_test.go
@@ -190,6 +190,7 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -223,4 +224,5 @@ func TestMSMG2MultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/curves/bw6761/include/g2_msm.h
+++ b/wrappers/golang/curves/bw6761/include/g2_msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bw6_761G2MSMCuda(scalar_t* scalars, g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
+cudaError_t bw6_761G2MSMCuda(const scalar_t* scalars,const  g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
 cudaError_t bw6_761G2PrecomputeMSMBases(g2_affine_t* points, int count, int precompute_factor, int _c, bool bases_on_device, DeviceContext* ctx, g2_affine_t* out);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bw6761/include/msm.h
+++ b/wrappers/golang/curves/bw6761/include/msm.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t bw6_761MSMCuda(scalar_t* scalars, affine_t* points, int count, MSMConfig* config, projective_t* out);
+cudaError_t bw6_761MSMCuda(const scalar_t* scalars, const affine_t* points, int count, MSMConfig* config, projective_t* out);
 cudaError_t bw6_761PrecomputeMSMBases(affine_t* points, int bases_size, int precompute_factor, int _c, bool are_bases_on_device, DeviceContext* ctx, affine_t* output_bases);
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bw6761/msm_test.go
+++ b/wrappers/golang/curves/bw6761/msm_test.go
@@ -188,6 +188,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
 
 	for i := 0; i < numDevices; i++ {
@@ -221,4 +222,5 @@ func TestMSMMultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }

--- a/wrappers/golang/internal/generator/templates/include/g2_msm.h.tmpl
+++ b/wrappers/golang/internal/generator/templates/include/g2_msm.h.tmpl
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t {{.Curve}}G2MSMCuda(scalar_t* scalars, g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
+cudaError_t {{.Curve}}G2MSMCuda(const scalar_t* scalars,const  g2_affine_t* points, int count, MSMConfig* config, g2_projective_t* out);
 cudaError_t {{.Curve}}G2PrecomputeMSMBases(g2_affine_t* points, int count, int precompute_factor, int _c, bool bases_on_device, DeviceContext* ctx, g2_affine_t* out);
 
 #ifdef __cplusplus

--- a/wrappers/golang/internal/generator/templates/include/msm.h.tmpl
+++ b/wrappers/golang/internal/generator/templates/include/msm.h.tmpl
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-cudaError_t {{.Curve}}MSMCuda(scalar_t* scalars, affine_t* points, int count, MSMConfig* config, projective_t* out);
+cudaError_t {{.Curve}}MSMCuda(const scalar_t* scalars, const affine_t* points, int count, MSMConfig* config, projective_t* out);
 cudaError_t {{.Curve}}PrecomputeMSMBases(affine_t* points, int bases_size, int precompute_factor, int _c, bool are_bases_on_device, DeviceContext* ctx, affine_t* output_bases);
 
 #ifdef __cplusplus

--- a/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/msm_test.go.tmpl
@@ -238,7 +238,9 @@ func TestMSM{{if .IsG2}}G2{{end}}SkewedDistribution(t *testing.T) {
 func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
 	fmt.Println("There are ", numDevices, " devices available")
+	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}
+
 
 	for i := 0; i < numDevices; i++ {
 		wg.Add(1)
@@ -271,4 +273,5 @@ func TestMSM{{if .IsG2}}G2{{end}}MultiDevice(t *testing.T) {
 		})
 	}
 	wg.Wait()
+	cr.SetDevice(orig_device)
 }


### PR DESCRIPTION
(1) MSM method now takes points and scalars params by const.
This is required to be able to compute MSM on polynomial coefficients, that are internal to the polynomial objects, thus can only be accessed by const, to avoid unexpected writes.
(2) NTTAlgorithm field added to golang NTTConfig