### PR TITLE
hotfix for slow twiddles on small domain sizes

### DIFF
--- a/icicle/src/ntt/kernel_ntt.cu
+++ b/icicle/src/ntt/kernel_ntt.cu
@@ -706,7 +706,7 @@ namespace mxntt {
       // TODO: should throw exception
       // TODO: fast twiddles should be used only with mixed radix ntt
       // THROW_ICICLE_ERR(IcicleError_t::InvalidArgument, "log_size must be >= 4");
-      printf("warning: log_size must be at least 4, got %d\n", log_size); // TODO: logging
+      printf("warning: when using fast twiddles, log_size must be at least 4, got %d\n", log_size); // TODO: logging
       return cudaSuccess;
     }
 

--- a/icicle/src/ntt/kernel_ntt.cu
+++ b/icicle/src/ntt/kernel_ntt.cu
@@ -703,11 +703,8 @@ namespace mxntt {
     CHK_INIT_IF_RETURN();
 
     if (log_size < 4) {
-      // TODO: should throw exception
       // TODO: fast twiddles should be used only with mixed radix ntt
-      // THROW_ICICLE_ERR(IcicleError_t::InvalidArgument, "log_size must be >= 4");
-      printf("warning: when using fast twiddles, log_size must be at least 4, got %d\n", log_size); // TODO: logging
-      return cudaSuccess;
+      THROW_ICICLE_ERR(IcicleError_t::InvalidArgument, "when using fast twiddles, log_size must be at least 4");
     }
 
     S* w6_table;

--- a/icicle/src/ntt/kernel_ntt.cu
+++ b/icicle/src/ntt/kernel_ntt.cu
@@ -702,6 +702,14 @@ namespace mxntt {
   {
     CHK_INIT_IF_RETURN();
 
+    if (log_size < 4) {
+      // TODO: should throw exception
+      // TODO: fast twiddles should be used only with mixed radix ntt
+      // THROW_ICICLE_ERR(IcicleError_t::InvalidArgument, "log_size must be >= 4");
+      printf("warning: log_size must be at least 4, got %d\n", log_size); // TODO: logging
+      return cudaSuccess;
+    }
+
     S* w6_table;
     S* w12_table;
     S* w18_table;

--- a/icicle/src/ntt/ntt.cu
+++ b/icicle/src/ntt/ntt.cu
@@ -469,6 +469,8 @@ namespace ntt {
       CHK_IF_RETURN(mxntt::generate_external_twiddles_generic(
         primitive_root, domain.twiddles, domain.internal_twiddles, domain.basic_twiddles, domain.max_log_size,
         ctx.stream));
+      
+      fast_twiddles_mode &= domain.max_log_size >= 4; // fast twiddles cannot be built for smaller domain
 
       if (fast_twiddles_mode) {
         // generating fast-twiddles (note that this cost 4N additional memory)


### PR DESCRIPTION
## Describe the changes

This PR is a hotfix for ntt domains of log2 sizes < 4

## Linked Issues

Resolves #
