### PR TITLE
[FEAT]: golang device slice ranges

### DIFF
--- a/wrappers/golang/core/slice.go
+++ b/wrappers/golang/core/slice.go
@@ -59,6 +59,10 @@ func (d *DeviceSlice) Range(start, end int, endInclusive bool) DeviceSlice {
 		panic("Cannot have negative or zero size slices")
 	}
 
+	if end >= d.length {
+		panic("Cannot increase slice size from Range")
+	}
+
 	var newSlice DeviceSlice
 	switch {
 	case start < 0:

--- a/wrappers/golang/core/slice.go
+++ b/wrappers/golang/core/slice.go
@@ -54,6 +54,56 @@ func (d DeviceSlice) CheckDevice() {
 	}
 }
 
+func(d *DeviceSlice) SliceRange(start, end int, endInclusive bool) DeviceSlice {
+	if end >= start {
+		panic("Cannot have negative size slices")
+	}
+	var newSlice DeviceSlice
+	switch {
+	case start < 0:
+		panic("Negative value for start is not supported")
+	case start == 0:
+		newSlice = d.SliceTo(end, endInclusive)
+	case start > 0:
+		sizeOfElement := d.capacity/d.length
+		newSlice.inner = unsafe.Pointer(uintptr(d.inner) + uintptr(start)*uintptr(sizeOfElement))
+		newSlice.length = end-start
+		if endInclusive {
+			newSlice.length += 1
+		}
+		newSlice.capacity = newSlice.length*sizeOfElement
+	}
+	return newSlice
+}
+
+func(d *DeviceSlice) SliceTo(end int, inclusive bool) DeviceSlice {
+	if end <= 0 {
+		panic("Cannot have negative or zero size slices")
+	}
+	
+	var newSlice DeviceSlice
+	sizeOfElement := d.capacity/d.length
+	newSlice.length = end
+	if inclusive {
+		newSlice.length += 1
+	}
+	newSlice.capacity = newSlice.length*sizeOfElement
+	return newSlice
+}
+
+func(d *DeviceSlice) SliceFrom(start int) DeviceSlice {
+	var newSlice DeviceSlice
+	sizeOfElement := d.capacity/d.length
+
+	newSlice.inner = unsafe.Pointer(uintptr(d.inner) + uintptr(start)*uintptr(sizeOfElement))
+	newSlice.length = d.length - start
+	newSlice.capacity = d.capacity - start*sizeOfElement
+
+	return newSlice
+}
+
+// TODO: change signature to be Malloc(element, numElements)
+// calc size internally
 func (d *DeviceSlice) Malloc(size, sizeOfElement int) (DeviceSlice, cr.CudaError) {
 	dp, err := cr.Malloc(uint(size))
 	d.inner = dp

--- a/wrappers/golang/core/slice.go
+++ b/wrappers/golang/core/slice.go
@@ -54,11 +54,11 @@ func (d DeviceSlice) CheckDevice() {
 	}
 }
 
-func(d *DeviceSlice) Range(start, end int, endInclusive bool) DeviceSlice {
+func (d *DeviceSlice) Range(start, end int, endInclusive bool) DeviceSlice {
 	if end <= start {
 		panic("Cannot have negative or zero size slices")
 	}
-	
+
 	if end >= d.length {
 		panic("Cannot increase slice size from Range")
 	}
@@ -76,7 +76,7 @@ func(d *DeviceSlice) Range(start, end int, endInclusive bool) DeviceSlice {
 	return newSlice
 }
 
-func(d *DeviceSlice) RangeTo(end int, inclusive bool) DeviceSlice {
+func (d *DeviceSlice) RangeTo(end int, inclusive bool) DeviceSlice {
 	if end <= 0 {
 		panic("Cannot have negative or zero size slices")
 	}
@@ -84,25 +84,25 @@ func(d *DeviceSlice) RangeTo(end int, inclusive bool) DeviceSlice {
 	if end >= d.length {
 		panic("Cannot increase slice size from Range")
 	}
-	
+
 	var newSlice DeviceSlice
-	sizeOfElement := d.capacity/d.length
+	sizeOfElement := d.capacity / d.length
 	newSlice.length = end
 	if inclusive {
 		newSlice.length += 1
 	}
-	newSlice.capacity = newSlice.length*sizeOfElement
+	newSlice.capacity = newSlice.length * sizeOfElement
 	newSlice.inner = d.inner
 	return newSlice
 }
 
-func(d *DeviceSlice) RangeFrom(start int) DeviceSlice {
+func (d *DeviceSlice) RangeFrom(start int) DeviceSlice {
 	if start >= d.length {
 		panic("Cannot have negative or zero size slices")
 	}
-	
+
 	var newSlice DeviceSlice
-	sizeOfElement := d.capacity/d.length
+	sizeOfElement := d.capacity / d.length
 
 	newSlice.inner = unsafe.Pointer(uintptr(d.inner) + uintptr(start)*uintptr(sizeOfElement))
 	newSlice.length = d.length - start

--- a/wrappers/golang/core/slice.go
+++ b/wrappers/golang/core/slice.go
@@ -59,10 +59,6 @@ func (d *DeviceSlice) Range(start, end int, endInclusive bool) DeviceSlice {
 		panic("Cannot have negative or zero size slices")
 	}
 
-	if end >= d.length {
-		panic("Cannot increase slice size from Range")
-	}
-
 	var newSlice DeviceSlice
 	switch {
 	case start < 0:
@@ -99,6 +95,10 @@ func (d *DeviceSlice) RangeTo(end int, inclusive bool) DeviceSlice {
 func (d *DeviceSlice) RangeFrom(start int) DeviceSlice {
 	if start >= d.length {
 		panic("Cannot have negative or zero size slices")
+	}
+
+	if start < 0 {
+		panic("Negative value for start is not supported")
 	}
 
 	var newSlice DeviceSlice

--- a/wrappers/golang/core/slice_test.go
+++ b/wrappers/golang/core/slice_test.go
@@ -215,7 +215,7 @@ func TestSliceRanges(t *testing.T) {
 	deviceSliceRangeTo := deviceSlice.RangeTo(numPoints-3, true)
 	hostSliceRet.CopyFromDevice(&deviceSliceRangeTo)
 	assert.Equal(t, hostSlice[:6], hostSliceRet)
-	
+
 	// Range
 	hostSliceRange := HostSliceWithValue[internal.MockProjective](zeroProj, numPoints-4)
 	deviceSliceRange := deviceSlice.Range(2, numPoints-3, true)

--- a/wrappers/golang/core/slice_test.go
+++ b/wrappers/golang/core/slice_test.go
@@ -81,6 +81,10 @@ func TestHostSlice(t *testing.T) {
 	hostSlice := HostSliceFromElements(randFields)
 	assert.Equal(t, hostSlice.Len(), 4)
 	assert.Equal(t, hostSlice.Cap(), 4)
+
+	hostSliceCasted := (HostSlice[internal.MockField])(randFields)
+	assert.Equal(t, hostSliceCasted.Len(), 4)
+	assert.Equal(t, hostSliceCasted.Cap(), 4)
 }
 
 func TestHostSliceIsEmpty(t *testing.T) {
@@ -189,4 +193,32 @@ func TestCopyToFromHostDeviceProjectivePoints(t *testing.T) {
 	hostSlice2.CopyFromDevice(&emptyDeviceSlice)
 
 	assert.Equal(t, hostSlice, hostSlice2)
+}
+
+func TestSliceRanges(t *testing.T) {
+	var deviceSlice DeviceSlice
+
+	numPoints := 1 << 3
+	randProjectives := randomProjectivePoints(numPoints, fieldSize)
+	hostSlice := (HostSlice[internal.MockProjective])(randProjectives)
+	hostSlice.CopyToDevice(&deviceSlice, true)
+
+	// RangeFrom
+	var zeroProj internal.MockProjective
+	hostSliceRet := HostSliceWithValue[internal.MockProjective](zeroProj, numPoints-2)
+
+	deviceSliceRangeFrom := deviceSlice.RangeFrom(2)
+	hostSliceRet.CopyFromDevice(&deviceSliceRangeFrom)
+	assert.Equal(t, hostSlice[2:], hostSliceRet)
+
+	// RangeTo
+	deviceSliceRangeTo := deviceSlice.RangeTo(numPoints-3, true)
+	hostSliceRet.CopyFromDevice(&deviceSliceRangeTo)
+	assert.Equal(t, hostSlice[:6], hostSliceRet)
+	
+	// Range
+	hostSliceRange := HostSliceWithValue[internal.MockProjective](zeroProj, numPoints-4)
+	deviceSliceRange := deviceSlice.Range(2, numPoints-3, true)
+	hostSliceRange.CopyFromDevice(&deviceSliceRange)
+	assert.Equal(t, hostSlice[2:6], hostSliceRange)
 }


### PR DESCRIPTION
## Describe the changes

This PR adds the capability to slice a DeviceSlice, allowing portions of data that are already on the device to be reused.

Additionally, this PR removes the need for a HostSlice underlying type to implement a Size function and uses unsafe.Sizeof instead. This together with #407 will allow direct usage of gnark-crypto types with HostSlice without the need for converting to ICICLE types
