### PR TITLE
fix: bug regarding MixedRadix coset NTT for NM/MN ordering

### DIFF
--- a/icicle/include/ntt/ntt_impl.cuh
+++ b/icicle/include/ntt/ntt_impl.cuh
@@ -32,6 +32,7 @@ namespace mxntt {
     S* external_twiddles,
     S* internal_twiddles,
     S* basic_twiddles,
+    S* linear_twiddle, // twiddles organized as [1,w,w^2,...] for coset-eval in fast-tw mode
     int ntt_size,
     int max_logn,
     int batch_size,

--- a/icicle/src/ntt/kernel_ntt.cu
+++ b/icicle/src/ntt/kernel_ntt.cu
@@ -141,14 +141,9 @@ namespace mxntt {
     if (tid >= size * batch_size) return;
     int64_t scalar_id = (tid / columns_batch_size) % size;
     if (rev_type != eRevType::None) {
-      // Notes:
-      // (1) DIF (I)NTT is mixing digits (N->M) such that a DIF reverse complemets it back to N. Same for DIT where a
-      // DIT reverse complements the DIT compute. Obviously DIF<->DIT complement each other. Therefore is should be
-      // clear that DIF is mixing like a DIT reverse and vice versa.
-      // (2) to multiply a Mixed-order in_vec by scalars, need to mix the scalars corresponding to how the in_vec was
-      // mixed. Mixing N->M is done by DIF (I)NTT. Therefore for multiplication in M state always use DIT reversal.
+      const bool dif = rev_type == eRevType::NaturalToMixedRev;
       scalar_id =
-        generalized_rev((tid / columns_batch_size) & ((1 << log_size) - 1), log_size, true /*=dit*/, fast_tw, rev_type);
+        generalized_rev((tid / columns_batch_size) & ((1 << log_size) - 1), log_size, !dif, fast_tw, rev_type);
     }
     out_vec[tid] = *(scalar_vec + ((scalar_id * step) % n_scalars)) * in_vec[tid];
   }

--- a/icicle/src/ntt/kernel_ntt.cu
+++ b/icicle/src/ntt/kernel_ntt.cu
@@ -141,6 +141,12 @@ namespace mxntt {
     if (tid >= size * batch_size) return;
     int64_t scalar_id = (tid / columns_batch_size) % size;
     if (rev_type != eRevType::None) {
+      // Note: when we multiply an in_vec that is mixed (by DIF (I)NTT), we want to shuffle the
+      // scalars the same way (then multiply element-wise). This would be a DIT-digit-reverse shuffle. (this is
+      // confusing but) BUT to avoid shuffling the scalars, we instead want to ask which element in the non-shuffled
+      // vec is now placed at index tid, which is the opposite of a DIT-digit-reverse --> this is the DIF-digit-reverse.
+      // Therefore we use the DIF-digit-reverse to know which element moved to index tid and use it to access the
+      // corresponding element in scalars vec.
       const bool dif = rev_type == eRevType::NaturalToMixedRev;
       scalar_id =
         generalized_rev((tid / columns_batch_size) & ((1 << log_size) - 1), log_size, !dif, fast_tw, rev_type);

--- a/icicle/src/ntt/ntt.cu
+++ b/icicle/src/ntt/ntt.cu
@@ -717,8 +717,7 @@ namespace ntt {
           d_input, d_output, domain.twiddles, size, domain.max_size, batch_size, is_inverse, config.ordering, coset,
           coset_index, stream));
       } else {
-        const bool is_on_coset = (coset_index != 0) || coset;
-        const bool is_fast_twiddles_enabled = (domain.fast_external_twiddles != nullptr) && !is_on_coset;
+        const bool is_fast_twiddles_enabled = (domain.fast_external_twiddles != nullptr);
         S* twiddles = is_fast_twiddles_enabled
                         ? (is_inverse ? domain.fast_external_twiddles_inv : domain.fast_external_twiddles)
                         : domain.twiddles;
@@ -728,9 +727,11 @@ namespace ntt {
         S* basic_twiddles = is_fast_twiddles_enabled
                               ? (is_inverse ? domain.fast_basic_twiddles_inv : domain.fast_basic_twiddles)
                               : domain.basic_twiddles;
+        S* linear_twiddles = domain.twiddles; // twiddles organized as [1,w,w^2,...]
         CHK_IF_RETURN(mxntt::mixed_radix_ntt(
-          d_input, d_output, twiddles, internal_twiddles, basic_twiddles, size, domain.max_log_size, batch_size,
-          config.columns_batch, is_inverse, is_fast_twiddles_enabled, config.ordering, coset, coset_index, stream));
+          d_input, d_output, twiddles, internal_twiddles, basic_twiddles, linear_twiddles, size, domain.max_log_size,
+          batch_size, config.columns_batch, is_inverse, is_fast_twiddles_enabled, config.ordering, coset, coset_index,
+          stream));
       }
     }
 

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -380,6 +380,13 @@ macro_rules! impl_ntt_tests {
 
         #[test]
         #[parallel]
+        fn test_ntt_coset_nm() {
+            INIT.get_or_init(move || init_domain::<$field>(MAX_SIZE, DEFAULT_DEVICE_ID, FAST_TWIDDLES_MODE));
+            check_ntt_coset_nm::<$field>();
+        }
+
+        #[test]
+        #[parallel]
         fn test_ntt_arbitrary_coset() {
             INIT.get_or_init(move || init_domain::<$field>(MAX_SIZE, DEFAULT_DEVICE_ID, FAST_TWIDDLES_MODE));
             check_ntt_arbitrary_coset::<$field>()

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -380,9 +380,9 @@ macro_rules! impl_ntt_tests {
 
         #[test]
         #[parallel]
-        fn test_ntt_coset_nm() {
+        fn test_ntt_coset_interpolation_nm() {
             INIT.get_or_init(move || init_domain::<$field>(MAX_SIZE, DEFAULT_DEVICE_ID, FAST_TWIDDLES_MODE));
-            check_ntt_coset_nm::<$field>();
+            check_ntt_coset_interpolation_nm::<$field>();
         }
 
         #[test]

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -195,7 +195,7 @@ where
     F::ArkEquivalent: FftField,
     <F as FieldImpl>::Config: NTT<F, F> + GenerateRandom<F>,
 {
-    let test_sizes = [1 << 9, 1 << 10, 1 << 11, 1 << 16];
+    let test_sizes = [1 << 9, 1 << 10, 1 << 11, 1 << 13, 1 << 14, 1 << 16];
     for test_size in test_sizes {
         let coset_generators = [
             F::from_ark(F::ArkEquivalent::get_root_of_unity((test_size << 1) as u64).unwrap()),

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -190,6 +190,43 @@ where
     }
 }
 
+pub fn check_ntt_coset_nm<F: FieldImpl + ArkConvertible>()
+where
+    F::ArkEquivalent: FftField,
+    <F as FieldImpl>::Config: NTT<F, F> + GenerateRandom<F>,
+{
+    let test_sizes = [1 << 9, 1 << 10, 1 << 11, 1 << 16];
+    for test_size in test_sizes {
+        let coset_generators = [
+            F::from_ark(F::ArkEquivalent::get_root_of_unity((test_size << 1) as u64).unwrap()),
+            F::Config::generate_random(1)[0],
+        ];
+
+        let scalars: Vec<F> = F::Config::generate_random(test_size);
+        for coset_gen in coset_generators {
+            let mut config = NTTConfig::default();
+            config.ordering = Ordering::kNM;
+            config.ntt_algorithm = NttAlgorithm::MixedRadix;
+            config.coset_gen = coset_gen;
+
+            let mut intt_result = vec![F::zero(); test_size];
+            let intt_result = HostSlice::from_mut_slice(&mut intt_result);
+            ntt(HostSlice::from_slice(&scalars), NTTDir::kInverse, &config, intt_result).unwrap();
+
+            config.ordering = Ordering::kMN;
+            let mut ntt_result = vec![F::zero(); test_size];
+            ntt(
+                intt_result,
+                NTTDir::kForward,
+                &config,
+                HostSlice::from_mut_slice(&mut ntt_result),
+            )
+            .unwrap();
+            assert_eq!(ntt_result, scalars);
+        }
+    }
+}
+
 pub fn check_ntt_arbitrary_coset<F: FieldImpl + ArkConvertible>()
 where
     F::ArkEquivalent: FftField + ArkField,


### PR DESCRIPTION
The bug was in how twiddles array is indexed when multiplied by a mixed (M) vector to implement (I)NTT on cosets.
The fix is to use the DIF-digit-reverse to know which element in the natural (N) vector, moved to index 'i' in the M vector. This is emulating a DIT-digit-reverse (which is mixing like a DIF-compute) reorder of the twiddles array and element-wise multiplication without reordering the twiddles memory.


