### PR TITLE
Bug/vlad/fix ci crash multidevice

### DIFF
--- a/wrappers/golang/core/msm.go
+++ b/wrappers/golang/core/msm.go
@@ -76,6 +76,26 @@ func GetDefaultMSMConfig() MSMConfig {
 	}
 }
 
+func GetDefaultMSMConfigForDevice(device int) MSMConfig {
+	ctx, _ := cr.GetDefaultContextForDevice(device)
+	return MSMConfig{
+		ctx,   // Ctx
+		0,     // pointsSize
+		1,     // PrecomputeFactor
+		0,     // C
+		0,     // Bitsize
+		10,    // LargeBucketFactor
+		1,     // batchSize
+		false, // areScalarsOnDevice
+		false, // AreScalarsMontgomeryForm
+		false, // arePointsOnDevice
+		false, // ArePointsMontgomeryForm
+		false, // areResultsOnDevice
+		false, // IsBigTriangle
+		false, // IsAsync
+	}
+}
+
 func MsmCheck(scalars HostOrDeviceSlice, points HostOrDeviceSlice, cfg *MSMConfig, results HostOrDeviceSlice) (unsafe.Pointer, unsafe.Pointer, unsafe.Pointer, int, unsafe.Pointer) {
 	scalarsLength, pointsLength, resultsLength := scalars.Len(), points.Len()/int(cfg.PrecomputeFactor), results.Len()
 	if scalarsLength%pointsLength != 0 {

--- a/wrappers/golang/core/ntt.go
+++ b/wrappers/golang/core/ntt.go
@@ -68,6 +68,21 @@ func GetDefaultNTTConfig[T any](cosetGen T) NTTConfig[T] {
 	}
 }
 
+func GetDefaultNttConfigForDevice[T any](cosetGen T, device int) NTTConfig[T] {
+	ctx, _ := cr.GetDefaultContextForDevice(device)
+	return NTTConfig[T]{
+		ctx,      // Ctx
+		cosetGen, // CosetGen
+		1,        // BatchSize
+		false,    // ColumnsBatch
+		KNN,      // Ordering
+		false,    // areInputsOnDevice
+		false,    // areOutputsOnDevice
+		false,    // IsAsync
+		Auto,
+	}
+}
+
 func NttCheck[T any](input HostOrDeviceSlice, cfg *NTTConfig[T], output HostOrDeviceSlice) (unsafe.Pointer, unsafe.Pointer, int, unsafe.Pointer) {
 	inputLen, outputLen := input.Len(), output.Len()
 	if inputLen != outputLen {

--- a/wrappers/golang/core/vec_ops.go
+++ b/wrappers/golang/core/vec_ops.go
@@ -46,6 +46,18 @@ func DefaultVecOpsConfig() VecOpsConfig {
 
 	return config
 }
+func DefaultVecOpsConfigForDevice(device int) VecOpsConfig {
+	ctx, _ := cr.GetDefaultContextForDevice(device)
+	config := VecOpsConfig{
+		ctx,   // ctx
+		false, // isAOnDevice
+		false, // isBOnDevice
+		false, // isResultOnDevice
+		false, // IsAsync
+	}
+
+	return config
+}
 
 func VecOpCheck(a, b, out HostOrDeviceSlice, cfg *VecOpsConfig) (unsafe.Pointer, unsafe.Pointer, unsafe.Pointer, unsafe.Pointer, int) {
 	aLen, bLen, outLen := a.Len(), b.Len(), out.Len()

--- a/wrappers/golang/cuda_runtime/device_context.go
+++ b/wrappers/golang/cuda_runtime/device_context.go
@@ -44,6 +44,25 @@ func GetDefaultDeviceContext() (DeviceContext, CudaError) {
 	}, CudaSuccess
 }
 
+func GetDefaultContextForDevice(device int) (DeviceContext, CudaError) {
+	numDevice, err := GetDeviceCount()
+	if err != CudaSuccess {
+		panic(fmt.Sprintf("Could not get current device count due to %v", err))
+	}
+	if device > numDevice-1 {
+		panic(fmt.Sprintf("Device %d does not exist, there are only %d devices available", device, numDevice))
+	}
+	SetDevice(device)
+	var defaultStream Stream
+	var defaultMempool MemPool
+
+	return DeviceContext{
+		&defaultStream,
+		uint(device),
+		defaultMempool,
+	}, CudaSuccess
+}
+
 func SetDevice(device int) CudaError {
 	cDevice := (C.int)(device)
 	ret := C.cudaSetDevice(cDevice)

--- a/wrappers/golang/curves/bls12377/ecntt/ecntt.go
+++ b/wrappers/golang/curves/bls12377/ecntt/ecntt.go
@@ -10,6 +10,7 @@ import (
 )
 
 func ECNtt[T any](points core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	pointsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](points, cfg, results)
 
 	cPoints := (*C.projective_t)(pointsPointer)

--- a/wrappers/golang/curves/bls12377/g2/msm.go
+++ b/wrappers/golang/curves/bls12377/g2/msm.go
@@ -5,17 +5,21 @@ package g2
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func G2GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bls12377/msm/msm.go
+++ b/wrappers/golang/curves/bls12377/msm/msm.go
@@ -5,17 +5,21 @@ package msm
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bls12377/ntt/ntt.go
+++ b/wrappers/golang/curves/bls12377/ntt/ntt.go
@@ -5,14 +5,17 @@ package ntt
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
 	bls12_377 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377"
 )
 
+import (
+	"unsafe"
+)
+
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](scalars, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)
@@ -35,6 +38,17 @@ func GetDefaultNttConfig() core.NTTConfig[[bls12_377.SCALAR_LIMBS]uint32] {
 	}
 
 	return core.GetDefaultNTTConfig(cosetGen)
+}
+
+func GetDefaultNttConfigForDevice(device int) core.NTTConfig[[bls12_377.SCALAR_LIMBS]uint32] {
+	cosetGenField := bls12_377.ScalarField{}
+	cosetGenField.One()
+	var cosetGen [bls12_377.SCALAR_LIMBS]uint32
+	for i, v := range cosetGenField.GetLimbs() {
+		cosetGen[i] = v
+	}
+
+	return core.GetDefaultNttConfigForDevice(cosetGen, device)
 }
 
 func InitDomain(primitiveRoot bls12_377.ScalarField, ctx cr.DeviceContext, fastTwiddles bool) core.IcicleError {

--- a/wrappers/golang/curves/bls12377/scalar_field.go
+++ b/wrappers/golang/curves/bls12377/scalar_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/curves/bls12377/tests/base_field_test.go
+++ b/wrappers/golang/curves/bls12377/tests/base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bls12_377 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bls12377/tests/curve_test.go
+++ b/wrappers/golang/curves/bls12377/tests/curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bls12_377 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestAffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bls12377/tests/ecntt_test.go
+++ b/wrappers/golang/curves/bls12377/tests/ecntt_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestECNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	points := bls12_377.GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {

--- a/wrappers/golang/curves/bls12377/tests/g2_curve_test.go
+++ b/wrappers/golang/curves/bls12377/tests/g2_curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestG2AffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bls12377/tests/g2_g2base_field_test.go
+++ b/wrappers/golang/curves/bls12377/tests/g2_g2base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bls12_377 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bls12377/tests/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12377/tests/g2_msm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
@@ -119,7 +119,7 @@ func convertIcicleG2AffineToG2Affine(iciclePoints []g2.G2Affine) []bls12377.G2Af
 }
 
 func TestMSMG2(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
@@ -127,6 +127,7 @@ func TestMSMG2(t *testing.T) {
 		scalars := icicleBls12_377.GenerateScalars(size)
 		points := g2.G2GenerateAffinePoints(size)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		stream, _ := cr.CreateStream()
 		var p g2.G2Projective
 		var out core.DeviceSlice
@@ -147,7 +148,7 @@ func TestMSMG2(t *testing.T) {
 	}
 }
 func TestMSMG2GnarkCryptoTypes(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{3} {
 		size := 1 << power
 
@@ -162,6 +163,7 @@ func TestMSMG2GnarkCryptoTypes(t *testing.T) {
 		pointsGnark := convertIcicleG2AffineToG2Affine(points)
 		pointsHost := (core.HostSlice[bls12377.G2Affine])(pointsGnark)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p g2.G2Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -181,7 +183,7 @@ func TestMSMG2GnarkCryptoTypes(t *testing.T) {
 }
 
 func TestMSMG2Batch(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
 			size := 1 << power
@@ -194,6 +196,7 @@ func TestMSMG2Batch(t *testing.T) {
 			_, e := out.Malloc(batchSize*p.Size(), p.Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			e = g2.G2Msm(scalars, points, &cfg, out)
 			assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 			outHost := make(core.HostSlice[g2.G2Projective], batchSize)
@@ -211,7 +214,7 @@ func TestMSMG2Batch(t *testing.T) {
 }
 
 func TestPrecomputeBaseG2(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	const precomputeFactor = 8
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
@@ -220,6 +223,7 @@ func TestPrecomputeBaseG2(t *testing.T) {
 			scalars := icicleBls12_377.GenerateScalars(totalSize)
 			points := g2.G2GenerateAffinePoints(totalSize)
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			var precomputeOut core.DeviceSlice
 			_, e := precomputeOut.Malloc(points[0].Size()*points.Len()*int(precomputeFactor), points[0].Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for PrecomputeBases results failed")
@@ -252,7 +256,7 @@ func TestPrecomputeBaseG2(t *testing.T) {
 }
 
 func TestMSMG2SkewedDistribution(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
@@ -265,6 +269,7 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 			points[i].Zero()
 		}
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p g2.G2Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -282,7 +287,6 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 
 func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
-	numDevices = 1 // TODO remove when test env is fixed
 	fmt.Println("There are ", numDevices, " devices available")
 	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}

--- a/wrappers/golang/curves/bls12377/tests/msm_test.go
+++ b/wrappers/golang/curves/bls12377/tests/msm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	bls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377"
+	"github.com/consensys/gnark-crypto/ecc/bls12-377"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 
@@ -79,7 +79,7 @@ func convertIcicleAffineToG1Affine(iciclePoints []icicleBls12_377.Affine) []bls1
 }
 
 func TestMSM(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
@@ -87,6 +87,7 @@ func TestMSM(t *testing.T) {
 		scalars := icicleBls12_377.GenerateScalars(size)
 		points := icicleBls12_377.GenerateAffinePoints(size)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		stream, _ := cr.CreateStream()
 		var p icicleBls12_377.Projective
 		var out core.DeviceSlice
@@ -107,7 +108,7 @@ func TestMSM(t *testing.T) {
 	}
 }
 func TestMSMGnarkCryptoTypes(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{3} {
 		size := 1 << power
 
@@ -122,6 +123,7 @@ func TestMSMGnarkCryptoTypes(t *testing.T) {
 		pointsGnark := convertIcicleAffineToG1Affine(points)
 		pointsHost := (core.HostSlice[bls12377.G1Affine])(pointsGnark)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p icicleBls12_377.Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -141,7 +143,7 @@ func TestMSMGnarkCryptoTypes(t *testing.T) {
 }
 
 func TestMSMBatch(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
 			size := 1 << power
@@ -154,6 +156,7 @@ func TestMSMBatch(t *testing.T) {
 			_, e := out.Malloc(batchSize*p.Size(), p.Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			e = msm.Msm(scalars, points, &cfg, out)
 			assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 			outHost := make(core.HostSlice[icicleBls12_377.Projective], batchSize)
@@ -171,7 +174,7 @@ func TestMSMBatch(t *testing.T) {
 }
 
 func TestPrecomputeBase(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	const precomputeFactor = 8
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
@@ -180,6 +183,7 @@ func TestPrecomputeBase(t *testing.T) {
 			scalars := icicleBls12_377.GenerateScalars(totalSize)
 			points := icicleBls12_377.GenerateAffinePoints(totalSize)
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			var precomputeOut core.DeviceSlice
 			_, e := precomputeOut.Malloc(points[0].Size()*points.Len()*int(precomputeFactor), points[0].Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for PrecomputeBases results failed")
@@ -212,7 +216,7 @@ func TestPrecomputeBase(t *testing.T) {
 }
 
 func TestMSMSkewedDistribution(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
@@ -225,6 +229,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 			points[i].Zero()
 		}
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p icicleBls12_377.Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -242,7 +247,6 @@ func TestMSMSkewedDistribution(t *testing.T) {
 
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
-	numDevices = 1 // TODO remove when test env is fixed
 	fmt.Println("There are ", numDevices, " devices available")
 	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}

--- a/wrappers/golang/curves/bls12377/tests/ntt_test.go
+++ b/wrappers/golang/curves/bls12377/tests/ntt_test.go
@@ -54,7 +54,7 @@ func testAgainstGnarkCryptoNttGnarkTypes(size int, scalarsFr core.HostSlice[fr.E
 	return reflect.DeepEqual(scalarsFr, outputAsFr)
 }
 func TestNTTGetDefaultConfig(t *testing.T) {
-	actual := ntt.GetDefaultNttConfig()
+	actual := ntt.GetDefaultNttConfigForDevice(0)
 	expected := test_helpers.GenerateLimbOne(int(bls12_377.SCALAR_LIMBS))
 	assert.Equal(t, expected, actual.CosetGen[:])
 
@@ -70,7 +70,7 @@ func TestInitDomain(t *testing.T) {
 }
 
 func TestNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bls12_377.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{4, largestTestSize} {
@@ -90,7 +90,7 @@ func TestNtt(t *testing.T) {
 	}
 }
 func TestNttFrElement(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := make([]fr.Element, 4)
 	var x fr.Element
 	for i := 0; i < 4; i++ {
@@ -116,7 +116,7 @@ func TestNttFrElement(t *testing.T) {
 }
 
 func TestNttDeviceAsync(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bls12_377.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {
@@ -125,6 +125,7 @@ func TestNttDeviceAsync(t *testing.T) {
 				testSize := 1 << size
 				scalarsCopy := core.HostSliceFromElements[bls12_377.ScalarField](scalars[:testSize])
 
+				cr.SetDevice(cfg.Ctx.GetDeviceId())
 				stream, _ := cr.CreateStream()
 
 				cfg.Ordering = v
@@ -150,7 +151,7 @@ func TestNttDeviceAsync(t *testing.T) {
 }
 
 func TestNttBatch(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	largestBatchSize := 100
 	scalars := bls12_377.GenerateScalars(1 << largestTestSize * largestBatchSize)
 

--- a/wrappers/golang/curves/bls12377/tests/polynomial_test.go
+++ b/wrappers/golang/curves/bls12377/tests/polynomial_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bls12_377 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377"
-
 	// "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377/ntt"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377/polynomial"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377/vecOps"
@@ -36,7 +35,7 @@ func vecOp(a, b bls12_377.ScalarField, op core.VecOps) bls12_377.ScalarField {
 	bhost := core.HostSliceWithValue(b, 1)
 	out := make(core.HostSlice[bls12_377.ScalarField], 1)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 	vecOps.VecOp(ahost, bhost, out, cfg, op)
 	return out[0]
 }

--- a/wrappers/golang/curves/bls12377/tests/scalar_field_test.go
+++ b/wrappers/golang/curves/bls12377/tests/scalar_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bls12_377 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12377"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bls12377/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12377/tests/vec_ops_test.go
@@ -46,7 +46,7 @@ func TestBls12_377Transpose(t *testing.T) {
 	out := make(core.HostSlice[bls12_377.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bls12_377.ScalarField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bls12377/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12377/tests/vec_ops_test.go
@@ -23,7 +23,7 @@ func TestBls12_377VecOps(t *testing.T) {
 	out2 := make(core.HostSlice[bls12_377.ScalarField], testSize)
 	out3 := make(core.HostSlice[bls12_377.ScalarField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestBls12_377Transpose(t *testing.T) {
 	out := make(core.HostSlice[bls12_377.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bls12_377.ScalarField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bls12377/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bls12377/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bls12377/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bls12381/ecntt/ecntt.go
+++ b/wrappers/golang/curves/bls12381/ecntt/ecntt.go
@@ -10,6 +10,7 @@ import (
 )
 
 func ECNtt[T any](points core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	pointsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](points, cfg, results)
 
 	cPoints := (*C.projective_t)(pointsPointer)

--- a/wrappers/golang/curves/bls12381/g2/msm.go
+++ b/wrappers/golang/curves/bls12381/g2/msm.go
@@ -5,17 +5,21 @@ package g2
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func G2GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bls12381/msm/msm.go
+++ b/wrappers/golang/curves/bls12381/msm/msm.go
@@ -5,17 +5,21 @@ package msm
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bls12381/ntt/ntt.go
+++ b/wrappers/golang/curves/bls12381/ntt/ntt.go
@@ -5,14 +5,17 @@ package ntt
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
 	bls12_381 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381"
 )
 
+import (
+	"unsafe"
+)
+
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](scalars, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)
@@ -35,6 +38,17 @@ func GetDefaultNttConfig() core.NTTConfig[[bls12_381.SCALAR_LIMBS]uint32] {
 	}
 
 	return core.GetDefaultNTTConfig(cosetGen)
+}
+
+func GetDefaultNttConfigForDevice(device int) core.NTTConfig[[bls12_381.SCALAR_LIMBS]uint32] {
+	cosetGenField := bls12_381.ScalarField{}
+	cosetGenField.One()
+	var cosetGen [bls12_381.SCALAR_LIMBS]uint32
+	for i, v := range cosetGenField.GetLimbs() {
+		cosetGen[i] = v
+	}
+
+	return core.GetDefaultNttConfigForDevice(cosetGen, device)
 }
 
 func InitDomain(primitiveRoot bls12_381.ScalarField, ctx cr.DeviceContext, fastTwiddles bool) core.IcicleError {

--- a/wrappers/golang/curves/bls12381/scalar_field.go
+++ b/wrappers/golang/curves/bls12381/scalar_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/curves/bls12381/tests/base_field_test.go
+++ b/wrappers/golang/curves/bls12381/tests/base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bls12_381 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bls12381/tests/curve_test.go
+++ b/wrappers/golang/curves/bls12381/tests/curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bls12_381 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestAffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bls12381/tests/ecntt_test.go
+++ b/wrappers/golang/curves/bls12381/tests/ecntt_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestECNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	points := bls12_381.GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {

--- a/wrappers/golang/curves/bls12381/tests/g2_curve_test.go
+++ b/wrappers/golang/curves/bls12381/tests/g2_curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestG2AffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bls12381/tests/g2_g2base_field_test.go
+++ b/wrappers/golang/curves/bls12381/tests/g2_g2base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bls12_381 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bls12381/tests/g2_msm_test.go
+++ b/wrappers/golang/curves/bls12381/tests/g2_msm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
@@ -119,7 +119,7 @@ func convertIcicleG2AffineToG2Affine(iciclePoints []g2.G2Affine) []bls12381.G2Af
 }
 
 func TestMSMG2(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
@@ -127,6 +127,7 @@ func TestMSMG2(t *testing.T) {
 		scalars := icicleBls12_381.GenerateScalars(size)
 		points := g2.G2GenerateAffinePoints(size)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		stream, _ := cr.CreateStream()
 		var p g2.G2Projective
 		var out core.DeviceSlice
@@ -147,7 +148,7 @@ func TestMSMG2(t *testing.T) {
 	}
 }
 func TestMSMG2GnarkCryptoTypes(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{3} {
 		size := 1 << power
 
@@ -162,6 +163,7 @@ func TestMSMG2GnarkCryptoTypes(t *testing.T) {
 		pointsGnark := convertIcicleG2AffineToG2Affine(points)
 		pointsHost := (core.HostSlice[bls12381.G2Affine])(pointsGnark)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p g2.G2Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -181,7 +183,7 @@ func TestMSMG2GnarkCryptoTypes(t *testing.T) {
 }
 
 func TestMSMG2Batch(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
 			size := 1 << power
@@ -194,6 +196,7 @@ func TestMSMG2Batch(t *testing.T) {
 			_, e := out.Malloc(batchSize*p.Size(), p.Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			e = g2.G2Msm(scalars, points, &cfg, out)
 			assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 			outHost := make(core.HostSlice[g2.G2Projective], batchSize)
@@ -211,7 +214,7 @@ func TestMSMG2Batch(t *testing.T) {
 }
 
 func TestPrecomputeBaseG2(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	const precomputeFactor = 8
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
@@ -220,6 +223,7 @@ func TestPrecomputeBaseG2(t *testing.T) {
 			scalars := icicleBls12_381.GenerateScalars(totalSize)
 			points := g2.G2GenerateAffinePoints(totalSize)
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			var precomputeOut core.DeviceSlice
 			_, e := precomputeOut.Malloc(points[0].Size()*points.Len()*int(precomputeFactor), points[0].Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for PrecomputeBases results failed")
@@ -252,7 +256,7 @@ func TestPrecomputeBaseG2(t *testing.T) {
 }
 
 func TestMSMG2SkewedDistribution(t *testing.T) {
-	cfg := g2.G2GetDefaultMSMConfig()
+	cfg := g2.G2GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
@@ -265,6 +269,7 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 			points[i].Zero()
 		}
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p g2.G2Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -282,7 +287,6 @@ func TestMSMG2SkewedDistribution(t *testing.T) {
 
 func TestMSMG2MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
-	numDevices = 1 // TODO remove when test env is fixed
 	fmt.Println("There are ", numDevices, " devices available")
 	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}

--- a/wrappers/golang/curves/bls12381/tests/msm_test.go
+++ b/wrappers/golang/curves/bls12381/tests/msm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/consensys/gnark-crypto/ecc"
-	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 
@@ -79,7 +79,7 @@ func convertIcicleAffineToG1Affine(iciclePoints []icicleBls12_381.Affine) []bls1
 }
 
 func TestMSM(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
@@ -87,6 +87,7 @@ func TestMSM(t *testing.T) {
 		scalars := icicleBls12_381.GenerateScalars(size)
 		points := icicleBls12_381.GenerateAffinePoints(size)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		stream, _ := cr.CreateStream()
 		var p icicleBls12_381.Projective
 		var out core.DeviceSlice
@@ -107,7 +108,7 @@ func TestMSM(t *testing.T) {
 	}
 }
 func TestMSMGnarkCryptoTypes(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{3} {
 		size := 1 << power
 
@@ -122,6 +123,7 @@ func TestMSMGnarkCryptoTypes(t *testing.T) {
 		pointsGnark := convertIcicleAffineToG1Affine(points)
 		pointsHost := (core.HostSlice[bls12381.G1Affine])(pointsGnark)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p icicleBls12_381.Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -141,7 +143,7 @@ func TestMSMGnarkCryptoTypes(t *testing.T) {
 }
 
 func TestMSMBatch(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
 			size := 1 << power
@@ -154,6 +156,7 @@ func TestMSMBatch(t *testing.T) {
 			_, e := out.Malloc(batchSize*p.Size(), p.Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			e = msm.Msm(scalars, points, &cfg, out)
 			assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 			outHost := make(core.HostSlice[icicleBls12_381.Projective], batchSize)
@@ -171,7 +174,7 @@ func TestMSMBatch(t *testing.T) {
 }
 
 func TestPrecomputeBase(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	const precomputeFactor = 8
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
@@ -180,6 +183,7 @@ func TestPrecomputeBase(t *testing.T) {
 			scalars := icicleBls12_381.GenerateScalars(totalSize)
 			points := icicleBls12_381.GenerateAffinePoints(totalSize)
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			var precomputeOut core.DeviceSlice
 			_, e := precomputeOut.Malloc(points[0].Size()*points.Len()*int(precomputeFactor), points[0].Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for PrecomputeBases results failed")
@@ -212,7 +216,7 @@ func TestPrecomputeBase(t *testing.T) {
 }
 
 func TestMSMSkewedDistribution(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
@@ -225,6 +229,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 			points[i].Zero()
 		}
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p icicleBls12_381.Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -242,7 +247,6 @@ func TestMSMSkewedDistribution(t *testing.T) {
 
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
-	numDevices = 1 // TODO remove when test env is fixed
 	fmt.Println("There are ", numDevices, " devices available")
 	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}

--- a/wrappers/golang/curves/bls12381/tests/ntt_test.go
+++ b/wrappers/golang/curves/bls12381/tests/ntt_test.go
@@ -54,7 +54,7 @@ func testAgainstGnarkCryptoNttGnarkTypes(size int, scalarsFr core.HostSlice[fr.E
 	return reflect.DeepEqual(scalarsFr, outputAsFr)
 }
 func TestNTTGetDefaultConfig(t *testing.T) {
-	actual := ntt.GetDefaultNttConfig()
+	actual := ntt.GetDefaultNttConfigForDevice(0)
 	expected := test_helpers.GenerateLimbOne(int(bls12_381.SCALAR_LIMBS))
 	assert.Equal(t, expected, actual.CosetGen[:])
 
@@ -70,7 +70,7 @@ func TestInitDomain(t *testing.T) {
 }
 
 func TestNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bls12_381.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{4, largestTestSize} {
@@ -90,7 +90,7 @@ func TestNtt(t *testing.T) {
 	}
 }
 func TestNttFrElement(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := make([]fr.Element, 4)
 	var x fr.Element
 	for i := 0; i < 4; i++ {
@@ -116,7 +116,7 @@ func TestNttFrElement(t *testing.T) {
 }
 
 func TestNttDeviceAsync(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bls12_381.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {
@@ -125,6 +125,7 @@ func TestNttDeviceAsync(t *testing.T) {
 				testSize := 1 << size
 				scalarsCopy := core.HostSliceFromElements[bls12_381.ScalarField](scalars[:testSize])
 
+				cr.SetDevice(cfg.Ctx.GetDeviceId())
 				stream, _ := cr.CreateStream()
 
 				cfg.Ordering = v
@@ -150,7 +151,7 @@ func TestNttDeviceAsync(t *testing.T) {
 }
 
 func TestNttBatch(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	largestBatchSize := 100
 	scalars := bls12_381.GenerateScalars(1 << largestTestSize * largestBatchSize)
 

--- a/wrappers/golang/curves/bls12381/tests/polynomial_test.go
+++ b/wrappers/golang/curves/bls12381/tests/polynomial_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bls12_381 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381"
-
 	// "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381/ntt"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381/polynomial"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381/vecOps"
@@ -36,7 +35,7 @@ func vecOp(a, b bls12_381.ScalarField, op core.VecOps) bls12_381.ScalarField {
 	bhost := core.HostSliceWithValue(b, 1)
 	out := make(core.HostSlice[bls12_381.ScalarField], 1)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 	vecOps.VecOp(ahost, bhost, out, cfg, op)
 	return out[0]
 }

--- a/wrappers/golang/curves/bls12381/tests/scalar_field_test.go
+++ b/wrappers/golang/curves/bls12381/tests/scalar_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bls12_381 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bls12381"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bls12381/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12381/tests/vec_ops_test.go
@@ -46,7 +46,7 @@ func TestBls12_381Transpose(t *testing.T) {
 	out := make(core.HostSlice[bls12_381.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bls12_381.ScalarField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bls12381/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bls12381/tests/vec_ops_test.go
@@ -23,7 +23,7 @@ func TestBls12_381VecOps(t *testing.T) {
 	out2 := make(core.HostSlice[bls12_381.ScalarField], testSize)
 	out3 := make(core.HostSlice[bls12_381.ScalarField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestBls12_381Transpose(t *testing.T) {
 	out := make(core.HostSlice[bls12_381.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bls12_381.ScalarField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bls12381/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bls12381/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bls12381/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bn254/ecntt/ecntt.go
+++ b/wrappers/golang/curves/bn254/ecntt/ecntt.go
@@ -10,6 +10,7 @@ import (
 )
 
 func ECNtt[T any](points core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	pointsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](points, cfg, results)
 
 	cPoints := (*C.projective_t)(pointsPointer)

--- a/wrappers/golang/curves/bn254/g2/msm.go
+++ b/wrappers/golang/curves/bn254/g2/msm.go
@@ -5,17 +5,21 @@ package g2
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func G2GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bn254/msm/msm.go
+++ b/wrappers/golang/curves/bn254/msm/msm.go
@@ -5,17 +5,21 @@ package msm
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bn254/ntt/ntt.go
+++ b/wrappers/golang/curves/bn254/ntt/ntt.go
@@ -5,14 +5,17 @@ package ntt
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
 	bn254 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254"
 )
 
+import (
+	"unsafe"
+)
+
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](scalars, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)
@@ -35,6 +38,17 @@ func GetDefaultNttConfig() core.NTTConfig[[bn254.SCALAR_LIMBS]uint32] {
 	}
 
 	return core.GetDefaultNTTConfig(cosetGen)
+}
+
+func GetDefaultNttConfigForDevice(device int) core.NTTConfig[[bn254.SCALAR_LIMBS]uint32] {
+	cosetGenField := bn254.ScalarField{}
+	cosetGenField.One()
+	var cosetGen [bn254.SCALAR_LIMBS]uint32
+	for i, v := range cosetGenField.GetLimbs() {
+		cosetGen[i] = v
+	}
+
+	return core.GetDefaultNttConfigForDevice(cosetGen, device)
 }
 
 func InitDomain(primitiveRoot bn254.ScalarField, ctx cr.DeviceContext, fastTwiddles bool) core.IcicleError {

--- a/wrappers/golang/curves/bn254/scalar_field.go
+++ b/wrappers/golang/curves/bn254/scalar_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/curves/bn254/tests/base_field_test.go
+++ b/wrappers/golang/curves/bn254/tests/base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bn254 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bn254/tests/curve_test.go
+++ b/wrappers/golang/curves/bn254/tests/curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bn254 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestAffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bn254/tests/ecntt_test.go
+++ b/wrappers/golang/curves/bn254/tests/ecntt_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestECNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	points := bn254.GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {

--- a/wrappers/golang/curves/bn254/tests/g2_curve_test.go
+++ b/wrappers/golang/curves/bn254/tests/g2_curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestG2AffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bn254/tests/g2_g2base_field_test.go
+++ b/wrappers/golang/curves/bn254/tests/g2_g2base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bn254 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bn254/tests/msm_test.go
+++ b/wrappers/golang/curves/bn254/tests/msm_test.go
@@ -79,7 +79,7 @@ func convertIcicleAffineToG1Affine(iciclePoints []icicleBn254.Affine) []bn254.G1
 }
 
 func TestMSM(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
@@ -87,6 +87,7 @@ func TestMSM(t *testing.T) {
 		scalars := icicleBn254.GenerateScalars(size)
 		points := icicleBn254.GenerateAffinePoints(size)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		stream, _ := cr.CreateStream()
 		var p icicleBn254.Projective
 		var out core.DeviceSlice
@@ -107,7 +108,7 @@ func TestMSM(t *testing.T) {
 	}
 }
 func TestMSMGnarkCryptoTypes(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{3} {
 		size := 1 << power
 
@@ -122,6 +123,7 @@ func TestMSMGnarkCryptoTypes(t *testing.T) {
 		pointsGnark := convertIcicleAffineToG1Affine(points)
 		pointsHost := (core.HostSlice[bn254.G1Affine])(pointsGnark)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p icicleBn254.Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -141,7 +143,7 @@ func TestMSMGnarkCryptoTypes(t *testing.T) {
 }
 
 func TestMSMBatch(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
 			size := 1 << power
@@ -154,6 +156,7 @@ func TestMSMBatch(t *testing.T) {
 			_, e := out.Malloc(batchSize*p.Size(), p.Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			e = msm.Msm(scalars, points, &cfg, out)
 			assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 			outHost := make(core.HostSlice[icicleBn254.Projective], batchSize)
@@ -171,7 +174,7 @@ func TestMSMBatch(t *testing.T) {
 }
 
 func TestPrecomputeBase(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	const precomputeFactor = 8
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
@@ -180,6 +183,7 @@ func TestPrecomputeBase(t *testing.T) {
 			scalars := icicleBn254.GenerateScalars(totalSize)
 			points := icicleBn254.GenerateAffinePoints(totalSize)
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			var precomputeOut core.DeviceSlice
 			_, e := precomputeOut.Malloc(points[0].Size()*points.Len()*int(precomputeFactor), points[0].Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for PrecomputeBases results failed")
@@ -212,7 +216,7 @@ func TestPrecomputeBase(t *testing.T) {
 }
 
 func TestMSMSkewedDistribution(t *testing.T) {
-	cfg := msm.GetDefaultMSMConfig()
+	cfg := msm.GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
@@ -225,6 +229,7 @@ func TestMSMSkewedDistribution(t *testing.T) {
 			points[i].Zero()
 		}
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p icicleBn254.Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -242,7 +247,6 @@ func TestMSMSkewedDistribution(t *testing.T) {
 
 func TestMSMMultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
-	numDevices = 1 // TODO remove when test env is fixed
 	fmt.Println("There are ", numDevices, " devices available")
 	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}

--- a/wrappers/golang/curves/bn254/tests/ntt_test.go
+++ b/wrappers/golang/curves/bn254/tests/ntt_test.go
@@ -54,7 +54,7 @@ func testAgainstGnarkCryptoNttGnarkTypes(size int, scalarsFr core.HostSlice[fr.E
 	return reflect.DeepEqual(scalarsFr, outputAsFr)
 }
 func TestNTTGetDefaultConfig(t *testing.T) {
-	actual := ntt.GetDefaultNttConfig()
+	actual := ntt.GetDefaultNttConfigForDevice(0)
 	expected := test_helpers.GenerateLimbOne(int(bn254.SCALAR_LIMBS))
 	assert.Equal(t, expected, actual.CosetGen[:])
 
@@ -70,7 +70,7 @@ func TestInitDomain(t *testing.T) {
 }
 
 func TestNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bn254.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{4, largestTestSize} {
@@ -90,7 +90,7 @@ func TestNtt(t *testing.T) {
 	}
 }
 func TestNttFrElement(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := make([]fr.Element, 4)
 	var x fr.Element
 	for i := 0; i < 4; i++ {
@@ -116,7 +116,7 @@ func TestNttFrElement(t *testing.T) {
 }
 
 func TestNttDeviceAsync(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bn254.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {
@@ -125,6 +125,7 @@ func TestNttDeviceAsync(t *testing.T) {
 				testSize := 1 << size
 				scalarsCopy := core.HostSliceFromElements[bn254.ScalarField](scalars[:testSize])
 
+				cr.SetDevice(cfg.Ctx.GetDeviceId())
 				stream, _ := cr.CreateStream()
 
 				cfg.Ordering = v
@@ -150,7 +151,7 @@ func TestNttDeviceAsync(t *testing.T) {
 }
 
 func TestNttBatch(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	largestBatchSize := 100
 	scalars := bn254.GenerateScalars(1 << largestTestSize * largestBatchSize)
 

--- a/wrappers/golang/curves/bn254/tests/polynomial_test.go
+++ b/wrappers/golang/curves/bn254/tests/polynomial_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bn254 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254"
-
 	// "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254/ntt"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254/polynomial"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254/vecOps"
@@ -36,7 +35,7 @@ func vecOp(a, b bn254.ScalarField, op core.VecOps) bn254.ScalarField {
 	bhost := core.HostSliceWithValue(b, 1)
 	out := make(core.HostSlice[bn254.ScalarField], 1)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 	vecOps.VecOp(ahost, bhost, out, cfg, op)
 	return out[0]
 }

--- a/wrappers/golang/curves/bn254/tests/scalar_field_test.go
+++ b/wrappers/golang/curves/bn254/tests/scalar_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bn254 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bn254"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bn254/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bn254/tests/vec_ops_test.go
@@ -46,7 +46,7 @@ func TestBn254Transpose(t *testing.T) {
 	out := make(core.HostSlice[bn254.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bn254.ScalarField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bn254/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bn254/tests/vec_ops_test.go
@@ -23,7 +23,7 @@ func TestBn254VecOps(t *testing.T) {
 	out2 := make(core.HostSlice[bn254.ScalarField], testSize)
 	out3 := make(core.HostSlice[bn254.ScalarField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestBn254Transpose(t *testing.T) {
 	out := make(core.HostSlice[bn254.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bn254.ScalarField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bn254/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bn254/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bn254/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bw6761/ecntt/ecntt.go
+++ b/wrappers/golang/curves/bw6761/ecntt/ecntt.go
@@ -10,6 +10,7 @@ import (
 )
 
 func ECNtt[T any](points core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	pointsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](points, cfg, results)
 
 	cPoints := (*C.projective_t)(pointsPointer)

--- a/wrappers/golang/curves/bw6761/g2/msm.go
+++ b/wrappers/golang/curves/bw6761/g2/msm.go
@@ -5,17 +5,21 @@ package g2
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func G2GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func G2GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func G2Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bw6761/msm/msm.go
+++ b/wrappers/golang/curves/bw6761/msm/msm.go
@@ -5,17 +5,21 @@ package msm
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/bw6761/ntt/ntt.go
+++ b/wrappers/golang/curves/bw6761/ntt/ntt.go
@@ -5,14 +5,17 @@ package ntt
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
 	bw6_761 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761"
 )
 
+import (
+	"unsafe"
+)
+
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](scalars, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)
@@ -35,6 +38,17 @@ func GetDefaultNttConfig() core.NTTConfig[[bw6_761.SCALAR_LIMBS]uint32] {
 	}
 
 	return core.GetDefaultNTTConfig(cosetGen)
+}
+
+func GetDefaultNttConfigForDevice(device int) core.NTTConfig[[bw6_761.SCALAR_LIMBS]uint32] {
+	cosetGenField := bw6_761.ScalarField{}
+	cosetGenField.One()
+	var cosetGen [bw6_761.SCALAR_LIMBS]uint32
+	for i, v := range cosetGenField.GetLimbs() {
+		cosetGen[i] = v
+	}
+
+	return core.GetDefaultNttConfigForDevice(cosetGen, device)
 }
 
 func InitDomain(primitiveRoot bw6_761.ScalarField, ctx cr.DeviceContext, fastTwiddles bool) core.IcicleError {

--- a/wrappers/golang/curves/bw6761/scalar_field.go
+++ b/wrappers/golang/curves/bw6761/scalar_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/curves/bw6761/tests/base_field_test.go
+++ b/wrappers/golang/curves/bw6761/tests/base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bw6_761 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bw6761/tests/curve_test.go
+++ b/wrappers/golang/curves/bw6761/tests/curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bw6_761 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestAffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bw6761/tests/ecntt_test.go
+++ b/wrappers/golang/curves/bw6761/tests/ecntt_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestECNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	points := bw6_761.GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {

--- a/wrappers/golang/curves/bw6761/tests/g2_curve_test.go
+++ b/wrappers/golang/curves/bw6761/tests/g2_curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestG2AffineZero(t *testing.T) {

--- a/wrappers/golang/curves/bw6761/tests/g2_g2base_field_test.go
+++ b/wrappers/golang/curves/bw6761/tests/g2_g2base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	bw6_761 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761/g2"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bw6761/tests/ntt_test.go
+++ b/wrappers/golang/curves/bw6761/tests/ntt_test.go
@@ -54,7 +54,7 @@ func testAgainstGnarkCryptoNttGnarkTypes(size int, scalarsFr core.HostSlice[fr.E
 	return reflect.DeepEqual(scalarsFr, outputAsFr)
 }
 func TestNTTGetDefaultConfig(t *testing.T) {
-	actual := ntt.GetDefaultNttConfig()
+	actual := ntt.GetDefaultNttConfigForDevice(0)
 	expected := test_helpers.GenerateLimbOne(int(bw6_761.SCALAR_LIMBS))
 	assert.Equal(t, expected, actual.CosetGen[:])
 
@@ -70,7 +70,7 @@ func TestInitDomain(t *testing.T) {
 }
 
 func TestNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bw6_761.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{4, largestTestSize} {
@@ -90,7 +90,7 @@ func TestNtt(t *testing.T) {
 	}
 }
 func TestNttFrElement(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := make([]fr.Element, 4)
 	var x fr.Element
 	for i := 0; i < 4; i++ {
@@ -116,7 +116,7 @@ func TestNttFrElement(t *testing.T) {
 }
 
 func TestNttDeviceAsync(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := bw6_761.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {
@@ -125,6 +125,7 @@ func TestNttDeviceAsync(t *testing.T) {
 				testSize := 1 << size
 				scalarsCopy := core.HostSliceFromElements[bw6_761.ScalarField](scalars[:testSize])
 
+				cr.SetDevice(cfg.Ctx.GetDeviceId())
 				stream, _ := cr.CreateStream()
 
 				cfg.Ordering = v
@@ -150,7 +151,7 @@ func TestNttDeviceAsync(t *testing.T) {
 }
 
 func TestNttBatch(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	largestBatchSize := 100
 	scalars := bw6_761.GenerateScalars(1 << largestTestSize * largestBatchSize)
 

--- a/wrappers/golang/curves/bw6761/tests/polynomial_test.go
+++ b/wrappers/golang/curves/bw6761/tests/polynomial_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bw6_761 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761"
-
 	// "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761/ntt"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761/polynomial"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761/vecOps"
@@ -36,7 +35,7 @@ func vecOp(a, b bw6_761.ScalarField, op core.VecOps) bw6_761.ScalarField {
 	bhost := core.HostSliceWithValue(b, 1)
 	out := make(core.HostSlice[bw6_761.ScalarField], 1)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 	vecOps.VecOp(ahost, bhost, out, cfg, op)
 	return out[0]
 }

--- a/wrappers/golang/curves/bw6761/tests/scalar_field_test.go
+++ b/wrappers/golang/curves/bw6761/tests/scalar_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	bw6_761 "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/bw6761"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/bw6761/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bw6761/tests/vec_ops_test.go
@@ -46,7 +46,7 @@ func TestBw6_761Transpose(t *testing.T) {
 	out := make(core.HostSlice[bw6_761.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bw6_761.ScalarField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bw6761/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/bw6761/tests/vec_ops_test.go
@@ -23,7 +23,7 @@ func TestBw6_761VecOps(t *testing.T) {
 	out2 := make(core.HostSlice[bw6_761.ScalarField], testSize)
 	out3 := make(core.HostSlice[bw6_761.ScalarField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestBw6_761Transpose(t *testing.T) {
 	out := make(core.HostSlice[bw6_761.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[bw6_761.ScalarField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/bw6761/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/bw6761/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/bw6761/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/grumpkin/msm/msm.go
+++ b/wrappers/golang/curves/grumpkin/msm/msm.go
@@ -5,17 +5,21 @@ package msm
 import "C"
 
 import (
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 func GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/curves/grumpkin/scalar_field.go
+++ b/wrappers/golang/curves/grumpkin/scalar_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/curves/grumpkin/tests/base_field_test.go
+++ b/wrappers/golang/curves/grumpkin/tests/base_field_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	grumpkin "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/grumpkin"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/grumpkin/tests/curve_test.go
+++ b/wrappers/golang/curves/grumpkin/tests/curve_test.go
@@ -1,11 +1,10 @@
 package tests
 
 import (
-	"testing"
-
 	grumpkin "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/grumpkin"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestAffineZero(t *testing.T) {

--- a/wrappers/golang/curves/grumpkin/tests/scalar_field_test.go
+++ b/wrappers/golang/curves/grumpkin/tests/scalar_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	grumpkin "github.com/ingonyama-zk/icicle/v2/wrappers/golang/curves/grumpkin"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/curves/grumpkin/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/grumpkin/tests/vec_ops_test.go
@@ -23,7 +23,7 @@ func TestGrumpkinVecOps(t *testing.T) {
 	out2 := make(core.HostSlice[grumpkin.ScalarField], testSize)
 	out3 := make(core.HostSlice[grumpkin.ScalarField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestGrumpkinTranspose(t *testing.T) {
 	out := make(core.HostSlice[grumpkin.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[grumpkin.ScalarField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/grumpkin/tests/vec_ops_test.go
+++ b/wrappers/golang/curves/grumpkin/tests/vec_ops_test.go
@@ -46,7 +46,7 @@ func TestGrumpkinTranspose(t *testing.T) {
 	out := make(core.HostSlice[grumpkin.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[grumpkin.ScalarField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/curves/grumpkin/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/grumpkin/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/curves/grumpkin/vecOps/vec_ops.go
+++ b/wrappers/golang/curves/grumpkin/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/fields/babybear/extension/extension_field.go
+++ b/wrappers/golang/fields/babybear/extension/extension_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/fields/babybear/extension/ntt/ntt.go
+++ b/wrappers/golang/fields/babybear/extension/ntt/ntt.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](scalars, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/fields/babybear/extension/vecOps/vec_ops.go
+++ b/wrappers/golang/fields/babybear/extension/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/fields/babybear/extension/vecOps/vec_ops.go
+++ b/wrappers/golang/fields/babybear/extension/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/fields/babybear/scalar_field.go
+++ b/wrappers/golang/fields/babybear/scalar_field.go
@@ -6,10 +6,9 @@ import "C"
 import (
 	"encoding/binary"
 	"fmt"
-	"unsafe"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	cr "github.com/ingonyama-zk/icicle/v2/wrappers/golang/cuda_runtime"
+	"unsafe"
 )
 
 const (

--- a/wrappers/golang/fields/babybear/tests/extension_field_test.go
+++ b/wrappers/golang/fields/babybear/tests/extension_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	babybear_extension "github.com/ingonyama-zk/icicle/v2/wrappers/golang/fields/babybear/extension"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/fields/babybear/tests/extension_vec_ops_test.go
+++ b/wrappers/golang/fields/babybear/tests/extension_vec_ops_test.go
@@ -46,7 +46,7 @@ func TestBabybear_extensionTranspose(t *testing.T) {
 	out := make(core.HostSlice[babybear_extension.ExtensionField], rowSize*columnSize)
 	out2 := make(core.HostSlice[babybear_extension.ExtensionField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/fields/babybear/tests/extension_vec_ops_test.go
+++ b/wrappers/golang/fields/babybear/tests/extension_vec_ops_test.go
@@ -23,7 +23,7 @@ func TestBabybear_extensionVecOps(t *testing.T) {
 	out2 := make(core.HostSlice[babybear_extension.ExtensionField], testSize)
 	out3 := make(core.HostSlice[babybear_extension.ExtensionField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestBabybear_extensionTranspose(t *testing.T) {
 	out := make(core.HostSlice[babybear_extension.ExtensionField], rowSize*columnSize)
 	out2 := make(core.HostSlice[babybear_extension.ExtensionField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/fields/babybear/tests/ntt_test.go
+++ b/wrappers/golang/fields/babybear/tests/ntt_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNTTGetDefaultConfig(t *testing.T) {
-	actual := ntt.GetDefaultNttConfig()
+	actual := ntt.GetDefaultNttConfigForDevice(0)
 	expected := test_helpers.GenerateLimbOne(int(babybear.SCALAR_LIMBS))
 	assert.Equal(t, expected, actual.CosetGen[:])
 
@@ -28,7 +28,7 @@ func TestInitDomain(t *testing.T) {
 }
 
 func TestNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := babybear.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{4, largestTestSize} {
@@ -47,7 +47,7 @@ func TestNtt(t *testing.T) {
 }
 
 func TestNttDeviceAsync(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := babybear.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {
@@ -56,6 +56,7 @@ func TestNttDeviceAsync(t *testing.T) {
 				testSize := 1 << size
 				scalarsCopy := core.HostSliceFromElements[babybear.ScalarField](scalars[:testSize])
 
+				cr.SetDevice(cfg.Ctx.GetDeviceId())
 				stream, _ := cr.CreateStream()
 
 				cfg.Ordering = v
@@ -79,7 +80,7 @@ func TestNttDeviceAsync(t *testing.T) {
 }
 
 func TestNttBatch(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	largestBatchSize := 100
 	scalars := babybear.GenerateScalars(1 << largestTestSize * largestBatchSize)
 

--- a/wrappers/golang/fields/babybear/tests/polynomial_test.go
+++ b/wrappers/golang/fields/babybear/tests/polynomial_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	babybear "github.com/ingonyama-zk/icicle/v2/wrappers/golang/fields/babybear"
-
 	// "github.com/ingonyama-zk/icicle/v2/wrappers/golang/fields/babybear/ntt"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/fields/babybear/polynomial"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/fields/babybear/vecOps"
@@ -36,7 +35,7 @@ func vecOp(a, b babybear.ScalarField, op core.VecOps) babybear.ScalarField {
 	bhost := core.HostSliceWithValue(b, 1)
 	out := make(core.HostSlice[babybear.ScalarField], 1)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 	vecOps.VecOp(ahost, bhost, out, cfg, op)
 	return out[0]
 }

--- a/wrappers/golang/fields/babybear/tests/scalar_field_test.go
+++ b/wrappers/golang/fields/babybear/tests/scalar_field_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
-	"testing"
-
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/core"
 	babybear "github.com/ingonyama-zk/icicle/v2/wrappers/golang/fields/babybear"
 	"github.com/ingonyama-zk/icicle/v2/wrappers/golang/test_helpers"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 const (

--- a/wrappers/golang/fields/babybear/tests/vec_ops_test.go
+++ b/wrappers/golang/fields/babybear/tests/vec_ops_test.go
@@ -23,7 +23,7 @@ func TestBabybearVecOps(t *testing.T) {
 	out2 := make(core.HostSlice[babybear.ScalarField], testSize)
 	out3 := make(core.HostSlice[babybear.ScalarField], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func TestBabybearTranspose(t *testing.T) {
 	out := make(core.HostSlice[babybear.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[babybear.ScalarField], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/fields/babybear/tests/vec_ops_test.go
+++ b/wrappers/golang/fields/babybear/tests/vec_ops_test.go
@@ -46,7 +46,7 @@ func TestBabybearTranspose(t *testing.T) {
 	out := make(core.HostSlice[babybear.ScalarField], rowSize*columnSize)
 	out2 := make(core.HostSlice[babybear.ScalarField], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/fields/babybear/vecOps/vec_ops.go
+++ b/wrappers/golang/fields/babybear/vecOps/vec_ops.go
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/fields/babybear/vecOps/vec_ops.go
+++ b/wrappers/golang/fields/babybear/vecOps/vec_ops.go
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError) {
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/internal/generator/ecntt/templates/ecntt.go.tmpl
+++ b/wrappers/golang/internal/generator/ecntt/templates/ecntt.go.tmpl
@@ -10,6 +10,7 @@ import (
 )
 
 func ECNtt[T any](points core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	pointsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](points, cfg, results)
 
 	cPoints := (*C.projective_t)(pointsPointer)

--- a/wrappers/golang/internal/generator/ecntt/templates/ecntt_test.go.tmpl
+++ b/wrappers/golang/internal/generator/ecntt/templates/ecntt_test.go.tmpl
@@ -11,7 +11,7 @@ import (
 )
 
 func TestECNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	points := {{.Curve}}.GenerateProjectivePoints(1 << largestTestSize)
 
 	for _, size := range []int{4, 5, 6, 7, 8} {

--- a/wrappers/golang/internal/generator/msm/templates/msm.go.tmpl
+++ b/wrappers/golang/internal/generator/msm/templates/msm.go.tmpl
@@ -14,7 +14,12 @@ func {{.CurvePrefix}}GetDefaultMSMConfig() core.MSMConfig {
 	return core.GetDefaultMSMConfig()
 }
 
+func {{.CurvePrefix}}GetDefaultMSMConfigForDevice(device int) core.MSMConfig {
+	return core.GetDefaultMSMConfigForDevice(device)
+}
+
 func {{.CurvePrefix}}Msm(scalars core.HostOrDeviceSlice, points core.HostOrDeviceSlice, cfg *core.MSMConfig, results core.HostOrDeviceSlice) cr.CudaError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, pointsPointer, resultsPointer, size, cfgPointer := core.MsmCheck(scalars, points, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)

--- a/wrappers/golang/internal/generator/msm/templates/msm_test.go.tmpl
+++ b/wrappers/golang/internal/generator/msm/templates/msm_test.go.tmpl
@@ -157,7 +157,7 @@ func convertIcicleG2AffineToG2Affine(iciclePoints []g2.G2Affine) []{{toPackage .
 }{{end}}{{end}}
 
 func TestMSM{{.CurvePrefix}}(t *testing.T) {
-	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfig()
+	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfigForDevice(0)
 	cfg.IsAsync = true
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
@@ -165,6 +165,7 @@ func TestMSM{{.CurvePrefix}}(t *testing.T) {
 		scalars := icicle{{capitalize .Curve}}.GenerateScalars(size)
 		points := {{if ne .CurvePrefix "G2"}}icicle{{capitalize .Curve}}{{else}}g2{{end}}.{{.CurvePrefix}}GenerateAffinePoints(size)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		stream, _ := cr.CreateStream()
 		var p {{if ne .CurvePrefix "G2"}}icicle{{capitalize .Curve}}{{else}}g2{{end}}.{{.CurvePrefix}}Projective
 		var out core.DeviceSlice
@@ -187,7 +188,7 @@ func TestMSM{{.CurvePrefix}}(t *testing.T) {
 }
 {{if ne .GnarkImport "" -}}
 func TestMSM{{if eq .CurvePrefix "G2"}}G2{{end}}GnarkCryptoTypes(t *testing.T) {
-	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfig()
+	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{3} {
 		size := 1 << power
 
@@ -202,6 +203,7 @@ func TestMSM{{if eq .CurvePrefix "G2"}}G2{{end}}GnarkCryptoTypes(t *testing.T) {
 		pointsGnark := convertIcicle{{$isNotBW6 := ne .Curve "bw6_761"}}{{$isG2 := eq .CurvePrefix "G2"}}{{if and $isNotBW6 $isG2}}G2{{end}}AffineTo{{if eq .CurvePrefix "G2"}}G2{{else}}G1{{end}}Affine(points)
 		pointsHost := (core.HostSlice[{{toPackage .GnarkImport}}.{{if eq .CurvePrefix "G2"}}G2{{else}}G1{{end}}Affine])(pointsGnark)
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p {{if ne .CurvePrefix "G2"}}icicle{{capitalize .Curve}}{{else}}g2{{end}}.{{.CurvePrefix}}Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -221,7 +223,7 @@ func TestMSM{{if eq .CurvePrefix "G2"}}G2{{end}}GnarkCryptoTypes(t *testing.T) {
 }
 {{end}}
 func TestMSM{{.CurvePrefix}}Batch(t *testing.T) {
-	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfig()
+	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
 			size := 1 << power
@@ -234,6 +236,7 @@ func TestMSM{{.CurvePrefix}}Batch(t *testing.T) {
 			_, e := out.Malloc(batchSize*p.Size(), p.Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for Projective results failed")
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			e = {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}Msm(scalars, points, &cfg, out)
 			assert.Equal(t, e, cr.CudaSuccess, "Msm failed")
 			outHost := make(core.HostSlice[{{if ne .CurvePrefix "G2"}}icicle{{capitalize .Curve}}{{else}}g2{{end}}.{{.CurvePrefix}}Projective], batchSize)
@@ -252,7 +255,7 @@ func TestMSM{{.CurvePrefix}}Batch(t *testing.T) {
 }
 
 func TestPrecomputeBase{{.CurvePrefix}}(t *testing.T) {
-	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfig()
+	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfigForDevice(0)
 	const precomputeFactor = 8
 	for _, power := range []int{10, 16} {
 		for _, batchSize := range []int{1, 3, 16} {
@@ -261,6 +264,7 @@ func TestPrecomputeBase{{.CurvePrefix}}(t *testing.T) {
 			scalars := icicle{{capitalize .Curve}}.GenerateScalars(totalSize)
 			points := {{if ne .CurvePrefix "G2"}}icicle{{capitalize .Curve}}{{else}}g2{{end}}.{{.CurvePrefix}}GenerateAffinePoints(totalSize)
 
+			cr.SetDevice(cfg.Ctx.GetDeviceId())
 			var precomputeOut core.DeviceSlice
 			_, e := precomputeOut.Malloc(points[0].Size()*points.Len()*int(precomputeFactor), points[0].Size())
 			assert.Equal(t, e, cr.CudaSuccess, "Allocating bytes on device for PrecomputeBases results failed")
@@ -294,7 +298,7 @@ func TestPrecomputeBase{{.CurvePrefix}}(t *testing.T) {
 }
 
 func TestMSM{{.CurvePrefix}}SkewedDistribution(t *testing.T) {
-	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfig()
+	cfg := {{if eq .CurvePrefix "G2"}}g2{{else}}msm{{end}}.{{.CurvePrefix}}GetDefaultMSMConfigForDevice(0)
 	for _, power := range []int{2, 3, 4, 5, 6, 7, 8, 10, 18} {
 		size := 1 << power
 
@@ -307,6 +311,7 @@ func TestMSM{{.CurvePrefix}}SkewedDistribution(t *testing.T) {
 			points[i].Zero()
 		}
 
+		cr.SetDevice(cfg.Ctx.GetDeviceId())
 		var p {{if ne .CurvePrefix "G2"}}icicle{{capitalize .Curve}}{{else}}g2{{end}}.{{.CurvePrefix}}Projective
 		var out core.DeviceSlice
 		_, e := out.Malloc(p.Size(), p.Size())
@@ -325,7 +330,6 @@ func TestMSM{{.CurvePrefix}}SkewedDistribution(t *testing.T) {
 
 func TestMSM{{.CurvePrefix}}MultiDevice(t *testing.T) {
 	numDevices, _ := cr.GetDeviceCount()
-	numDevices = 1 // TODO remove when test env is fixed
 	fmt.Println("There are ", numDevices, " devices available")
 	orig_device, _ := cr.GetDevice()
 	wg := sync.WaitGroup{}

--- a/wrappers/golang/internal/generator/ntt/templates/ntt.go.tmpl
+++ b/wrappers/golang/internal/generator/ntt/templates/ntt.go.tmpl
@@ -16,6 +16,7 @@ import (
 ){{end}}
 
 func Ntt[T any](scalars core.HostOrDeviceSlice, dir core.NTTDir, cfg *core.NTTConfig[T], results core.HostOrDeviceSlice) core.IcicleError {
+	cr.SetDevice(cfg.Ctx.GetDeviceId())
 	scalarsPointer, resultsPointer, size, cfgPointer := core.NttCheck[T](scalars, cfg, results)
 
 	cScalars := (*C.scalar_t)(scalarsPointer)
@@ -38,6 +39,17 @@ func GetDefaultNttConfig() core.NTTConfig[[{{.Field}}.{{toConst .FieldPrefix}}LI
 	}
 
 	return core.GetDefaultNTTConfig(cosetGen)
+}
+
+func GetDefaultNttConfigForDevice(device int) core.NTTConfig[[{{.Field}}.{{toConst .FieldPrefix}}LIMBS]uint32] {
+	cosetGenField := {{.Field}}.{{.FieldPrefix}}Field{}
+	cosetGenField.One()
+	var cosetGen [{{.Field}}.{{toConst .FieldPrefix}}LIMBS]uint32
+	for i, v := range cosetGenField.GetLimbs() {
+		cosetGen[i] = v
+	}
+
+	return core.GetDefaultNttConfigForDevice(cosetGen, device)
 }
 
 func InitDomain(primitiveRoot {{.Field}}.{{.FieldPrefix}}Field, ctx cr.DeviceContext, fastTwiddles bool) core.IcicleError {

--- a/wrappers/golang/internal/generator/ntt/templates/ntt_test.go.tmpl
+++ b/wrappers/golang/internal/generator/ntt/templates/ntt_test.go.tmpl
@@ -61,7 +61,7 @@ func testAgainstGnarkCryptoNttGnarkTypes(size int, scalarsFr core.HostSlice[fr.E
 {{end -}}
 
 func TestNTTGetDefaultConfig(t *testing.T) {
-	actual := ntt.GetDefaultNttConfig()
+	actual := ntt.GetDefaultNttConfigForDevice(0)
 	expected := test_helpers.GenerateLimbOne(int({{.Field}}.{{toConst .FieldPrefix}}LIMBS))
 	assert.Equal(t, expected, actual.CosetGen[:])
 
@@ -77,7 +77,7 @@ func TestInitDomain(t *testing.T) {
 }
 
 func TestNtt(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := {{.Field}}.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{4, largestTestSize} {
@@ -100,7 +100,7 @@ func TestNtt(t *testing.T) {
 }
 {{if ne .GnarkImport "" -}}
 func TestNttFrElement(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := make([]fr.Element, 4)
 	var x fr.Element
 	for i := 0; i < 4; i++ {
@@ -126,7 +126,7 @@ func TestNttFrElement(t *testing.T) {
 }
 {{end}}
 func TestNttDeviceAsync(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	scalars := {{.Field}}.GenerateScalars(1 << largestTestSize)
 
 	for _, size := range []int{1, 10, largestTestSize} {
@@ -135,6 +135,7 @@ func TestNttDeviceAsync(t *testing.T) {
 				testSize := 1 << size
 				scalarsCopy := core.HostSliceFromElements[{{.Field}}.{{.FieldPrefix}}Field](scalars[:testSize])
 
+				cr.SetDevice(cfg.Ctx.GetDeviceId())
 				stream, _ := cr.CreateStream()
 
 				cfg.Ordering = v
@@ -162,7 +163,7 @@ func TestNttDeviceAsync(t *testing.T) {
 }
 
 func TestNttBatch(t *testing.T) {
-	cfg := ntt.GetDefaultNttConfig()
+	cfg := ntt.GetDefaultNttConfigForDevice(0)
 	largestBatchSize := 100
 	scalars := {{.Field}}.GenerateScalars(1 << largestTestSize * largestBatchSize)
 

--- a/wrappers/golang/internal/generator/polynomial/templates/polynomial_test.go.tmpl
+++ b/wrappers/golang/internal/generator/polynomial/templates/polynomial_test.go.tmpl
@@ -35,7 +35,7 @@ func vecOp(a, b {{.Field}}.{{.FieldPrefix}}Field, op core.VecOps) {{.Field}}.{{.
 	bhost := core.HostSliceWithValue(b, 1)
 	out := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], 1)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 	vecOps.VecOp(ahost, bhost, out, cfg, op)
 	return out[0]
 }

--- a/wrappers/golang/internal/generator/vecOps/templates/vec_ops.go.tmpl
+++ b/wrappers/golang/internal/generator/vecOps/templates/vec_ops.go.tmpl
@@ -12,6 +12,7 @@ import (
 )
 
 func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.VecOps) (ret cr.CudaError) {
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	aPointer, bPointer, outPointer, cfgPointer, size := core.VecOpCheck(a, b, out, &config)
 
 	cA := (*C.scalar_t)(aPointer)
@@ -33,6 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
+	cr.SetDevice(config.Ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 	
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/internal/generator/vecOps/templates/vec_ops.go.tmpl
+++ b/wrappers/golang/internal/generator/vecOps/templates/vec_ops.go.tmpl
@@ -34,7 +34,7 @@ func VecOp(a, b, out core.HostOrDeviceSlice, config core.VecOpsConfig, op core.V
 }
 
 func TransposeMatrix(in, out core.HostOrDeviceSlice, columnSize, rowSize int, ctx cr.DeviceContext, onDevice, isAsync bool) (ret core.IcicleError){
-	cr.SetDevice(config.Ctx.GetDeviceId())
+	cr.SetDevice(ctx.GetDeviceId())
 	core.TransposeCheck(in, out, onDevice)
 	
 	cIn := (*C.scalar_t)(in.AsUnsafePointer())

--- a/wrappers/golang/internal/generator/vecOps/templates/vec_ops_test.go.tmpl
+++ b/wrappers/golang/internal/generator/vecOps/templates/vec_ops_test.go.tmpl
@@ -23,7 +23,7 @@ func Test{{capitalize .Field}}VecOps(t *testing.T) {
 	out2 := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], testSize)
 	out3 := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], testSize)
 
-	cfg := core.DefaultVecOpsConfig()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.VecOp(a, b, out, cfg, core.Add)
 	vecOps.VecOp(out, b, out2, cfg, core.Sub)
@@ -46,7 +46,7 @@ func Test{{capitalize .Field}}Transpose(t *testing.T) {
 	out := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], rowSize*columnSize)
 	out2 := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], rowSize*columnSize)
 
-	ctx, _ := cr.GetDefaultDeviceContext()
+	cfg := core.DefaultVecOpsConfigForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)

--- a/wrappers/golang/internal/generator/vecOps/templates/vec_ops_test.go.tmpl
+++ b/wrappers/golang/internal/generator/vecOps/templates/vec_ops_test.go.tmpl
@@ -46,7 +46,7 @@ func Test{{capitalize .Field}}Transpose(t *testing.T) {
 	out := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], rowSize*columnSize)
 	out2 := make(core.HostSlice[{{.Field}}.{{.FieldPrefix}}Field], rowSize*columnSize)
 
-	cfg := core.DefaultVecOpsConfigForDevice(0)
+	ctx, _ := cr.GetDefaultContextForDevice(0)
 
 	vecOps.TransposeMatrix(matrix, out, columnSize, rowSize, ctx, onDevice, isAsync)
 	vecOps.TransposeMatrix(out, out2, rowSize, columnSize, ctx, onDevice, isAsync)


### PR DESCRIPTION
## Describe the changes

This PR fixes the non deterministic crashes when running tests on multidevice.
The errors come from the fact getDevice() will return the current active device, which might not be the one you want if you're running multidevice tests concurrently.
GetDefaultDeviceContext uses GetDevice and the different getDefaultConfigs functions use GetDefaultDeviceContext which means when you get the default config for a primitive it might not be on the right device.
I wrote GetDefaultContextForDevice(device int) and a function for each config that returns a config on the given device.
I also added cr.setDevice(cfg.Ctx.GetDeviceId) where it was needed (before creating a stream or a slice, or before a Check)

## Linked Issues

Resolves #
