### PR TITLE
Feat/vlad/transpose go binding

### DIFF
--- a/wrappers/golang/core/vec_ops.go
+++ b/wrappers/golang/core/vec_ops.go
@@ -72,3 +72,29 @@ func VecOpCheck(a, b, out HostOrDeviceSlice, cfg *VecOpsConfig) {
 	cfg.isBOnDevice = b.IsOnDevice()
 	cfg.isResultOnDevice = out.IsOnDevice()
 }
+
+func TransposeCheck(in, out HostOrDeviceSlice, onDevice bool) {
+	inLen, outLen := in.Len(), out.Len()
+
+	if inLen != outLen {
+		errorString := fmt.Sprintf(
+			"in and out vector lengths %d; %d are not equal",
+			inLen,
+			outLen,
+		)
+		panic(errorString)
+	}
+	if (onDevice != in.IsOnDevice()) || (onDevice != out.IsOnDevice()) {
+		errorString := fmt.Sprintf(
+			"onDevice is set to %t, but in.IsOnDevice():%t and out.IsOnDevice():%t",
+			onDevice,
+			in.IsOnDevice(),
+			out.IsOnDevice(),
+		)
+		panic(errorString)
+	}
+	if onDevice {
+		in.(DeviceSlice).CheckDevice()
+		out.(DeviceSlice).CheckDevice()
+	}
+}

--- a/wrappers/golang/curves/bls12377/include/vec_ops.h
+++ b/wrappers/golang/curves/bls12377/include/vec_ops.h
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include "../../include/types.h"
+#include <stdbool.h>
 
 #ifndef _BLS12_377_VEC_OPS_H
 #define _BLS12_377_VEC_OPS_H
@@ -30,6 +31,16 @@ cudaError_t bls12_377SubCuda(
   int n,
   VecOpsConfig* config,
   scalar_t* result
+);
+
+cudaError_t bls12_377TransposeMatrix(
+  scalar_t* mat_in,
+  int row_size,
+  int column_size,
+  scalar_t* mat_out,
+  DeviceContext* ctx,
+  bool on_device,
+  bool is_async
 );
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bls12377/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vec_ops.go
@@ -55,7 +55,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-
+	core.TransposeCheck(in, out, onDevice)
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
 		inPointer = in.(core.DeviceSlice).AsPointer()

--- a/wrappers/golang/curves/bls12377/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vec_ops.go
@@ -53,3 +53,26 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 
 	return ret
 }
+
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+
+	var inPointer, outPointer unsafe.Pointer
+	if onDevice {
+		inPointer = in.(core.DeviceSlice).AsPointer()
+		outPointer = out.(core.DeviceSlice).AsPointer()
+	} else {
+		inPointer = unsafe.Pointer(&in.(core.HostSlice[ScalarField])[0])
+		outPointer = unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0])
+	}
+	cIn := (*C.scalar_t)(inPointer)
+	cOut := (*C.scalar_t)(outPointer)
+
+	cCtx := (*C.DeviceContext)(unsafe.Pointer(&ctx))
+	cRowSize := (C.int)(rowSize)
+	cColumnSize := (C.int)(columnSize)
+	cOnDevice := (C._Bool)(onDevice)
+	cIsAsync := (C._Bool)(isAsync)
+
+	err := (cr.CudaError)(C.bls12_377TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	return core.FromCudaError(err)
+} 

--- a/wrappers/golang/curves/bls12377/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vec_ops.go
@@ -54,7 +54,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	return ret
 }
 
-func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
 
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
@@ -73,6 +73,6 @@ func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ct
 	cOnDevice := (C._Bool)(onDevice)
 	cIsAsync := (C._Bool)(isAsync)
 
-	err := (cr.CudaError)(C.bls12_377TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	err := (cr.CudaError)(C.bls12_377TransposeMatrix(cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
 	return core.FromCudaError(err)
-} 
+}

--- a/wrappers/golang/curves/bls12377/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12377/vec_ops_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	"github.com/stretchr/testify/assert"
+	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func TestVecOps(t *testing.T) {
@@ -29,5 +30,40 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, a, out3)
+	assert.Equal(t, ones, out3)
+}
+
+
+func TestTranspose(t *testing.T) {
+
+	rowSize := 1 << 6
+	columnSize := 1 << 8
+	onDevice := false
+	isAsync := true
+
+	matrix := GenerateScalars(rowSize * columnSize)
+
+	out := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
+
+	ctx, _ := cr.GetDefaultDeviceContext()
+
+	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	
+	assert.Equal(t, matrix, out2)
+
+	var d_matrix, d_out, d_out2 core.DeviceSlice
+	onDevice = true
+
+	matrix.CopyToDeviceAsync(&d_matrix, *ctx.Stream, true)
+	d_out.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+	d_out2.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+
+	TransposeMatrix(d_matrix, d_out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(d_out, d_out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	output := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	output.CopyFromDeviceAsync(&d_out2, *ctx.Stream)
+
+	assert.Equal(t, matrix, output)
 }

--- a/wrappers/golang/curves/bls12377/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12377/vec_ops_test.go
@@ -30,7 +30,7 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, ones, out3)
+	assert.Equal(t, a, out3)
 }
 
 

--- a/wrappers/golang/curves/bls12377/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12377/vec_ops_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
-	"github.com/stretchr/testify/assert"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVecOps(t *testing.T) {
@@ -33,7 +33,6 @@ func TestVecOps(t *testing.T) {
 	assert.Equal(t, a, out3)
 }
 
-
 func TestTranspose(t *testing.T) {
 
 	rowSize := 1 << 6
@@ -50,7 +49,7 @@ func TestTranspose(t *testing.T) {
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
-	
+
 	assert.Equal(t, matrix, out2)
 
 	var d_matrix, d_out, d_out2 core.DeviceSlice

--- a/wrappers/golang/curves/bls12377/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12377/vec_ops_test.go
@@ -38,7 +38,7 @@ func TestTranspose(t *testing.T) {
 	rowSize := 1 << 6
 	columnSize := 1 << 8
 	onDevice := false
-	isAsync := true
+	isAsync := false
 
 	matrix := GenerateScalars(rowSize * columnSize)
 
@@ -46,6 +46,8 @@ func TestTranspose(t *testing.T) {
 	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
 
 	ctx, _ := cr.GetDefaultDeviceContext()
+	stream, _ := cr.CreateStream()
+	ctx.Stream = &stream
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bls12381/include/vec_ops.h
+++ b/wrappers/golang/curves/bls12381/include/vec_ops.h
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include "../../include/types.h"
+#include <stdbool.h>
 
 #ifndef _BLS12_381_VEC_OPS_H
 #define _BLS12_381_VEC_OPS_H
@@ -30,6 +31,16 @@ cudaError_t bls12_381SubCuda(
   int n,
   VecOpsConfig* config,
   scalar_t* result
+);
+
+cudaError_t bls12_381TransposeMatrix(
+  scalar_t* mat_in,
+  int row_size,
+  int column_size,
+  scalar_t* mat_out,
+  DeviceContext* ctx,
+  bool on_device,
+  bool is_async
 );
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bls12381/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vec_ops.go
@@ -55,7 +55,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-
+	core.TransposeCheck(in, out, onDevice)
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
 		inPointer = in.(core.DeviceSlice).AsPointer()

--- a/wrappers/golang/curves/bls12381/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vec_ops.go
@@ -54,7 +54,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	return ret
 }
 
-func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
 
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
@@ -73,6 +73,6 @@ func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ct
 	cOnDevice := (C._Bool)(onDevice)
 	cIsAsync := (C._Bool)(isAsync)
 
-	err := (cr.CudaError)(C.bls12_381TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	err := (cr.CudaError)(C.bls12_381TransposeMatrix(cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
 	return core.FromCudaError(err)
-} 
+}

--- a/wrappers/golang/curves/bls12381/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vec_ops.go
@@ -53,3 +53,26 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 
 	return ret
 }
+
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+
+	var inPointer, outPointer unsafe.Pointer
+	if onDevice {
+		inPointer = in.(core.DeviceSlice).AsPointer()
+		outPointer = out.(core.DeviceSlice).AsPointer()
+	} else {
+		inPointer = unsafe.Pointer(&in.(core.HostSlice[ScalarField])[0])
+		outPointer = unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0])
+	}
+	cIn := (*C.scalar_t)(inPointer)
+	cOut := (*C.scalar_t)(outPointer)
+
+	cCtx := (*C.DeviceContext)(unsafe.Pointer(&ctx))
+	cRowSize := (C.int)(rowSize)
+	cColumnSize := (C.int)(columnSize)
+	cOnDevice := (C._Bool)(onDevice)
+	cIsAsync := (C._Bool)(isAsync)
+
+	err := (cr.CudaError)(C.bls12_381TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	return core.FromCudaError(err)
+} 

--- a/wrappers/golang/curves/bls12381/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12381/vec_ops_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	"github.com/stretchr/testify/assert"
+	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func TestVecOps(t *testing.T) {
@@ -29,5 +30,40 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, a, out3)
+	assert.Equal(t, ones, out3)
+}
+
+
+func TestTranspose(t *testing.T) {
+
+	rowSize := 1 << 6
+	columnSize := 1 << 8
+	onDevice := false
+	isAsync := true
+
+	matrix := GenerateScalars(rowSize * columnSize)
+
+	out := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
+
+	ctx, _ := cr.GetDefaultDeviceContext()
+
+	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	
+	assert.Equal(t, matrix, out2)
+
+	var d_matrix, d_out, d_out2 core.DeviceSlice
+	onDevice = true
+
+	matrix.CopyToDeviceAsync(&d_matrix, *ctx.Stream, true)
+	d_out.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+	d_out2.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+
+	TransposeMatrix(d_matrix, d_out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(d_out, d_out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	output := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	output.CopyFromDeviceAsync(&d_out2, *ctx.Stream)
+
+	assert.Equal(t, matrix, output)
 }

--- a/wrappers/golang/curves/bls12381/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12381/vec_ops_test.go
@@ -30,7 +30,7 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, ones, out3)
+	assert.Equal(t, a, out3)
 }
 
 

--- a/wrappers/golang/curves/bls12381/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12381/vec_ops_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
-	"github.com/stretchr/testify/assert"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVecOps(t *testing.T) {
@@ -33,7 +33,6 @@ func TestVecOps(t *testing.T) {
 	assert.Equal(t, a, out3)
 }
 
-
 func TestTranspose(t *testing.T) {
 
 	rowSize := 1 << 6
@@ -50,7 +49,7 @@ func TestTranspose(t *testing.T) {
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
-	
+
 	assert.Equal(t, matrix, out2)
 
 	var d_matrix, d_out, d_out2 core.DeviceSlice

--- a/wrappers/golang/curves/bls12381/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12381/vec_ops_test.go
@@ -38,7 +38,7 @@ func TestTranspose(t *testing.T) {
 	rowSize := 1 << 6
 	columnSize := 1 << 8
 	onDevice := false
-	isAsync := true
+	isAsync := false
 
 	matrix := GenerateScalars(rowSize * columnSize)
 
@@ -46,6 +46,8 @@ func TestTranspose(t *testing.T) {
 	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
 
 	ctx, _ := cr.GetDefaultDeviceContext()
+	stream, _ := cr.CreateStream()
+	ctx.Stream = &stream
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bn254/include/vec_ops.h
+++ b/wrappers/golang/curves/bn254/include/vec_ops.h
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include "../../include/types.h"
+#include <stdbool.h>
 
 #ifndef _BN254_VEC_OPS_H
 #define _BN254_VEC_OPS_H
@@ -30,6 +31,16 @@ cudaError_t bn254SubCuda(
   int n,
   VecOpsConfig* config,
   scalar_t* result
+);
+
+cudaError_t bn254TransposeMatrix(
+  scalar_t* mat_in,
+  int row_size,
+  int column_size,
+  scalar_t* mat_out,
+  DeviceContext* ctx,
+  bool on_device,
+  bool is_async
 );
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bn254/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vec_ops.go
@@ -55,7 +55,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-
+	core.TransposeCheck(in, out, onDevice)
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
 		inPointer = in.(core.DeviceSlice).AsPointer()

--- a/wrappers/golang/curves/bn254/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vec_ops.go
@@ -53,3 +53,26 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 
 	return ret
 }
+
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+
+	var inPointer, outPointer unsafe.Pointer
+	if onDevice {
+		inPointer = in.(core.DeviceSlice).AsPointer()
+		outPointer = out.(core.DeviceSlice).AsPointer()
+	} else {
+		inPointer = unsafe.Pointer(&in.(core.HostSlice[ScalarField])[0])
+		outPointer = unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0])
+	}
+	cIn := (*C.scalar_t)(inPointer)
+	cOut := (*C.scalar_t)(outPointer)
+
+	cCtx := (*C.DeviceContext)(unsafe.Pointer(&ctx))
+	cRowSize := (C.int)(rowSize)
+	cColumnSize := (C.int)(columnSize)
+	cOnDevice := (C._Bool)(onDevice)
+	cIsAsync := (C._Bool)(isAsync)
+
+	err := (cr.CudaError)(C.bn254TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	return core.FromCudaError(err)
+} 

--- a/wrappers/golang/curves/bn254/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vec_ops.go
@@ -54,7 +54,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	return ret
 }
 
-func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
 
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
@@ -73,6 +73,6 @@ func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ct
 	cOnDevice := (C._Bool)(onDevice)
 	cIsAsync := (C._Bool)(isAsync)
 
-	err := (cr.CudaError)(C.bn254TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	err := (cr.CudaError)(C.bn254TransposeMatrix(cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
 	return core.FromCudaError(err)
-} 
+}

--- a/wrappers/golang/curves/bn254/vec_ops_test.go
+++ b/wrappers/golang/curves/bn254/vec_ops_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	"github.com/stretchr/testify/assert"
+	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func TestVecOps(t *testing.T) {
@@ -29,5 +30,40 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, a, out3)
+	assert.Equal(t, ones, out3)
+}
+
+
+func TestTranspose(t *testing.T) {
+
+	rowSize := 1 << 6
+	columnSize := 1 << 8
+	onDevice := false
+	isAsync := true
+
+	matrix := GenerateScalars(rowSize * columnSize)
+
+	out := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
+
+	ctx, _ := cr.GetDefaultDeviceContext()
+
+	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	
+	assert.Equal(t, matrix, out2)
+
+	var d_matrix, d_out, d_out2 core.DeviceSlice
+	onDevice = true
+
+	matrix.CopyToDeviceAsync(&d_matrix, *ctx.Stream, true)
+	d_out.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+	d_out2.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+
+	TransposeMatrix(d_matrix, d_out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(d_out, d_out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	output := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	output.CopyFromDeviceAsync(&d_out2, *ctx.Stream)
+
+	assert.Equal(t, matrix, output)
 }

--- a/wrappers/golang/curves/bn254/vec_ops_test.go
+++ b/wrappers/golang/curves/bn254/vec_ops_test.go
@@ -30,7 +30,7 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, ones, out3)
+	assert.Equal(t, a, out3)
 }
 
 

--- a/wrappers/golang/curves/bn254/vec_ops_test.go
+++ b/wrappers/golang/curves/bn254/vec_ops_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
-	"github.com/stretchr/testify/assert"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVecOps(t *testing.T) {
@@ -33,7 +33,6 @@ func TestVecOps(t *testing.T) {
 	assert.Equal(t, a, out3)
 }
 
-
 func TestTranspose(t *testing.T) {
 
 	rowSize := 1 << 6
@@ -50,7 +49,7 @@ func TestTranspose(t *testing.T) {
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
-	
+
 	assert.Equal(t, matrix, out2)
 
 	var d_matrix, d_out, d_out2 core.DeviceSlice

--- a/wrappers/golang/curves/bn254/vec_ops_test.go
+++ b/wrappers/golang/curves/bn254/vec_ops_test.go
@@ -38,7 +38,7 @@ func TestTranspose(t *testing.T) {
 	rowSize := 1 << 6
 	columnSize := 1 << 8
 	onDevice := false
-	isAsync := true
+	isAsync := false
 
 	matrix := GenerateScalars(rowSize * columnSize)
 
@@ -46,6 +46,8 @@ func TestTranspose(t *testing.T) {
 	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
 
 	ctx, _ := cr.GetDefaultDeviceContext()
+	stream, _ := cr.CreateStream()
+	ctx.Stream = &stream
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bw6761/include/vec_ops.h
+++ b/wrappers/golang/curves/bw6761/include/vec_ops.h
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include "../../include/types.h"
+#include <stdbool.h>
 
 #ifndef _BW6_761_VEC_OPS_H
 #define _BW6_761_VEC_OPS_H
@@ -30,6 +31,16 @@ cudaError_t bw6_761SubCuda(
   int n,
   VecOpsConfig* config,
   scalar_t* result
+);
+
+cudaError_t bw6_761TransposeMatrix(
+  scalar_t* mat_in,
+  int row_size,
+  int column_size,
+  scalar_t* mat_out,
+  DeviceContext* ctx,
+  bool on_device,
+  bool is_async
 );
 
 #ifdef __cplusplus

--- a/wrappers/golang/curves/bw6761/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vec_ops.go
@@ -55,7 +55,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-
+	core.TransposeCheck(in, out, onDevice)
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
 		inPointer = in.(core.DeviceSlice).AsPointer()

--- a/wrappers/golang/curves/bw6761/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vec_ops.go
@@ -54,7 +54,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 	return ret
 }
 
-func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
 
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
@@ -73,6 +73,6 @@ func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ct
 	cOnDevice := (C._Bool)(onDevice)
 	cIsAsync := (C._Bool)(isAsync)
 
-	err := (cr.CudaError)(C.bw6_761TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	err := (cr.CudaError)(C.bw6_761TransposeMatrix(cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
 	return core.FromCudaError(err)
-} 
+}

--- a/wrappers/golang/curves/bw6761/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vec_ops.go
@@ -53,3 +53,26 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 
 	return ret
 }
+
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+
+	var inPointer, outPointer unsafe.Pointer
+	if onDevice {
+		inPointer = in.(core.DeviceSlice).AsPointer()
+		outPointer = out.(core.DeviceSlice).AsPointer()
+	} else {
+		inPointer = unsafe.Pointer(&in.(core.HostSlice[ScalarField])[0])
+		outPointer = unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0])
+	}
+	cIn := (*C.scalar_t)(inPointer)
+	cOut := (*C.scalar_t)(outPointer)
+
+	cCtx := (*C.DeviceContext)(unsafe.Pointer(&ctx))
+	cRowSize := (C.int)(rowSize)
+	cColumnSize := (C.int)(columnSize)
+	cOnDevice := (C._Bool)(onDevice)
+	cIsAsync := (C._Bool)(isAsync)
+
+	err := (cr.CudaError)(C.bw6_761TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	return core.FromCudaError(err)
+} 

--- a/wrappers/golang/curves/bw6761/vec_ops_test.go
+++ b/wrappers/golang/curves/bw6761/vec_ops_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	"github.com/stretchr/testify/assert"
+	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func TestVecOps(t *testing.T) {
@@ -29,5 +30,40 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, a, out3)
+	assert.Equal(t, ones, out3)
+}
+
+
+func TestTranspose(t *testing.T) {
+
+	rowSize := 1 << 6
+	columnSize := 1 << 8
+	onDevice := false
+	isAsync := true
+
+	matrix := GenerateScalars(rowSize * columnSize)
+
+	out := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
+
+	ctx, _ := cr.GetDefaultDeviceContext()
+
+	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	
+	assert.Equal(t, matrix, out2)
+
+	var d_matrix, d_out, d_out2 core.DeviceSlice
+	onDevice = true
+
+	matrix.CopyToDeviceAsync(&d_matrix, *ctx.Stream, true)
+	d_out.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+	d_out2.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+
+	TransposeMatrix(d_matrix, d_out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(d_out, d_out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	output := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	output.CopyFromDeviceAsync(&d_out2, *ctx.Stream)
+
+	assert.Equal(t, matrix, output)
 }

--- a/wrappers/golang/curves/bw6761/vec_ops_test.go
+++ b/wrappers/golang/curves/bw6761/vec_ops_test.go
@@ -30,7 +30,7 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, ones, out3)
+	assert.Equal(t, a, out3)
 }
 
 

--- a/wrappers/golang/curves/bw6761/vec_ops_test.go
+++ b/wrappers/golang/curves/bw6761/vec_ops_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
-	"github.com/stretchr/testify/assert"
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVecOps(t *testing.T) {
@@ -33,7 +33,6 @@ func TestVecOps(t *testing.T) {
 	assert.Equal(t, a, out3)
 }
 
-
 func TestTranspose(t *testing.T) {
 
 	rowSize := 1 << 6
@@ -50,7 +49,7 @@ func TestTranspose(t *testing.T) {
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
-	
+
 	assert.Equal(t, matrix, out2)
 
 	var d_matrix, d_out, d_out2 core.DeviceSlice

--- a/wrappers/golang/curves/bw6761/vec_ops_test.go
+++ b/wrappers/golang/curves/bw6761/vec_ops_test.go
@@ -38,7 +38,7 @@ func TestTranspose(t *testing.T) {
 	rowSize := 1 << 6
 	columnSize := 1 << 8
 	onDevice := false
-	isAsync := true
+	isAsync := false
 
 	matrix := GenerateScalars(rowSize * columnSize)
 
@@ -46,6 +46,8 @@ func TestTranspose(t *testing.T) {
 	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
 
 	ctx, _ := cr.GetDefaultDeviceContext()
+	stream, _ := cr.CreateStream()
+	ctx.Stream = &stream
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/internal/generator/templates/include/vec_ops.h.tmpl
+++ b/wrappers/golang/internal/generator/templates/include/vec_ops.h.tmpl
@@ -1,5 +1,6 @@
 #include <cuda_runtime.h>
 #include "../../include/types.h"
+#include <stdbool.h>
 
 #ifndef _{{toUpper .Curve}}_VEC_OPS_H
 #define _{{toUpper .Curve}}_VEC_OPS_H
@@ -30,6 +31,16 @@ cudaError_t {{.Curve}}SubCuda(
   int n,
   VecOpsConfig* config,
   scalar_t* result
+);
+
+cudaError_t {{.Curve}}TransposeMatrix(
+  scalar_t* mat_in,
+  int row_size,
+  int column_size,
+  scalar_t* mat_out,
+  DeviceContext* ctx,
+  bool on_device,
+  bool is_async
 );
 
 #ifdef __cplusplus

--- a/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
@@ -55,7 +55,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
-
+	core.TransposeCheck(in, out, onDevice)
 	var inPointer, outPointer unsafe.Pointer
 	if onDevice {
 		inPointer = in.(core.DeviceSlice).AsPointer()

--- a/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops.go.tmpl
@@ -53,3 +53,26 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 
 	return ret
 }
+
+func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+
+	var inPointer, outPointer unsafe.Pointer
+	if onDevice {
+		inPointer = in.(core.DeviceSlice).AsPointer()
+		outPointer = out.(core.DeviceSlice).AsPointer()
+	} else {
+		inPointer = unsafe.Pointer(&in.(core.HostSlice[ScalarField])[0])
+		outPointer = unsafe.Pointer(&out.(core.HostSlice[ScalarField])[0])
+	}
+	cIn := (*C.scalar_t)(inPointer)
+	cOut := (*C.scalar_t)(outPointer)
+
+	cCtx := (*C.DeviceContext)(unsafe.Pointer(&ctx))
+	cRowSize := (C.int)(rowSize)
+	cColumnSize := (C.int)(columnSize)
+	cOnDevice := (C._Bool)(onDevice)
+	cIsAsync := (C._Bool)(isAsync)
+
+	err := (cr.CudaError)(C.{{.Curve}}TransposeMatrix( cIn, cRowSize, cColumnSize, cOut, cCtx, cOnDevice, cIsAsync))
+	return core.FromCudaError(err)
+} 

--- a/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ingonyama-zk/icicle/wrappers/golang/core"
 	"github.com/stretchr/testify/assert"
+	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 )
 
 func TestVecOps(t *testing.T) {
@@ -29,5 +30,40 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, a, out3)
+	assert.Equal(t, ones, out3)
+}
+
+
+func TestTranspose(t *testing.T) {
+
+	rowSize := 1 << 6
+	columnSize := 1 << 8
+	onDevice := false
+	isAsync := true
+
+	matrix := GenerateScalars(rowSize * columnSize)
+
+	out := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
+
+	ctx, _ := cr.GetDefaultDeviceContext()
+
+	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	
+	assert.Equal(t, matrix, out2)
+
+	var d_matrix, d_out, d_out2 core.DeviceSlice
+	onDevice = true
+
+	matrix.CopyToDeviceAsync(&d_matrix, *ctx.Stream, true)
+	d_out.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+	d_out2.MallocAsync(columnSize*rowSize*matrix.SizeOfElement(), matrix.SizeOfElement(), *ctx.Stream)
+
+	TransposeMatrix(d_matrix, d_out, columnSize, rowSize, ctx, onDevice, isAsync)
+	TransposeMatrix(d_out, d_out2, rowSize, columnSize, ctx, onDevice, isAsync)
+	output := make(core.HostSlice[ScalarField], rowSize*columnSize)
+	output.CopyFromDeviceAsync(&d_out2, *ctx.Stream)
+
+	assert.Equal(t, matrix, output)
 }

--- a/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
@@ -30,7 +30,7 @@ func TestVecOps(t *testing.T) {
 
 	VecOp(a, ones, out3, cfg, core.Mul)
 
-	assert.Equal(t, ones, out3)
+	assert.Equal(t, a, out3)
 }
 
 

--- a/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
@@ -47,6 +47,8 @@ func TestTranspose(t *testing.T) {
 	out2 := make(core.HostSlice[ScalarField], rowSize*columnSize)
 
 	ctx, _ := cr.GetDefaultDeviceContext()
+	stream, _ := cr.CreateStream()
+	ctx.Stream = &stream
 
 	TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
+++ b/wrappers/golang/internal/generator/templates/vec_ops_test.go.tmpl
@@ -39,7 +39,7 @@ func TestTranspose(t *testing.T) {
 	rowSize := 1 << 6
 	columnSize := 1 << 8
 	onDevice := false
-	isAsync := true
+	isAsync := false
 
 	matrix := GenerateScalars(rowSize * columnSize)
 

--- a/wrappers/rust/Cargo.toml
+++ b/wrappers/rust/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.9.1"
+version = "1.10.0"
 edition = "2021"
 authors = [ "Ingonyama" ]
 homepage = "https://www.ingonyama.com"


### PR DESCRIPTION
## Describe the changes

This PR adds a golang binding for the transpose matrix kernel in vec_ops.go.
There is also a test for it in vec_ops_test

## Linked Issues

Resolves #
