### PR TITLE
Fix Golang TestNttDeviceAsync

### DIFF
--- a/wrappers/golang/curves/bls12377/ntt_test.go
+++ b/wrappers/golang/curves/bls12377/ntt_test.go
@@ -120,6 +120,7 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bls12377/ntt_test.go
+++ b/wrappers/golang/curves/bls12377/ntt_test.go
@@ -77,6 +77,12 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
+func TestInitDomain(t *testing.T) {
+	t.Skip("Skipped because each test requires the domain to be initialized before running. We ensure this using the init() function")
+	cfg := GetDefaultNttConfig()
+	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
+}
+
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)

--- a/wrappers/golang/curves/bls12377/ntt_test.go
+++ b/wrappers/golang/curves/bls12377/ntt_test.go
@@ -16,6 +16,11 @@ const (
 	largestTestSize = 17
 )
 
+func init() {
+	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
+}
+
 func initDomain[T any](largestTestSize int, cfg core.NTTConfig[T]) {
 	rouMont, _ := fft.Generator(uint64(1 << largestTestSize))
 	rou := rouMont.Bits()
@@ -72,11 +77,6 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
-func TestInitDomain(t *testing.T) {
-	cfg := GetDefaultNttConfig()
-	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
-}
-
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)
@@ -100,7 +100,6 @@ func TestNtt(t *testing.T) {
 
 func TestECNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	points := GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {
@@ -120,7 +119,6 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bls12381/ntt_test.go
+++ b/wrappers/golang/curves/bls12381/ntt_test.go
@@ -120,6 +120,7 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bls12381/ntt_test.go
+++ b/wrappers/golang/curves/bls12381/ntt_test.go
@@ -77,6 +77,12 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
+func TestInitDomain(t *testing.T) {
+	t.Skip("Skipped because each test requires the domain to be initialized before running. We ensure this using the init() function")
+	cfg := GetDefaultNttConfig()
+	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
+}
+
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)

--- a/wrappers/golang/curves/bls12381/ntt_test.go
+++ b/wrappers/golang/curves/bls12381/ntt_test.go
@@ -16,6 +16,11 @@ const (
 	largestTestSize = 17
 )
 
+func init() {
+	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
+}
+
 func initDomain[T any](largestTestSize int, cfg core.NTTConfig[T]) {
 	rouMont, _ := fft.Generator(uint64(1 << largestTestSize))
 	rou := rouMont.Bits()
@@ -72,11 +77,6 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
-func TestInitDomain(t *testing.T) {
-	cfg := GetDefaultNttConfig()
-	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
-}
-
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)
@@ -100,7 +100,6 @@ func TestNtt(t *testing.T) {
 
 func TestECNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	points := GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {
@@ -120,7 +119,6 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bn254/ntt_test.go
+++ b/wrappers/golang/curves/bn254/ntt_test.go
@@ -120,6 +120,7 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bn254/ntt_test.go
+++ b/wrappers/golang/curves/bn254/ntt_test.go
@@ -77,6 +77,12 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
+func TestInitDomain(t *testing.T) {
+	t.Skip("Skipped because each test requires the domain to be initialized before running. We ensure this using the init() function")
+	cfg := GetDefaultNttConfig()
+	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
+}
+
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)

--- a/wrappers/golang/curves/bn254/ntt_test.go
+++ b/wrappers/golang/curves/bn254/ntt_test.go
@@ -16,6 +16,11 @@ const (
 	largestTestSize = 17
 )
 
+func init() {
+	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
+}
+
 func initDomain[T any](largestTestSize int, cfg core.NTTConfig[T]) {
 	rouMont, _ := fft.Generator(uint64(1 << largestTestSize))
 	rou := rouMont.Bits()
@@ -72,11 +77,6 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
-func TestInitDomain(t *testing.T) {
-	cfg := GetDefaultNttConfig()
-	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
-}
-
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)
@@ -100,7 +100,6 @@ func TestNtt(t *testing.T) {
 
 func TestECNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	points := GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {
@@ -120,7 +119,6 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bw6761/ntt_test.go
+++ b/wrappers/golang/curves/bw6761/ntt_test.go
@@ -120,6 +120,7 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/curves/bw6761/ntt_test.go
+++ b/wrappers/golang/curves/bw6761/ntt_test.go
@@ -77,6 +77,12 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
+func TestInitDomain(t *testing.T) {
+	t.Skip("Skipped because each test requires the domain to be initialized before running. We ensure this using the init() function")
+	cfg := GetDefaultNttConfig()
+	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
+}
+
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)

--- a/wrappers/golang/curves/bw6761/ntt_test.go
+++ b/wrappers/golang/curves/bw6761/ntt_test.go
@@ -16,6 +16,11 @@ const (
 	largestTestSize = 17
 )
 
+func init() {
+	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
+}
+
 func initDomain[T any](largestTestSize int, cfg core.NTTConfig[T]) {
 	rouMont, _ := fft.Generator(uint64(1 << largestTestSize))
 	rou := rouMont.Bits()
@@ -72,11 +77,6 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
-func TestInitDomain(t *testing.T) {
-	cfg := GetDefaultNttConfig()
-	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
-}
-
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)
@@ -100,7 +100,6 @@ func TestNtt(t *testing.T) {
 
 func TestECNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	points := GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {
@@ -120,7 +119,6 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/internal/generator/templates/ntt_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/ntt_test.go.tmpl
@@ -120,6 +120,7 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {

--- a/wrappers/golang/internal/generator/templates/ntt_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/ntt_test.go.tmpl
@@ -77,6 +77,12 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
+func TestInitDomain(t *testing.T) {
+	t.Skip("Skipped because each test requires the domain to be initialized before running. We ensure this using the init() function")
+	cfg := GetDefaultNttConfig()
+	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
+}
+
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)

--- a/wrappers/golang/internal/generator/templates/ntt_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/ntt_test.go.tmpl
@@ -16,6 +16,11 @@ const (
 	largestTestSize = 17
 )
 
+func init() {
+	cfg := GetDefaultNttConfig()
+	initDomain(largestTestSize, cfg)
+}
+
 func initDomain[T any](largestTestSize int, cfg core.NTTConfig[T]) {
 	rouMont, _ := fft.Generator(uint64(1 << largestTestSize))
 	rou := rouMont.Bits()
@@ -72,11 +77,6 @@ func TestNTTGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, cosetGenField.GetLimbs(), actual.CosetGen)
 }
 
-func TestInitDomain(t *testing.T) {
-	cfg := GetDefaultNttConfig()
-	assert.NotPanics(t, func() { initDomain(largestTestSize, cfg) })
-}
-
 func TestNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
 	scalars := GenerateScalars(1 << largestTestSize)
@@ -100,7 +100,6 @@ func TestNtt(t *testing.T) {
 
 func TestECNtt(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	points := GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {
@@ -120,7 +119,6 @@ func TestECNtt(t *testing.T) {
 
 func TestNttDeviceAsync(t *testing.T) {
 	cfg := GetDefaultNttConfig()
-	initDomain(largestTestSize, cfg)
 	scalars := GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {


### PR DESCRIPTION
## Describe the changes

This PR fixes TestNttDeviceAsync by adding a missing call to initDomain

## Linked Issues

Resolves #
