### PR TITLE
Update Test-Running Command in Documentation

### DIFF
--- a/icicle/README.md
+++ b/icicle/README.md
@@ -6,7 +6,7 @@
 mkdir -p build;
 cmake -DBUILD_TESTS=ON -DCURVE=<supported_curve> -S . -B build;
 cmake --build build;
-./build/runner --gtest_brief=1
+./build/tests/runner --gtest_brief=1
 ```
 
 The command above will build ICICLE Core and run the ctest.


### PR DESCRIPTION
This pull request updates the test-running command in the documentation to reflect the correct path for the test executable. The command should be:

./build/tests/runner --gtest_brief=1

This change ensures that users follow the correct procedure for running tests after building the project.