### PR TITLE
Allow overriding compiler's chosen GPU arch via cmake

### DIFF
--- a/icicle/cmake/Common.cmake
+++ b/icicle/cmake/Common.cmake
@@ -14,12 +14,12 @@ endfunction()
 function(set_gpu_env)
     # add the target cuda architectures
     # each additional architecture increases the compilation time and output file size
-	if(DEFINED CUDA_ARCH) # user defined arch takes priority
-	    set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH})
-	elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0") # otherwise, use native to detect GPU arch
-	    set(CMAKE_CUDA_ARCHITECTURES native)
+    if(DEFINED CUDA_ARCH) # user defined arch takes priority
+        set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH} PARENT_SCOPE)
+    elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0") # otherwise, use native to detect GPU arch
+        set(CMAKE_CUDA_ARCHITECTURES native PARENT_SCOPE)
     else()
-	    find_program(_nvidia_smi "nvidia-smi")
+        find_program(_nvidia_smi "nvidia-smi")
 
     if(_nvidia_smi)
         set(DETECT_GPU_COUNT_NVIDIA_SMI 0)

--- a/icicle/cmake/Common.cmake
+++ b/icicle/cmake/Common.cmake
@@ -14,10 +14,12 @@ endfunction()
 function(set_gpu_env)
     # add the target cuda architectures
     # each additional architecture increases the compilation time and output file size
-    if(${CMAKE_VERSION} VERSION_LESS "3.24.0")
-    set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH} PARENT_SCOPE)
+	if(DEFINED CUDA_ARCH) # user defined arch takes priority
+	    set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH})
+	elseif(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0") # otherwise, use native to detect GPU arch
+	    set(CMAKE_CUDA_ARCHITECTURES native)
     else()
-    find_program(_nvidia_smi "nvidia-smi")
+	    find_program(_nvidia_smi "nvidia-smi")
 
     if(_nvidia_smi)
         set(DETECT_GPU_COUNT_NVIDIA_SMI 0)


### PR DESCRIPTION
## Describe the changes

This PR modifies icicle/cmake/Common.cmake to set CMAKE_CUDA_ARCHITECTURES to ${CUDA_ARCH} if the user defines the arch, to set CMAKE_CUDA_ARCHITECTURES to native if the cmake version is greater than or equal to 3.24.0. This change has been successfully tested with cmake 3.22.0 and 3.25.2.

## Linked Issues

Resolves #167. 
