### PR TITLE
Feat/vlad/signed msm

### DIFF
--- a/icicle/include/msm/msm.cuh
+++ b/icicle/include/msm/msm.cuh
@@ -79,7 +79,7 @@ namespace msm {
                                  *   non-blocking and you'd need to synchronize it explicitly by running
                                  *   `cudaStreamSynchronize` or `cudaDeviceSynchronize`. If set to false, the MSM
                                  *   function will block the current CPU thread. */
-    bool is_signed; /**< Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+    bool is_signed; /**< Whether to run the MSM using the signed digit trick. If set to true, the MSM function will use
                      *   about half as much memory and will also be faster
                      *   Default value: false. */
   };

--- a/icicle/include/msm/msm.cuh
+++ b/icicle/include/msm/msm.cuh
@@ -79,6 +79,9 @@ namespace msm {
                                  *   non-blocking and you'd need to synchronize it explicitly by running
                                  *   `cudaStreamSynchronize` or `cudaDeviceSynchronize`. If set to false, the MSM
                                  *   function will block the current CPU thread. */
+    bool is_signed;              /**< Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+                                 *   about half as much memory and will also be faster
+                                 *   Default value: false. */
   };
 
   /**
@@ -103,6 +106,7 @@ namespace msm {
       false, // are_results_on_device
       false, // is_big_triangle
       false, // is_async
+      false, // is_signed
     };
     return config;
   }

--- a/icicle/include/msm/msm.cuh
+++ b/icicle/include/msm/msm.cuh
@@ -79,9 +79,9 @@ namespace msm {
                                  *   non-blocking and you'd need to synchronize it explicitly by running
                                  *   `cudaStreamSynchronize` or `cudaDeviceSynchronize`. If set to false, the MSM
                                  *   function will block the current CPU thread. */
-    bool is_signed;              /**< Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
-                                 *   about half as much memory and will also be faster
-                                 *   Default value: false. */
+    bool is_signed; /**< Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+                     *   about half as much memory and will also be faster
+                     *   Default value: false. */
   };
 
   /**

--- a/icicle/src/msm/msm.cu
+++ b/icicle/src/msm/msm.cu
@@ -216,7 +216,6 @@ namespace msm {
       bool negate_point = false;
       bool negate_chunk;
       unsigned msm_index = tid / msm_size;
-      const S& scalar = scalars[tid];
       // if field bit count divides c we need to negate both the point and scalar if the msb is set to avoid overflow
       if (S::NBITS % c == 0){
         if (scalars[tid].get_scalar_digit(S::NBITS - 1, 1)){
@@ -509,7 +508,7 @@ namespace msm {
       unsigned input_indexes_count = nof_scalars * total_bms_per_msm;
 
       unsigned bm_bitsize = (unsigned)ceil(std::log2(nof_bms_per_msm));
-      unsigned msm_log_size = (unsigned)ceil(std::log2(nof_points));
+      unsigned msm_log_size = (unsigned)ceil(std::log2(nof_points * precompute_factor));
 
       unsigned* bucket_indices;
       unsigned* point_indices;

--- a/icicle/src/msm/msm.cu
+++ b/icicle/src/msm/msm.cu
@@ -939,6 +939,12 @@ namespace msm {
     }
     bool is_signed = (c == 1) ? false : config.is_signed;
 
+    if (config.is_signed || !config.is_big_triangle) {
+        THROW_ICICLE_ERR(
+          IcicleError_t::InvalidArgument,
+          "bucket_method_msm: signed msm currently only works with big triangle");
+      }
+
     return CHK_STICKY(bucket_method_msm(
       bitsize, c, scalars, points, config.batch_size, msm_size,
       (config.points_size == 0) ? msm_size : config.points_size, results, config.are_scalars_on_device,

--- a/icicle/src/msm/msm.cu
+++ b/icicle/src/msm/msm.cu
@@ -218,13 +218,13 @@ namespace msm {
       unsigned msm_index = tid / msm_size;
       const S& scalar = scalars[tid];
       // if field bit count divides c we need to negate both the point and scalar if the msb is set to avoid overflow
+      if (S::NBITS % c == 0){
+        if (scalars[tid].get_scalar_digit(S::NBITS - 1, 1)){
+          negate_point = true;
+        }
+      }
 
-      // if (S::NBITS % c == 0){
-      //   if (scalar.get_scalar_digit(S::NBITS, 1)){
-      //     scalar = S::neg(scalar);
-      //     negate_point = true;
-      //   }
-      // }
+      const S& scalar = negate_point ? S::neg(scalars[tid]) : scalars[tid];
 
       for (unsigned bm = 0; bm < nof_bms; bm++) {
         const unsigned precomputed_index = bm / precomputed_bms_stride;

--- a/icicle/src/msm/msm.cu
+++ b/icicle/src/msm/msm.cu
@@ -946,7 +946,7 @@ namespace msm {
     }
     bool is_signed = (c == 1) ? false : config.is_signed;
 
-    if (config.is_signed || !config.is_big_triangle) {
+    if (config.is_signed && !config.is_big_triangle) {
       THROW_ICICLE_ERR(
         IcicleError_t::InvalidArgument, "bucket_method_msm: signed msm currently only works with big triangle");
     }

--- a/icicle/src/msm/msm.cu
+++ b/icicle/src/msm/msm.cu
@@ -255,8 +255,8 @@ namespace msm {
         point_indices[current_index] =
           tid % points_size + points_size * precomputed_index; // the point index is saved for later
         if (negate_chunk)
-          point_indices[current_index] +=
-            1 << msm_log_size; // we add a sign bit to know wether to add P or -P during accumulation
+          point_indices[current_index] |=
+            1 << msm_log_size; // we add a sign bit to know whether to add P or -P during accumulation
       }
     }
     template <typename S>

--- a/wrappers/golang/core/msm.go
+++ b/wrappers/golang/core/msm.go
@@ -55,7 +55,7 @@ type MSMConfig struct {
 	/// If set to `false`, the MSM function will block the current CPU thread.
 	IsAsync bool
 
-	/// Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+	/// Whether to run the MSM using the signed digit trick. If set to true, the MSM function will use
 	/// about half as much memory and will also be faster
 	IsSigned bool
 }

--- a/wrappers/golang/core/msm.go
+++ b/wrappers/golang/core/msm.go
@@ -54,6 +54,10 @@ type MSMConfig struct {
 	/// and you'd need to synchronize it explicitly by running `cudaStreamSynchronize` or `cudaDeviceSynchronize`.
 	/// If set to `false`, the MSM function will block the current CPU thread.
 	IsAsync bool
+
+	/// Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+	/// about half as much memory and will also be faster
+	IsSigned bool
 }
 
 func GetDefaultMSMConfig() MSMConfig {
@@ -73,6 +77,7 @@ func GetDefaultMSMConfig() MSMConfig {
 		false, // areResultsOnDevice
 		false, // IsBigTriangle
 		false, // IsAsync
+		false, //IsSigned
 	}
 }
 

--- a/wrappers/golang/core/msm_test.go
+++ b/wrappers/golang/core/msm_test.go
@@ -26,6 +26,7 @@ func TestMSMDefaultConfig(t *testing.T) {
 		false, // areResultsOnDevice
 		false, // IsBigTriangle
 		false, // IsAsync
+		false, // IsSigned
 	}
 
 	actual := GetDefaultMSMConfig()

--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -61,7 +61,7 @@ pub struct MSMConfig<'a> {
     /// If set to `false`, the MSM function will block the current CPU thread.
     pub is_async: bool,
 
-    /// Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+    /// Whether to run the MSM using the signed digit trick. If set to true, the MSM function will use
     /// about half as much memory and will also be faster
     pub is_signed: bool,
 }

--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -60,6 +60,10 @@ pub struct MSMConfig<'a> {
     /// and you'd need to synchronize it explicitly by running `cudaStreamSynchronize` or `cudaDeviceSynchronize`.
     /// If set to `false`, the MSM function will block the current CPU thread.
     pub is_async: bool,
+
+    /// Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
+	/// about half as much memory and will also be faster
+	pub is_signed: bool,
 }
 
 impl<'a> Default for MSMConfig<'a> {
@@ -85,6 +89,7 @@ impl<'a> MSMConfig<'a> {
             are_results_on_device: false,
             is_big_triangle: false,
             is_async: false,
+            is_signed: false,
         }
     }
 }

--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -62,8 +62,8 @@ pub struct MSMConfig<'a> {
     pub is_async: bool,
 
     /// Whether to run the MSM usign the signed digit trick. If set to true, the MSM function will use
-	/// about half as much memory and will also be faster
-	pub is_signed: bool,
+    /// about half as much memory and will also be faster
+    pub is_signed: bool,
 }
 
 impl<'a> Default for MSMConfig<'a> {


### PR DESCRIPTION
## Describe the changes

This PR adds an option to run msm using signed digits.
Currently only works with big triangle
I set the default is_signed to false because big triangle is false by default.
I made the split scalars kernel into two different ones for readibility but I can make it a single one if necessary

## Linked Issues

Resolves #
