### PR TITLE
NTT inplace in Rust

### DIFF
--- a/icicle/appUtils/ntt/ntt.cu
+++ b/icicle/appUtils/ntt/ntt.cu
@@ -33,9 +33,14 @@ namespace ntt {
         int batch_idx = threadId / n;
         int idx_reversed = __brev(idx) >> (32 - logn);
 
-        E val = arr[batch_idx * n + idx];
-        if (arr == arr_reversed) { __syncthreads(); } // for in-place (when pointers arr==arr_reversed)
-        arr_reversed[batch_idx * n + idx_reversed] = val;
+        if (arr == arr_reversed) { // for in-place (when pointers arr==arr_reversed)
+          if (idx < idx_reversed) {
+            E val = arr[batch_idx * n + idx];
+            arr_reversed[batch_idx * n + idx] = arr[batch_idx * n + idx_reversed];
+            arr_reversed[batch_idx * n + idx_reversed] = val;
+          }
+        } else
+          arr_reversed[batch_idx * n + idx_reversed] = arr[batch_idx * n + idx];
       }
     }
 

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -121,11 +121,7 @@ pub trait NTT<F: FieldImpl> {
         cfg: &NTTConfig<F>,
         output: &mut HostOrDeviceSlice<F>,
     ) -> IcicleResult<()>;
-    fn ntt_inplace_unchecked(
-        inout: &mut HostOrDeviceSlice<F>,
-        dir: NTTDir,
-        cfg: &NTTConfig<F>,
-    ) -> IcicleResult<()>;
+    fn ntt_inplace_unchecked(inout: &mut HostOrDeviceSlice<F>, dir: NTTDir, cfg: &NTTConfig<F>) -> IcicleResult<()>;
     fn initialize_domain(primitive_root: F, ctx: &DeviceContext) -> IcicleResult<()>;
     fn initialize_domain_fast_twiddles_mode(primitive_root: F, ctx: &DeviceContext) -> IcicleResult<()>;
 }
@@ -174,11 +170,7 @@ where
 /// * `dir` - whether to compute forward of inverse NTT.
 ///
 /// * `cfg` - config used to specify extra arguments of the NTT.
-pub fn ntt_inplace<F>(
-    inout: &mut HostOrDeviceSlice<F>,
-    dir: NTTDir,
-    cfg: &NTTConfig<F>,
-) -> IcicleResult<()>
+pub fn ntt_inplace<F>(inout: &mut HostOrDeviceSlice<F>, dir: NTTDir, cfg: &NTTConfig<F>) -> IcicleResult<()>
 where
     F: FieldImpl,
     <F as FieldImpl>::Config: NTT<F>,

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -121,6 +121,11 @@ pub trait NTT<F: FieldImpl> {
         cfg: &NTTConfig<F>,
         output: &mut HostOrDeviceSlice<F>,
     ) -> IcicleResult<()>;
+    fn ntt_inplace_unchecked(
+        inout: &mut HostOrDeviceSlice<F>,
+        dir: NTTDir,
+        cfg: &NTTConfig<F>,
+    ) -> IcicleResult<()>;
     fn initialize_domain(primitive_root: F, ctx: &DeviceContext) -> IcicleResult<()>;
     fn initialize_domain_fast_twiddles_mode(primitive_root: F, ctx: &DeviceContext) -> IcicleResult<()>;
 }
@@ -158,6 +163,31 @@ where
     local_cfg.are_outputs_on_device = output.is_on_device();
 
     <<F as FieldImpl>::Config as NTT<F>>::ntt_unchecked(input, dir, &local_cfg, output)
+}
+
+/// Computes the NTT, or a batch of several NTTs inplace.
+///
+/// # Arguments
+///
+/// * `inout` - buffer with inputs to also write the NTT outputs into.
+///
+/// * `dir` - whether to compute forward of inverse NTT.
+///
+/// * `cfg` - config used to specify extra arguments of the NTT.
+pub fn ntt_inplace<F>(
+    inout: &mut HostOrDeviceSlice<F>,
+    dir: NTTDir,
+    cfg: &NTTConfig<F>,
+) -> IcicleResult<()>
+where
+    F: FieldImpl,
+    <F as FieldImpl>::Config: NTT<F>,
+{
+    let mut local_cfg = cfg.clone();
+    local_cfg.are_inputs_on_device = inout.is_on_device();
+    local_cfg.are_outputs_on_device = inout.is_on_device();
+
+    <<F as FieldImpl>::Config as NTT<F>>::ntt_inplace_unchecked(inout, dir, &local_cfg)
 }
 
 /// Generates twiddle factors which will be used to compute NTTs.
@@ -228,6 +258,23 @@ macro_rules! impl_ntt {
                         dir,
                         cfg,
                         output.as_mut_ptr(),
+                    )
+                    .wrap()
+                }
+            }
+
+            fn ntt_inplace_unchecked(
+                inout: &mut HostOrDeviceSlice<$field>,
+                dir: NTTDir,
+                cfg: &NTTConfig<$field>,
+            ) -> IcicleResult<()> {
+                unsafe {
+                    $field_prefix_ident::ntt_cuda(
+                        inout.as_ptr(),
+                        (inout.len() / (cfg.batch_size as usize)) as i32,
+                        dir,
+                        cfg,
+                        inout.as_mut_ptr(),
                     )
                     .wrap()
                 }


### PR DESCRIPTION
## Describe the changes

Due to Rust's ownership rules, we can't run NTT inplace using the [`ntt`](https://github.com/ingonyama-zk/icicle/blob/v1.9.1/wrappers/rust/icicle-core/src/ntt/mod.rs#L139) function. Which is why we saw a need to add a separate function a couple of times.

Incidentally an issue with radix-2 NTT was found when ran inplace, `__syncthreads()` was used in reverse order kernel as if it was a global barrier for all blocks and not block-local one. Thus data race happened that is fixed by this PR.