### PR TITLE
transpose kernel in vec_ops and rust binding

### DIFF
--- a/icicle/utils/vec_ops.cu
+++ b/icicle/utils/vec_ops.cu
@@ -111,7 +111,7 @@ namespace vec_ops {
 
   template <typename E>
   cudaError_t transpose_batch(
-  E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx, bool on_device)
+    E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx, bool on_device)
   {
     int number_of_threads = MAX_THREADS_PER_BLOCK;
     int number_of_blocks = (row_size * column_size + number_of_threads - 1) / number_of_threads;
@@ -120,7 +120,8 @@ namespace vec_ops {
     E *d_mat_in, *d_mat_out;
     if (!on_device) {
       CHK_IF_RETURN(cudaMallocAsync(&d_mat_in, row_size * column_size * sizeof(E), ctx.stream));
-      CHK_IF_RETURN(cudaMemcpyAsync(d_mat_in, mat_in, row_size * column_size * sizeof(E), cudaMemcpyHostToDevice, ctx.stream));
+      CHK_IF_RETURN(
+        cudaMemcpyAsync(d_mat_in, mat_in, row_size * column_size * sizeof(E), cudaMemcpyHostToDevice, ctx.stream));
 
       CHK_IF_RETURN(cudaMallocAsync(&d_mat_out, row_size * column_size * sizeof(E), ctx.stream));
     } else {
@@ -131,7 +132,8 @@ namespace vec_ops {
     transpose_kernel<<<number_of_blocks, number_of_threads, 0, stream>>>(d_mat_in, d_mat_out, row_size, column_size);
 
     if (!on_device) {
-      CHK_IF_RETURN(cudaMemcpyAsync(mat_out, d_mat_out, row_size * column_size * sizeof(E), cudaMemcpyDeviceToHost, ctx.stream));
+      CHK_IF_RETURN(
+        cudaMemcpyAsync(mat_out, d_mat_out, row_size * column_size * sizeof(E), cudaMemcpyDeviceToHost, ctx.stream));
       CHK_IF_RETURN(cudaFreeAsync(d_mat_out, ctx.stream));
       CHK_IF_RETURN(cudaFreeAsync(d_mat_in, ctx.stream));
     }
@@ -189,12 +191,12 @@ namespace vec_ops {
    * @return `cudaSuccess` if the execution was successful and an error code otherwise.
    */
   extern "C" cudaError_t CONCAT_EXPAND(CURVE, TransposeBatch)(
-  curve_config::scalar_t* input,
-  uint32_t row_size,
-  uint32_t column_size,
-  curve_config::scalar_t* output,
-  device_context::DeviceContext& ctx,
-  bool on_device)
+    curve_config::scalar_t* input,
+    uint32_t row_size,
+    uint32_t column_size,
+    curve_config::scalar_t* output,
+    device_context::DeviceContext& ctx,
+    bool on_device)
   {
     return transpose_batch<curve_config::scalar_t>(input, output, row_size, column_size, ctx, on_device);
   }

--- a/icicle/utils/vec_ops.cu
+++ b/icicle/utils/vec_ops.cu
@@ -111,19 +111,25 @@ namespace vec_ops {
 
   template <typename E>
   cudaError_t transpose_matrix(
-    const E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx, bool on_device, bool is_async)
+    const E* mat_in,
+    E* mat_out,
+    uint32_t row_size,
+    uint32_t column_size,
+    device_context::DeviceContext& ctx,
+    bool on_device,
+    bool is_async)
   {
     int number_of_threads = MAX_THREADS_PER_BLOCK;
     int number_of_blocks = (row_size * column_size + number_of_threads - 1) / number_of_threads;
     cudaStream_t stream = ctx.stream;
 
-    const E *d_mat_in;
-    E *d_allocated_input = nullptr;
-    E *d_mat_out;
+    const E* d_mat_in;
+    E* d_allocated_input = nullptr;
+    E* d_mat_out;
     if (!on_device) {
       CHK_IF_RETURN(cudaMallocAsync(&d_allocated_input, row_size * column_size * sizeof(E), ctx.stream));
-      CHK_IF_RETURN(
-        cudaMemcpyAsync(d_allocated_input, mat_in, row_size * column_size * sizeof(E), cudaMemcpyHostToDevice, ctx.stream));
+      CHK_IF_RETURN(cudaMemcpyAsync(
+        d_allocated_input, mat_in, row_size * column_size * sizeof(E), cudaMemcpyHostToDevice, ctx.stream));
 
       CHK_IF_RETURN(cudaMallocAsync(&d_mat_out, row_size * column_size * sizeof(E), ctx.stream));
       d_mat_in = d_allocated_input;

--- a/icicle/utils/vec_ops.cuh
+++ b/icicle/utils/vec_ops.cuh
@@ -111,8 +111,14 @@ namespace vec_ops {
    * @return `cudaSuccess` if the execution was successful and an error code otherwise.
    */
   template <typename E>
-  cudaError_t
-  transpose_batch(const E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx, bool on_device, bool is_async);
+  cudaError_t transpose_batch(
+    const E* mat_in,
+    E* mat_out,
+    uint32_t row_size,
+    uint32_t column_size,
+    device_context::DeviceContext& ctx,
+    bool on_device,
+    bool is_async);
 } // namespace vec_ops
 
 #endif

--- a/icicle/utils/vec_ops.cuh
+++ b/icicle/utils/vec_ops.cuh
@@ -105,7 +105,7 @@ namespace vec_ops {
    * @param row_size size of rows.
    * @param column_size size of columns.
    * @param ctx Device context.
-   * @param on_device wether the input and output are on device.
+   * @param on_device Whether the input and output are on device.
    * @tparam E The type of elements `mat_in' and `mat_out`.
    */
   template <typename E>

--- a/icicle/utils/vec_ops.cuh
+++ b/icicle/utils/vec_ops.cuh
@@ -106,11 +106,13 @@ namespace vec_ops {
    * @param column_size size of columns.
    * @param ctx Device context.
    * @param on_device Whether the input and output are on device.
+   * @param is_async Whether to run the vector operations asynchronously.
    * @tparam E The type of elements `mat_in' and `mat_out`.
+   * @return `cudaSuccess` if the execution was successful and an error code otherwise.
    */
   template <typename E>
   cudaError_t
-  transpose_batch(E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx);
+  transpose_batch(const E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx, bool on_device, bool is_async);
 } // namespace vec_ops
 
 #endif

--- a/icicle/utils/vec_ops.cuh
+++ b/icicle/utils/vec_ops.cuh
@@ -109,7 +109,8 @@ namespace vec_ops {
    * @tparam E The type of elements `mat_in' and `mat_out`.
    */
   template <typename E>
-  cudaError_t transpose_batch(E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx);
+  cudaError_t
+  transpose_batch(E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx);
 } // namespace vec_ops
 
 #endif

--- a/icicle/utils/vec_ops.cuh
+++ b/icicle/utils/vec_ops.cuh
@@ -95,6 +95,21 @@ namespace vec_ops {
    */
   template <typename E>
   cudaError_t Sub(E* vec_a, E* vec_b, int n, VecOpsConfig<E>& config, E* result);
+
+  /**
+   * Transposes an input matrix out-of-place inside GPU.
+   * for example: for ([a[0],a[1],a[2],a[3]], 2, 2) it returns
+   * [a[0],a[2],a[1],a[3]].
+   * @param mat_in array of some object of type E of size row_size * column_size.
+   * @param arr_out buffer of the same size as `mat_in` to write the transpose matrix into.
+   * @param row_size size of rows.
+   * @param column_size size of columns.
+   * @param ctx Device context.
+   * @param on_device wether the input and output are on device.
+   * @tparam E The type of elements `mat_in' and `mat_out`.
+   */
+  template <typename E>
+  cudaError_t transpose_batch(E* mat_in, E* mat_out, uint32_t row_size, uint32_t column_size, device_context::DeviceContext& ctx);
 } // namespace vec_ops
 
 #endif

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -237,7 +237,7 @@ where
 
 pub fn check_ntt_batch<F: FieldImpl>()
 where
-    <F as FieldImpl>::Config: NTT<F> + GenerateRandom<F>,
+<F as FieldImpl>::Config: NTT<F> + GenerateRandom<F>, <F as FieldImpl>::Config: VecOps<F>
 {
     let test_sizes = [1 << 4, 1 << 12];
     let batch_sizes = [1, 1 << 4, 100];

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -8,6 +8,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
     ntt::{initialize_domain, initialize_domain_fast_twiddles_mode, ntt, NTTDir, NttAlgorithm, Ordering},
+    vec_ops::{transpose_matrix, VecOps},
     traits::{ArkConvertible, FieldImpl, GenerateRandom},
 };
 

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -285,6 +285,7 @@ where
                         let row_size = test_size as u32;
                         let column_size = batch_size as u32;
                         let on_device = false;
+                        let is_async = false;
                         // for now, columns batching only works with MixedRadix NTT
                         config.batch_size = batch_size as i32;
                         config.columns_batch = true;
@@ -296,6 +297,7 @@ where
                             &mut transposed_input,
                             &config.ctx,
                             on_device,
+                            is_async,
                         )
                         .unwrap();
                         let mut col_batch_ntt_result =
@@ -308,6 +310,7 @@ where
                             &mut transposed_input,
                             &config.ctx,
                             on_device,
+                            is_async,
                         )
                         .unwrap();
                         assert_eq!(batch_ntt_result[..], *transposed_input.as_slice());

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -8,8 +8,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
     ntt::{initialize_domain, initialize_domain_fast_twiddles_mode, ntt, NTTDir, NttAlgorithm, Ordering},
-    vec_ops::{transpose_matrix, VecOps},
     traits::{ArkConvertible, FieldImpl, GenerateRandom},
+    vec_ops::{transpose_matrix, VecOps},
 };
 
 use super::{NTTConfig, NTT};
@@ -237,7 +237,8 @@ where
 
 pub fn check_ntt_batch<F: FieldImpl>()
 where
-<F as FieldImpl>::Config: NTT<F> + GenerateRandom<F>, <F as FieldImpl>::Config: VecOps<F>
+    <F as FieldImpl>::Config: NTT<F> + GenerateRandom<F>,
+    <F as FieldImpl>::Config: VecOps<F>,
 {
     let test_sizes = [1 << 4, 1 << 12];
     let batch_sizes = [1, 1 << 4, 100];
@@ -288,15 +289,28 @@ where
                         config.batch_size = batch_size as i32;
                         config.columns_batch = true;
                         let mut transposed_input = HostOrDeviceSlice::on_host(vec![F::zero(); batch_size * test_size]);
-                        transpose_matrix(&scalars, row_size, column_size, &mut transposed_input, &config.ctx, on_device).unwrap();
+                        transpose_matrix(
+                            &scalars,
+                            row_size,
+                            column_size,
+                            &mut transposed_input,
+                            &config.ctx,
+                            on_device,
+                        )
+                        .unwrap();
                         let mut col_batch_ntt_result =
                             HostOrDeviceSlice::on_host(vec![F::zero(); batch_size * test_size]);
                         ntt(&transposed_input, is_inverse, &config, &mut col_batch_ntt_result).unwrap();
-                        transpose_matrix(&col_batch_ntt_result, column_size, row_size, &mut transposed_input, &config.ctx, on_device).unwrap();
-                        assert_eq!(
-                            batch_ntt_result[..],
-                            *transposed_input.as_slice()
-                        );
+                        transpose_matrix(
+                            &col_batch_ntt_result,
+                            column_size,
+                            row_size,
+                            &mut transposed_input,
+                            &config.ctx,
+                            on_device,
+                        )
+                        .unwrap();
+                        assert_eq!(batch_ntt_result[..], *transposed_input.as_slice());
                         config.columns_batch = false;
                     }
                 }

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -63,6 +63,15 @@ pub trait VecOps<F> {
         result: &mut HostOrDeviceSlice<F>,
         cfg: &VecOpsConfig,
     ) -> IcicleResult<()>;
+
+    fn transpose(
+        input: &HostOrDeviceSlice<F>,
+        row_size:u32,
+        column_size:u32,
+        output: &mut HostOrDeviceSlice<F>,
+        ctx: &DeviceContext,
+        on_device: bool,
+    ) -> IcicleResult<()>;
 }
 
 fn check_vec_ops_args<F>(a: &HostOrDeviceSlice<F>, b: &HostOrDeviceSlice<F>, result: &mut HostOrDeviceSlice<F>) {
@@ -118,6 +127,21 @@ where
     <<F as FieldImpl>::Config as VecOps<F>>::mul(a, b, result, cfg)
 }
 
+pub fn transpose_matrix<F>(
+    input: &HostOrDeviceSlice<F>,
+    row_size:u32,
+    column_size:u32,
+    output: &mut HostOrDeviceSlice<F>,
+    ctx: &DeviceContext,
+    on_device: bool,
+) -> IcicleResult<()>
+where
+    F: FieldImpl,
+    <F as FieldImpl>::Config: VecOps<F>,
+{
+    <<F as FieldImpl>::Config as VecOps<F>>::transpose(input, row_size, column_size, output, ctx, on_device)
+}
+
 #[macro_export]
 macro_rules! impl_vec_ops_field {
     (
@@ -156,6 +180,16 @@ macro_rules! impl_vec_ops_field {
                     size: u32,
                     cfg: *const VecOpsConfig,
                     result: *mut $field,
+                ) -> CudaError;
+
+                #[link_name = concat!($field_prefix, "TransposeBatch")]
+                pub(crate) fn transpose_cuda(
+                    input: *const $field,
+                    row_size: u32,
+                    column_size: u32,
+                    output: *mut $field,
+                    ctx: *const DeviceContext,
+                    on_device: bool,
                 ) -> CudaError;
             }
         }
@@ -210,6 +244,27 @@ macro_rules! impl_vec_ops_field {
                         a.len() as u32,
                         cfg as *const _ as *const VecOpsConfig,
                         result.as_mut_ptr(),
+                    )
+                    .wrap()
+                }
+            }
+
+            fn transpose(
+                input: &HostOrDeviceSlice<$field>,
+                row_size:u32,
+                column_size:u32,
+                output: &mut HostOrDeviceSlice<$field>,
+                ctx: &DeviceContext,
+                on_device: bool,
+            ) -> IcicleResult<()> {
+                unsafe {
+                    $field_prefix_ident::transpose_cuda(
+                        input.as_ptr(),
+                        row_size,
+                        column_size,
+                        output.as_mut_ptr(),
+                        ctx as *const _ as *const DeviceContext,
+                        on_device,
                     )
                     .wrap()
                 }

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -66,8 +66,8 @@ pub trait VecOps<F> {
 
     fn transpose(
         input: &HostOrDeviceSlice<F>,
-        row_size:u32,
-        column_size:u32,
+        row_size: u32,
+        column_size: u32,
         output: &mut HostOrDeviceSlice<F>,
         ctx: &DeviceContext,
         on_device: bool,
@@ -129,8 +129,8 @@ where
 
 pub fn transpose_matrix<F>(
     input: &HostOrDeviceSlice<F>,
-    row_size:u32,
-    column_size:u32,
+    row_size: u32,
+    column_size: u32,
     output: &mut HostOrDeviceSlice<F>,
     ctx: &DeviceContext,
     on_device: bool,
@@ -251,8 +251,8 @@ macro_rules! impl_vec_ops_field {
 
             fn transpose(
                 input: &HostOrDeviceSlice<$field>,
-                row_size:u32,
-                column_size:u32,
+                row_size: u32,
+                column_size: u32,
                 output: &mut HostOrDeviceSlice<$field>,
                 ctx: &DeviceContext,
                 on_device: bool,

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -71,6 +71,7 @@ pub trait VecOps<F> {
         output: &mut HostOrDeviceSlice<F>,
         ctx: &DeviceContext,
         on_device: bool,
+        is_async: bool,
     ) -> IcicleResult<()>;
 }
 
@@ -134,12 +135,13 @@ pub fn transpose_matrix<F>(
     output: &mut HostOrDeviceSlice<F>,
     ctx: &DeviceContext,
     on_device: bool,
+    is_async: bool,
 ) -> IcicleResult<()>
 where
     F: FieldImpl,
     <F as FieldImpl>::Config: VecOps<F>,
 {
-    <<F as FieldImpl>::Config as VecOps<F>>::transpose(input, row_size, column_size, output, ctx, on_device)
+    <<F as FieldImpl>::Config as VecOps<F>>::transpose(input, row_size, column_size, output, ctx, on_device, is_async)
 }
 
 #[macro_export]
@@ -182,7 +184,7 @@ macro_rules! impl_vec_ops_field {
                     result: *mut $field,
                 ) -> CudaError;
 
-                #[link_name = concat!($field_prefix, "TransposeBatch")]
+                #[link_name = concat!($field_prefix, "TransposeMatrix")]
                 pub(crate) fn transpose_cuda(
                     input: *const $field,
                     row_size: u32,
@@ -190,6 +192,7 @@ macro_rules! impl_vec_ops_field {
                     output: *mut $field,
                     ctx: *const DeviceContext,
                     on_device: bool,
+                    is_async: bool,
                 ) -> CudaError;
             }
         }
@@ -256,6 +259,7 @@ macro_rules! impl_vec_ops_field {
                 output: &mut HostOrDeviceSlice<$field>,
                 ctx: &DeviceContext,
                 on_device: bool,
+                is_async: bool,
             ) -> IcicleResult<()> {
                 unsafe {
                     $field_prefix_ident::transpose_cuda(
@@ -265,6 +269,7 @@ macro_rules! impl_vec_ops_field {
                         output.as_mut_ptr(),
                         ctx as *const _ as *const DeviceContext,
                         on_device,
+                        is_async,
                     )
                     .wrap()
                 }


### PR DESCRIPTION
## Describe the changes

This PR adds an extern C link to the transpose kernel, now in vec_ops.cu.
Also Rust binding, and I updated the test check_ntt_batch to use the new transpose function.
The test passes.

## Linked Issues

Resolves #
