### PR TITLE
Plonky3 babybear consistency

### DIFF
--- a/icicle/include/fields/stark_fields/babybear.cuh
+++ b/icicle/include/fields/stark_fields/babybear.cuh
@@ -47,8 +47,7 @@ namespace babybear {
     // nonresidue to generate the extension field
     static constexpr uint32_t nonresidue = 11;
     // true if nonresidue is negative.
-    // TODO: we're very confused by plonky3 and risc0 having different nonresidues: 11 and -11 respectively
-    static constexpr bool nonresidue_is_negative = true;
+    static constexpr bool nonresidue_is_negative = false;
   };
 
   /**

--- a/wrappers/rust/icicle-fields/icicle-babybear/Cargo.toml
+++ b/wrappers/rust/icicle-fields/icicle-babybear/Cargo.toml
@@ -17,7 +17,11 @@ cmake = "0.1.50"
 [dev-dependencies]
 risc0-core = "0.21.0"
 risc0-zkp = "0.21.0"
-#icicle-core = { path = "../../icicle-core", features = ["arkworks"] }
+p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3", rev = "83590121c8c28011cffa7e73cb71cf9bf94b8477" }
+p3-field = { git = "https://github.com/Plonky3/Plonky3", rev = "83590121c8c28011cffa7e73cb71cf9bf94b8477" }
+p3-dft = { git = "https://github.com/Plonky3/Plonky3", rev = "83590121c8c28011cffa7e73cb71cf9bf94b8477" }
+p3-matrix = { git = "https://github.com/Plonky3/Plonky3", rev = "83590121c8c28011cffa7e73cb71cf9bf94b8477" }
+serial_test = "3.0.0"
 
 [features]
 default = []

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/ntt/mod.rs
@@ -15,15 +15,14 @@ impl_ntt_without_domain!("babybearExtension", ExtensionField, ScalarField, Scala
 pub(crate) mod tests {
     use super::{ExtensionField, ScalarField};
     use icicle_core::{
-        ntt::{initialize_domain, release_domain, ntt_inplace, NTTConfig, NTTDir},
+        ntt::{initialize_domain, ntt_inplace, release_domain, NTTConfig, NTTDir},
         traits::{FieldImpl, GenerateRandom},
     };
     use icicle_cuda_runtime::{device_context::DeviceContext, memory::HostSlice};
     use p3_baby_bear::BabyBear;
     use p3_dft::{Radix2Dit, TwoAdicSubgroupDft};
     use p3_field::{
-        extension::BinomialExtensionField, AbstractExtensionField, AbstractField, PrimeField32,
-        TwoAdicField,
+        extension::BinomialExtensionField, AbstractExtensionField, AbstractField, PrimeField32, TwoAdicField,
     };
     use p3_matrix::dense::RowMajorMatrix;
     use risc0_core::field::{


### PR DESCRIPTION
This PR adds a test that shows the consistency of our baby bear implementation with both plonky3 and risc0. Initially I assumed that the difference in non-residues (-11 vs. 11) will affect the correctness but actually they are equivalent.