### PR TITLE
[FEAT] v3 vec_ops accumulation

### DIFF
--- a/icicle_v3/backend/cpu/src/field/cpu_vec_ops.cpp
+++ b/icicle_v3/backend/cpu/src/field/cpu_vec_ops.cpp
@@ -22,6 +22,19 @@ cpu_vector_add(const Device& device, const T* vec_a, const T* vec_b, uint64_t n,
 
 REGISTER_VECTOR_ADD_BACKEND("CPU", cpu_vector_add<scalar_t>);
 
+/*********************************** ACCUMULATE ***********************************/
+template <typename T>
+eIcicleError
+cpu_vector_accumulate(const Device& device, T* vec_a, const T* vec_b, uint64_t n, const VecOpsConfig& config)
+{
+  for (uint64_t i = 0; i < n; ++i) {
+    vec_a[i] = vec_a[i] + vec_b[i];
+  }
+  return eIcicleError::SUCCESS;
+}
+
+REGISTER_VECTOR_ACCUMULATE_BACKEND("CPU", cpu_vector_accumulate<scalar_t>);
+
 /*********************************** SUB ***********************************/
 template <typename T>
 eIcicleError

--- a/icicle_v3/backend/cpu/src/field/cpu_vec_ops.cpp
+++ b/icicle_v3/backend/cpu/src/field/cpu_vec_ops.cpp
@@ -128,6 +128,7 @@ REGISTER_CONVERT_MONTGOMERY_BACKEND("CPU", cpu_convert_montgomery<scalar_t>);
 
 #ifdef EXT_FIELD
 REGISTER_VECTOR_ADD_EXT_FIELD_BACKEND("CPU", cpu_vector_add<extension_t>);
+REGISTER_VECTOR_ACCUMULATE_EXT_FIELD_BACKEND("CPU", cpu_vector_accumulate<extension_t>);
 REGISTER_VECTOR_SUB_EXT_FIELD_BACKEND("CPU", cpu_vector_sub<extension_t>);
 REGISTER_VECTOR_MUL_EXT_FIELD_BACKEND("CPU", cpu_vector_mul<extension_t>);
 REGISTER_CONVERT_MONTGOMERY_EXT_FIELD_BACKEND("CPU", cpu_convert_montgomery<extension_t>);

--- a/icicle_v3/include/icicle/backend/vec_ops_backend.h
+++ b/icicle_v3/include/icicle/backend/vec_ops_backend.h
@@ -15,12 +15,30 @@ namespace icicle {
     const VecOpsConfig& config,
     scalar_t* output)>;
 
+  using scalarVectorOpImpl2 = std::function<eIcicleError(
+    const Device& device,
+    scalar_t* vec_a,
+    const scalar_t* vec_b,
+    uint64_t n,
+    const VecOpsConfig& config
+    )>;
+
   void register_vector_add(const std::string& deviceType, scalarVectorOpImpl impl);
 
 #define REGISTER_VECTOR_ADD_BACKEND(DEVICE_TYPE, FUNC)                                                                 \
   namespace {                                                                                                          \
     static bool UNIQUE(_reg_vec_add) = []() -> bool {                                                                  \
       register_vector_add(DEVICE_TYPE, FUNC);                                                                          \
+      return true;                                                                                                     \
+    }();                                                                                                               \
+  }
+
+  void register_vector_accumulate(const std::string& deviceType, scalarVectorOpImpl2 impl);
+
+#define REGISTER_VECTOR_ACCUMULATE_BACKEND(DEVICE_TYPE, FUNC)                                                                 \
+  namespace {                                                                                                          \
+    static bool UNIQUE(_reg_vec_accumulate) = []() -> bool {                                                                  \
+      register_vector_accumulate(DEVICE_TYPE, FUNC);                                                                          \
       return true;                                                                                                     \
     }();                                                                                                               \
   }

--- a/icicle_v3/include/icicle/backend/vec_ops_backend.h
+++ b/icicle_v3/include/icicle/backend/vec_ops_backend.h
@@ -242,12 +242,29 @@ namespace icicle {
     const VecOpsConfig& config,
     extension_t* output)>;
 
+  using extFieldVectorOpImpl2 = std::function<eIcicleError(
+    const Device& device,
+    extension_t* vec_a,
+    const extension_t* vec_b,
+    uint64_t n,
+    const VecOpsConfig& config)>;
+
   void register_extension_vector_add(const std::string& deviceType, extFieldVectorOpImpl impl);
 
 #define REGISTER_VECTOR_ADD_EXT_FIELD_BACKEND(DEVICE_TYPE, FUNC)                                                       \
   namespace {                                                                                                          \
     static bool UNIQUE(_reg_vec_add_ext_field) = []() -> bool {                                                        \
       register_extension_vector_add(DEVICE_TYPE, FUNC);                                                                \
+      return true;                                                                                                     \
+    }();                                                                                                               \
+  }
+
+  void register_extension_vector_accumulate(const std::string& deviceType, extFieldVectorOpImpl2 impl);
+
+#define REGISTER_VECTOR_ACCUMULATE_EXT_FIELD_BACKEND(DEVICE_TYPE, FUNC)                                                       \
+  namespace {                                                                                                          \
+    static bool UNIQUE(_reg_vec_accumulate_ext_field) = []() -> bool {                                                        \
+      register_extension_vector_accumulate(DEVICE_TYPE, FUNC);                                                                \
       return true;                                                                                                     \
     }();                                                                                                               \
   }

--- a/icicle_v3/include/icicle/vec_ops.h
+++ b/icicle_v3/include/icicle/vec_ops.h
@@ -63,6 +63,19 @@ namespace icicle {
   eIcicleError vector_add(const T* vec_a, const T* vec_b, uint64_t size, const VecOpsConfig& config, T* output);
 
   /**
+   * @brief Accumulates the elements of two vectors element-wise and stores the result in the first vector.
+   *
+   * @tparam T Type of the elements in the vectors.
+   * @param vec_a Input/output vector `a`. The result will be written back to this vector.
+   * @param vec_b Input vector `b`.
+   * @param size Number of elements in the vectors.
+   * @param config Configuration for the operation.
+   * @return eIcicleError Error code indicating success or failure.
+   */
+  template <typename T>
+  eIcicleError vector_accumulate(T* vec_a, const T* vec_b, uint64_t size, const VecOpsConfig& config);
+
+  /**
    * @brief Subtracts vector `b` from vector `a` element-wise.
    *
    * @tparam T Type of the elements in the vectors.

--- a/icicle_v3/src/vec_ops.cpp
+++ b/icicle_v3/src/vec_ops.cpp
@@ -46,11 +46,28 @@ namespace icicle {
   }
 
   template <>
-  eIcicleError
-  vector_accumulate(scalar_t* vec_a, const scalar_t* vec_b, uint64_t n, const VecOpsConfig& config)
+  eIcicleError vector_accumulate(
+    scalar_t* vec_a, const scalar_t* vec_b, uint64_t n, const VecOpsConfig& config)
   {
     return CONCAT_EXPAND(FIELD, vector_accumulate)(vec_a, vec_b, n, config);
   }
+
+#ifdef EXT_FIELD
+  ICICLE_DISPATCHER_INST(VectorAccumulateExtFieldDispatcher, extension_vector_accumulate, extFieldVectorOpImpl2);
+
+  extern "C" eIcicleError CONCAT_EXPAND(FIELD, extension_vector_accumulate)(
+    extension_t* vec_a, const extension_t* vec_b, uint64_t n, const VecOpsConfig& config)
+  {
+    return VectorAccumulateExtFieldDispatcher::execute(vec_a, vec_b, n, config);
+  }
+
+  template <>
+  eIcicleError vector_accumulate(
+    extension_t* vec_a, const extension_t* vec_b, uint64_t n, const VecOpsConfig& config)
+  {
+    return CONCAT_EXPAND(FIELD, extension_vector_accumulate)(vec_a, vec_b, n, config);
+  }
+#endif // EXT_FIELD
 
   /*********************************** SUB ***********************************/
   ICICLE_DISPATCHER_INST(VectorSubDispatcher, vector_sub, scalarVectorOpImpl);

--- a/icicle_v3/src/vec_ops.cpp
+++ b/icicle_v3/src/vec_ops.cpp
@@ -36,6 +36,22 @@ namespace icicle {
   }
 #endif // EXT_FIELD
 
+  /*********************************** ACCUMULATE ***********************************/
+  ICICLE_DISPATCHER_INST(VectorAccumulateDispatcher, vector_accumulate, scalarVectorOpImpl2);
+
+  extern "C" eIcicleError CONCAT_EXPAND(FIELD, vector_accumulate)(
+    scalar_t* vec_a, const scalar_t* vec_b, uint64_t n, const VecOpsConfig& config)
+  {
+    return VectorAccumulateDispatcher::execute(vec_a, vec_b, n, config);
+  }
+
+  template <>
+  eIcicleError
+  vector_accumulate(scalar_t* vec_a, const scalar_t* vec_b, uint64_t n, const VecOpsConfig& config)
+  {
+    return CONCAT_EXPAND(FIELD, vector_accumulate)(vec_a, vec_b, n, config);
+  }
+
   /*********************************** SUB ***********************************/
   ICICLE_DISPATCHER_INST(VectorSubDispatcher, vector_sub, scalarVectorOpImpl);
 

--- a/icicle_v3/tests/test_field_api.cpp
+++ b/icicle_v3/tests/test_field_api.cpp
@@ -98,6 +98,10 @@ TYPED_TEST(FieldApiTest, vectorOps)
   auto out_main = std::make_unique<TypeParam[]>(N);
   auto out_ref = std::make_unique<TypeParam[]>(N);
 
+  auto vector_accumulate_wrapper = [](TypeParam* a, const TypeParam* b, uint64_t size, const VecOpsConfig& config, TypeParam* /*out*/) {
+      return vector_accumulate(a, b, size, config);
+  };
+
   auto run =
     [&](const std::string& dev_type, TypeParam* out, bool measure, auto vec_op_func, const char* msg, int iters) {
       Device dev = {dev_type, 0};
@@ -117,6 +121,17 @@ TYPED_TEST(FieldApiTest, vectorOps)
   // warmup
   // run(s_reference_target, out_ref.get(), false /*=measure*/, 16 /*=iters*/);
   // run(s_main_target, out_main.get(), false /*=measure*/, 1 /*=iters*/);
+
+  //accumulate
+  auto temp_result = std::make_unique<TypeParam[]>(N);
+  auto initial_in_a = std::make_unique<TypeParam[]>(N);
+
+  std::memcpy(initial_in_a.get(), in_a.get(), N * sizeof(TypeParam));
+  run(s_reference_target, out_main.get(), VERBOSE /*=measure*/, vector_accumulate_wrapper, "vector accumulate", ITERS);
+  std::memcpy(temp_result.get(), in_a.get(), N * sizeof(TypeParam));
+  std::memcpy(in_a.get(), initial_in_a.get(), N * sizeof(TypeParam));
+  run(s_main_target, out_main.get(), VERBOSE /*=measure*/, vector_accumulate_wrapper, "vector accumulate", ITERS);
+  ASSERT_EQ(0, memcmp(in_a.get(), temp_result.get(), N * sizeof(TypeParam)));
 
   // add
   run(s_reference_target, out_ref.get(), VERBOSE /*=measure*/, vector_add<TypeParam>, "vector add", ITERS);

--- a/wrappers/rust_v3/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust_v3/icicle-core/src/vec_ops/tests.rs
@@ -2,7 +2,7 @@
 use crate::test_utilities;
 use crate::traits::GenerateRandom;
 use crate::vec_ops::{
-    add_scalars, bit_reverse, bit_reverse_inplace, mul_scalars, sub_scalars, transpose_matrix, FieldImpl, VecOps,
+    add_scalars, accumulate_scalars, bit_reverse, bit_reverse_inplace, mul_scalars, sub_scalars, transpose_matrix, FieldImpl, VecOps,
     VecOpsConfig,
 };
 use icicle_runtime::device::Device;
@@ -39,36 +39,127 @@ pub fn check_vec_ops_scalars<F: FieldImpl>()
 where
     <F as FieldImpl>::Config: VecOps<F> + GenerateRandom<F>,
 {
-    test_utilities::test_set_main_device();
     let test_size = 1 << 14;
 
-    let a = F::Config::generate_random(test_size);
+    check_vec_ops_scalars_add::<F>(test_size);
+    check_vec_ops_scalars_sub::<F>(test_size);
+    check_vec_ops_scalars_mul::<F>(test_size);
+    check_vec_ops_scalars_accumulate::<F>(test_size);
+}
+
+pub fn check_vec_ops_scalars_add<F: FieldImpl>(test_size: usize)
+where
+    <F as FieldImpl>::Config: VecOps<F> + GenerateRandom<F>,
+{
+    let a_main = F::Config::generate_random(test_size);
     let b = F::Config::generate_random(test_size);
-    let ones = vec![F::one(); test_size];
-    let mut result = vec![F::zero(); test_size];
-    let mut result2 = vec![F::zero(); test_size];
-    let mut result3 = vec![F::zero(); test_size];
-    let a = HostSlice::from_slice(&a);
+    let mut result_main = vec![F::zero(); test_size];
+    let mut result_ref = vec![F::zero(); test_size];
+
+    let a_main = HostSlice::from_slice(&a_main);
     let b = HostSlice::from_slice(&b);
-    let ones = HostSlice::from_slice(&ones);
-    let result = HostSlice::from_mut_slice(&mut result);
-    let result2 = HostSlice::from_mut_slice(&mut result2);
-    let result3 = HostSlice::from_mut_slice(&mut result3);
+    let result_main = HostSlice::from_mut_slice(&mut result_main);
+    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
 
     let mut stream = IcicleStream::create().unwrap();
     let mut cfg = VecOpsConfig::default();
     cfg.stream_handle = *stream;
 
-    add_scalars(a, b, result, &cfg).unwrap();
-    sub_scalars(result, b, result2, &cfg).unwrap();
-    assert_eq!(a[0], result2[0]);
+    test_utilities::test_set_main_device();
+    add_scalars(a_main, b, result_main, &cfg).unwrap();
 
-    mul_scalars(a, ones, result3, &cfg).unwrap();
-    assert_eq!(a[0], result3[0]);
+    test_utilities::test_set_ref_device();
+    add_scalars(a_main, b, result_ref, &cfg).unwrap();
 
-    stream
-        .destroy()
-        .unwrap();
+    assert_eq!(result_main[0], result_ref[0]);
+
+    stream.destroy().unwrap();
+}
+
+pub fn check_vec_ops_scalars_sub<F: FieldImpl>(test_size: usize)
+where
+    <F as FieldImpl>::Config: VecOps<F> + GenerateRandom<F>,
+{
+    let a_main = F::Config::generate_random(test_size);
+    let b = F::Config::generate_random(test_size);
+    let mut result_main = vec![F::zero(); test_size];
+    let mut result_ref = vec![F::zero(); test_size];
+
+    let a_main = HostSlice::from_slice(&a_main);
+    let b = HostSlice::from_slice(&b);
+    let result_main = HostSlice::from_mut_slice(&mut result_main);
+    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+
+    let mut stream = IcicleStream::create().unwrap();
+    let mut cfg = VecOpsConfig::default();
+    cfg.stream_handle = *stream;
+
+    test_utilities::test_set_main_device();
+    sub_scalars(a_main, b, result_main, &cfg).unwrap();
+
+    test_utilities::test_set_ref_device();
+    sub_scalars(a_main, b, result_ref, &cfg).unwrap();
+
+    assert_eq!(result_main[0], result_ref[0]);
+
+    stream.destroy().unwrap();
+}
+
+pub fn check_vec_ops_scalars_mul<F: FieldImpl>(test_size: usize)
+where
+    <F as FieldImpl>::Config: VecOps<F> + GenerateRandom<F>,
+{
+    let a_main = F::Config::generate_random(test_size);
+    let b = F::Config::generate_random(test_size);
+    let mut result_main = vec![F::zero(); test_size];
+    let mut result_ref = vec![F::zero(); test_size];
+
+    let a_main = HostSlice::from_slice(&a_main);
+    let b = HostSlice::from_slice(&b);
+    let result_main = HostSlice::from_mut_slice(&mut result_main);
+    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+
+    let mut stream = IcicleStream::create().unwrap();
+    let mut cfg = VecOpsConfig::default();
+    cfg.stream_handle = *stream;
+
+    test_utilities::test_set_main_device();
+    mul_scalars(a_main, b, result_main, &cfg).unwrap();
+
+    test_utilities::test_set_ref_device();
+    mul_scalars(a_main, b, result_ref, &cfg).unwrap();
+
+    assert_eq!(result_main[0], result_ref[0]);
+
+    stream.destroy().unwrap();
+}
+
+pub fn check_vec_ops_scalars_accumulate<F: FieldImpl>(test_size: usize)
+where
+    <F as FieldImpl>::Config: VecOps<F> + GenerateRandom<F>,
+{
+    let mut a_main = F::Config::generate_random(test_size);
+    let b = F::Config::generate_random(test_size);
+
+    let mut a_clone = a_main.clone();
+
+    let a_main_slice = HostSlice::from_mut_slice(&mut a_main);
+    let b_slice = HostSlice::from_slice(&b);
+    let a_clone_slice = HostSlice::from_mut_slice(&mut a_clone);
+
+    let mut stream = IcicleStream::create().unwrap();
+    let mut cfg = VecOpsConfig::default();
+    cfg.stream_handle = *stream;
+
+    test_utilities::test_set_main_device();
+    accumulate_scalars(a_main_slice, b_slice, &cfg).unwrap();
+
+    test_utilities::test_set_ref_device();
+    accumulate_scalars(a_clone_slice, b_slice, &cfg).unwrap();
+
+    assert_eq!(a_clone_slice[0], a_main_slice[0]);
+
+    stream.destroy().unwrap();
 }
 
 pub fn check_matrix_transpose<F: FieldImpl>()


### PR DESCRIPTION
## Changes

This PR introduces the `accumulate` function for `vec_ops`, implemented in both C++ and CUDA. Additionally, a Rust wrapper for this function has been developed. Tests for the `accumulate` function have been added for both C++ and Rust.