### PR TITLE
[PATCH]: Update module with v2 versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ingonyama-zk/icicle
+module github.com/ingonyama-zk/icicle/v2
 
 go 1.20
 


### PR DESCRIPTION
## Describe the changes

This PR fixes the issue of v2 ICICLE not being discovered by Go's packaging service by adding the required "v2" to the module path: https://go.dev/doc/modules/release-workflow#breaking