### PR TITLE
Fix golang vec ops config

### DIFF
--- a/docs/docs/icicle/golang-bindings/vec-ops.md
+++ b/docs/docs/icicle/golang-bindings/vec-ops.md
@@ -109,7 +109,6 @@ type VecOpsConfig struct {
     isAOnDevice bool
     isBOnDevice bool
     isResultOnDevice bool
-    IsResultMontgomeryForm bool
     IsAsync bool
 }
 ```
@@ -120,7 +119,6 @@ type VecOpsConfig struct {
 - **isAOnDevice**: Indicates if vector `a` is located on the device.
 - **isBOnDevice**: Indicates if vector `b` is located on the device.
 - **isResultOnDevice**: Specifies where the result vector should be stored (device or host memory).
-- **IsResultMontgomeryForm**: Determines if the result vector should be in Montgomery form.
 - **IsAsync**: Controls whether the vector operation runs asynchronously.
 
 ### Default Configuration

--- a/docs/docs/icicle/rust-bindings/vec-ops.md
+++ b/docs/docs/icicle/rust-bindings/vec-ops.md
@@ -74,7 +74,6 @@ pub struct VecOpsConfig<'a> {
     is_a_on_device: bool,
     is_b_on_device: bool,
     is_result_on_device: bool,
-    is_result_montgomery_form: bool,
     pub is_async: bool,
 }
 ```
@@ -85,7 +84,6 @@ pub struct VecOpsConfig<'a> {
 - **`is_a_on_device`**: Indicates if the first operand vector resides in device memory.
 - **`is_b_on_device`**: Indicates if the second operand vector resides in device memory.
 - **`is_result_on_device`**: Specifies if the result vector should be stored in device memory.
-- **`is_result_montgomery_form`**: Determines if the result should be in Montgomery form.
 - **`is_async`**: Enables asynchronous operation. If `true`, operations are non-blocking; otherwise, they block the current thread.
 
 ### Default Configuration
@@ -112,7 +110,6 @@ impl<'a> VecOpsConfig<'a> {
             is_a_on_device: false,
             is_b_on_device: false,
             is_result_on_device: false,
-            is_result_montgomery_form: false,
             is_async: false,
         }
     }

--- a/wrappers/golang/core/vec_ops.go
+++ b/wrappers/golang/core/vec_ops.go
@@ -23,8 +23,6 @@ type VecOpsConfig struct {
 	isBOnDevice bool
 	/* If true, output is preserved on device, otherwise on host. Default value: false. */
 	isResultOnDevice bool
-	/* True if `result` vector should be in Montgomery form and false otherwise. Default value: false. */
-	IsResultMontgomeryForm bool
 	/* Whether to run the vector operations asynchronously. If set to `true`, the function will be
 	*  non-blocking and you'll need to synchronize it explicitly by calling
 	*  `SynchronizeStream`. If set to false, the function will block the current CPU thread. */
@@ -42,7 +40,6 @@ func DefaultVecOpsConfig() VecOpsConfig {
 		false, // isAOnDevice
 		false, // isBOnDevice
 		false, // isResultOnDevice
-		false, // IsResultMontgomeryForm
 		false, // IsAsync
 	}
 

--- a/wrappers/golang/core/vec_ops_test.go
+++ b/wrappers/golang/core/vec_ops_test.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"testing"
+
 	cr "github.com/ingonyama-zk/icicle/wrappers/golang/cuda_runtime"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestVecOpsDefaultConfig(t *testing.T) {
@@ -13,7 +14,6 @@ func TestVecOpsDefaultConfig(t *testing.T) {
 		false, // isAOnDevice
 		false, // isBOnDevice
 		false, // isResultOnDevice
-		false, // IsResultMontgomeryForm
 		false, // IsAsync
 	}
 


### PR DESCRIPTION
At some point we deleted Montgomery flag from vector ops config in C++ code and Rust bindings, but it stayed in golang bindings. This is fixed by this PR. Probably best to merge before releasing V2 as this is strictly speaking a breaking change.