### PR TITLE
Panic Instead Of Mismatched Types Error

### DIFF
--- a/wrappers/rust/icicle-cuda-runtime/build.rs
+++ b/wrappers/rust/icicle-cuda-runtime/build.rs
@@ -12,6 +12,11 @@ fn cuda_include_path() -> &'static str {
     {
         "/usr/local/cuda/include"
     }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        panic!("Currently, ICICLE can only be built for Windows or Linux")
+    }
 }
 
 fn cuda_lib_path() -> &'static str {
@@ -23,6 +28,11 @@ fn cuda_lib_path() -> &'static str {
     #[cfg(target_os = "linux")]
     {
         "/usr/local/cuda/lib64"
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        panic!("Currently, ICICLE can only be built for Windows or Linux")
     }
 }
 


### PR DESCRIPTION
## Describe the changes

This PR adds conditional compilation attributes to the `cuda_include_path` and `cuda_lib_path` functions to handle cases where the target OS is neither Windows nor Linux. Previously, the functions returned mismatched types, causing compilation errors when the target OS was unsupported. The added code now explicitly panics with a descriptive error message in such cases, improving code clarity and error handling.

### Changes made:

1. **`cuda_include_path` function:**
   - Added `#[cfg(not(any(target_os = "windows", target_os = "linux")))]` conditional attribute to handle unsupported OS cases.
   - Included a panic with the message "Currently, ICICLE can only be built for Windows or Linux".

2. **`cuda_lib_path` function:**
   - Added `#[cfg(not(any(target_os = "windows", target_os = "linux")))]` conditional attribute to handle unsupported OS cases.
   - Included a panic with the message "Currently, ICICLE can only be built for Windows or Linux".

### Example of new code:
```rust
fn cuda_include_path() -> &'static str {
    #[cfg(target_os = "windows")]
    {
        concat!(env!("CUDA_PATH"), "\\include")
    }

    #[cfg(target_os = "linux")]
    {
        "/usr/local/cuda/include"
    }

    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
    {
        panic!("Currently, ICICLE can only be built for Windows or Linux")
    }
}

fn cuda_lib_path() -> &'static str {
    #[cfg(target_os = "windows")]
    {
        concat!(env!("CUDA_PATH"), "\\lib\\x64")
    }

    #[cfg(target_os = "linux")]
    {
        "/usr/local/cuda/lib64"
    }

    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
    {
        panic!("Currently, ICICLE can only be built for Windows or Linux")
    }
}
```

### Previous error resolved:

Before these changes, attempting to compile for unsupported OSes resulted in the following errors:
```
error[E0308]: mismatched types
 --> /path/to/icicle-cuda-runtime/build.rs:5:27
  |
5 | fn cuda_include_path() -> &'static str {
  |    -----------------      ^^^^^^^^^^^^ expected `&str`, found `()`
  |    |
  |    implicitly returns `()` as its body has no tail or `return` expression

error[E0308]: mismatched types
 --> /path/to/icicle-cuda-runtime/build.rs:17:23
  |
17 | fn cuda_lib_path() -> &'static str {
  |    -------------      ^^^^^^^^^^^^ expected `&str`, found `()`
  |    |
  |    implicitly returns `()` as its body has no tail or `return` expression
```

The added conditions now prevent these errors by explicitly handling unsupported OS cases with a panic message.