### PR TITLE
Koren/msm not enough tasks bugfix

### DIFF
--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -47,7 +47,7 @@ option(G2 "Build G2 MSM" ON)
 option(EXT_FIELD "Build extension field" ON)
 option(HASH "Build hashes and tree builders" ON)
 option(POSEIDON "Build poseidon hash" ON)
-option(SANITIZE "Enable memory address sanitizer" ON)
+option(SANITIZE "Enable memory address sanitizer" OFF)
 
 # address sanitizer
 if(SANITIZE)

--- a/icicle/CMakeLists.txt
+++ b/icicle/CMakeLists.txt
@@ -47,6 +47,13 @@ option(G2 "Build G2 MSM" ON)
 option(EXT_FIELD "Build extension field" ON)
 option(HASH "Build hashes and tree builders" ON)
 option(POSEIDON "Build poseidon hash" ON)
+option(SANITIZE "Enable memory address sanitizer" ON)
+
+# address sanitizer
+if(SANITIZE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fsanitize=address")
+endif()
 
 # device API library
 add_library(icicle_device SHARED

--- a/icicle/backend/cpu/include/tasks_manager.h
+++ b/icicle/backend/cpu/include/tasks_manager.h
@@ -5,7 +5,6 @@
 
 #define LOG_TASKS_PER_THREAD 6
 #define TASKS_PER_THREAD     (1 << LOG_TASKS_PER_THREAD)
-#define TASK_IDX_MASK        (TASKS_PER_THREAD - 1)
 #define MANAGER_SLEEP_USEC   10
 #define THREAD_SLEEP_USEC    1
 
@@ -82,9 +81,16 @@ class TasksManager
 public:
   /**
    * @brief Constructor for `TaskManager`.
-   * @param nof_workers - number of workers / threads to be ran simultaneously
+   * @param nof_workers - Number of workers / threads to be ran simultaneously
+   * @param min_nof_tasks - Total number of tasks required by the application
    */
-  TasksManager(const int nof_workers) : m_workers(nof_workers), m_next_worker_idx(0) {}
+  TasksManager(int nof_workers, int min_nof_tasks = 0);
+
+  /**
+   * @brief Destructor of `TasksManager`.
+   * Frees the worker pointer.
+   */
+  ~TasksManager();
 
   /**
    * @brief Get free slot to insert new task to be executed. This is a blocking function - until a free task is found.
@@ -126,7 +132,8 @@ private:
      * @brief Constructor of `Worker`.
      * Inits default values for the class's members and launches the thread.
      */
-    Worker();
+    Worker(int nof_tasks);
+    
     /**
      * @brief Destructor of `Worker`.
      * Signals the thread to terminate and joins it with main. The destructor does not handle existing tasks' results
@@ -174,7 +181,7 @@ private:
     std::thread task_executor; // Thread to be run parallel to main
     std::vector<Task> m_tasks; // vector containing the worker's task. a Vector is used to allow buffering.
     int m_next_task_idx;       // Tail (input) idx of the fifo above. Checks for free task start at this idx.
-    bool kill;                 // boolean to flag from main to the thread to finish.
+    bool m_kill;               // boolean to flag from main to the thread to finish.
 
     #ifdef LOG_UTILIZATION
     int m_nof_sleeps = 0;
@@ -182,12 +189,12 @@ private:
     #endif
   };
 
-  std::vector<Worker> m_workers; // Vector of workers/threads to be ran simultaneously.
+  std::vector<Worker*> m_workers; // Vector of workers/threads to be ran simultaneously.
   int m_next_worker_idx;
 };
 
 template <class Task>
-TasksManager<Task>::Worker::Worker() : m_tasks(TASKS_PER_THREAD), m_next_task_idx(0), kill(false)
+TasksManager<Task>::Worker::Worker(int nof_tasks) : m_tasks(nof_tasks), m_next_task_idx(0), m_kill(false)
 {
   // Init thread only after finishing all other setup to avoid data races
   task_executor = std::thread(&TasksManager<Task>::Worker::worker_loop, this);
@@ -196,7 +203,7 @@ TasksManager<Task>::Worker::Worker() : m_tasks(TASKS_PER_THREAD), m_next_task_id
 template <class Task>
 TasksManager<Task>::Worker::~Worker()
 {
-  kill = true;
+  m_kill = true;
   task_executor.join();
 
   #ifdef LOG_UTILIZATION
@@ -210,7 +217,7 @@ void TasksManager<Task>::Worker::worker_loop()
   #ifdef LOG_UTILIZATION
   bool had_work_since_sleep = false;
   #endif
-  while (!kill) {
+  while (!m_kill) {
     bool all_tasks_idle = true;
     for (int head = 0; head < m_tasks.size(); head++) {
       Task* task = &m_tasks[head];
@@ -244,7 +251,7 @@ Task* TasksManager<Task>::Worker::get_idle_or_completed_task()
 {
   for (int i = 0; i < m_tasks.size(); i++) {
     // TASKS_PER_WORKER is a power of 2 so modulo is done via bitmask.
-    m_next_task_idx = (1 + m_next_task_idx) & TASK_IDX_MASK;
+    m_next_task_idx = (m_next_task_idx < m_tasks.size() - 1) ? m_next_task_idx + 1 : 0;
 
     if (m_tasks[m_next_task_idx].is_idle() || m_tasks[m_next_task_idx].is_completed()) {
       return &m_tasks[m_next_task_idx];
@@ -257,7 +264,7 @@ template <class Task>
 Task* TasksManager<Task>::Worker::get_idle_task()
 {
   for (int i = 0; i < m_tasks.size(); i++) {
-    m_next_task_idx = (1 + m_next_task_idx) & TASK_IDX_MASK;
+    m_next_task_idx = (m_next_task_idx < m_tasks.size() - 1) ? m_next_task_idx + 1 : 0;
 
     if (m_tasks[m_next_task_idx].is_idle()) { return &m_tasks[m_next_task_idx]; }
   }
@@ -268,7 +275,7 @@ template <class Task>
 Task* TasksManager<Task>::Worker::get_completed_task(bool& is_idle)
 {
   for (int i = 0; i < m_tasks.size(); i++) {
-    m_next_task_idx = (1 + m_next_task_idx) & TASK_IDX_MASK;
+    m_next_task_idx = (m_next_task_idx < m_tasks.size() - 1) ? m_next_task_idx + 1 : 0;
 
     if (m_tasks[m_next_task_idx].is_completed()) {
       is_idle = false;
@@ -292,6 +299,26 @@ void TasksManager<Task>::Worker::wait_done()
 }
 
 template <class Task>
+TasksManager<Task>::TasksManager(int nof_workers, int min_nof_tasks) : m_workers(nof_workers), m_next_worker_idx(0)
+{
+  ICICLE_ASSERT(nof_workers > 0) << "Number of workers must be at least 1.";
+  int nof_tasks_per_worker = std::max((min_nof_tasks + nof_workers - 1) / nof_workers, TASKS_PER_THREAD);
+  for (int i = 0; i < nof_workers; i++)
+  {
+    m_workers[i] = new Worker(nof_tasks_per_worker);
+  }
+}
+
+template <class Task>
+TasksManager<Task>::~TasksManager()
+{
+  for (auto &&worker : m_workers)
+  {
+    delete worker;
+  }
+}
+
+template <class Task>
 Task* TasksManager<Task>::get_idle_or_completed_task()
 {
   Task* task = nullptr;
@@ -299,7 +326,7 @@ Task* TasksManager<Task>::get_idle_or_completed_task()
     for (int i = 0; i < m_workers.size(); i++) {
       m_next_worker_idx = (m_next_worker_idx < m_workers.size() - 1) ? m_next_worker_idx + 1 : 0;
 
-      task = m_workers[m_next_worker_idx].get_idle_or_completed_task();
+      task = m_workers[m_next_worker_idx]->get_idle_or_completed_task();
       if (task != nullptr) { return task; }
     }
     std::this_thread::sleep_for(std::chrono::microseconds(MANAGER_SLEEP_USEC));
@@ -313,7 +340,7 @@ Task* TasksManager<Task>::get_idle_task()
   for (int i = 0; i < m_workers.size(); i++) {
     m_next_worker_idx = (m_next_worker_idx < m_workers.size() - 1) ? m_next_worker_idx + 1 : 0;
 
-    idle_task = m_workers[m_next_worker_idx].get_idle_task();
+    idle_task = m_workers[m_next_worker_idx]->get_idle_task();
     if (idle_task != nullptr) { return idle_task; }
   }
   // No completed tasks were found in the loop - return null.
@@ -331,7 +358,7 @@ Task* TasksManager<Task>::get_completed_task()
     for (int i = 0; i < m_workers.size(); i++) {
       m_next_worker_idx = (m_next_worker_idx < m_workers.size() - 1) ? m_next_worker_idx + 1 : 0;
 
-      completed_task = m_workers[m_next_worker_idx].get_completed_task(all_idle);
+      completed_task = m_workers[m_next_worker_idx]->get_completed_task(all_idle);
       if (completed_task != nullptr) { return completed_task; }
     }
     std::this_thread::sleep_for(std::chrono::microseconds(MANAGER_SLEEP_USEC));
@@ -343,7 +370,7 @@ Task* TasksManager<Task>::get_completed_task()
 template <class Task>
 void TasksManager<Task>::wait_done()
 {
-  for (Worker& worker : m_workers) {
-    worker.wait_done();
+  for (Worker*& worker : m_workers) {
+    worker->wait_done();
   }
 }

--- a/icicle/backend/cpu/include/tasks_manager.h
+++ b/icicle/backend/cpu/include/tasks_manager.h
@@ -133,7 +133,7 @@ private:
      * Inits default values for the class's members and launches the thread.
      */
     Worker(int nof_tasks);
-    
+
     /**
      * @brief Destructor of `Worker`.
      * Signals the thread to terminate and joins it with main. The destructor does not handle existing tasks' results
@@ -183,10 +183,10 @@ private:
     int m_next_task_idx;       // Tail (input) idx of the fifo above. Checks for free task start at this idx.
     bool m_kill;               // boolean to flag from main to the thread to finish.
 
-    #ifdef LOG_UTILIZATION
+#ifdef LOG_UTILIZATION
     int m_nof_sleeps = 0;
     int m_total_sleep_us = 0;
-    #endif
+#endif
   };
 
   std::vector<Worker*> m_workers; // Vector of workers/threads to be ran simultaneously.
@@ -206,17 +206,18 @@ TasksManager<Task>::Worker::~Worker()
   m_kill = true;
   task_executor.join();
 
-  #ifdef LOG_UTILIZATION
-  ICICLE_LOG_INFO << "Thread utilization:\n#sleeps =\t\t" << m_nof_sleeps << "\nTotal sleep time =\t" << m_total_sleep_us << "us";
-  #endif
+#ifdef LOG_UTILIZATION
+  ICICLE_LOG_INFO << "Thread utilization:\n#sleeps =\t\t" << m_nof_sleeps << "\nTotal sleep time =\t"
+                  << m_total_sleep_us << "us";
+#endif
 }
 
 template <class Task>
 void TasksManager<Task>::Worker::worker_loop()
 {
-  #ifdef LOG_UTILIZATION
+#ifdef LOG_UTILIZATION
   bool had_work_since_sleep = false;
-  #endif
+#endif
   while (!m_kill) {
     bool all_tasks_idle = true;
     for (int head = 0; head < m_tasks.size(); head++) {
@@ -226,22 +227,22 @@ void TasksManager<Task>::Worker::worker_loop()
         task->set_completed();
         all_tasks_idle = false;
 
-        #ifdef LOG_UTILIZATION
+#ifdef LOG_UTILIZATION
         had_work_since_sleep = true;
-  #endif
+#endif
       }
     }
     if (all_tasks_idle) {
       // Sleep as the thread apparently isn't fully utilized currently
       std::this_thread::sleep_for(std::chrono::microseconds(THREAD_SLEEP_USEC));
 
-      #ifdef LOG_UTILIZATION
-      if (had_work_since_sleep) { 
+#ifdef LOG_UTILIZATION
+      if (had_work_since_sleep) {
         m_nof_sleeps++;
         had_work_since_sleep = false;
       }
       m_total_sleep_us++;
-  #endif
+#endif
     }
   }
 }
@@ -303,8 +304,7 @@ TasksManager<Task>::TasksManager(int nof_workers, int min_nof_tasks) : m_workers
 {
   ICICLE_ASSERT(nof_workers > 0) << "Number of workers must be at least 1.";
   int nof_tasks_per_worker = std::max((min_nof_tasks + nof_workers - 1) / nof_workers, TASKS_PER_THREAD);
-  for (int i = 0; i < nof_workers; i++)
-  {
+  for (int i = 0; i < nof_workers; i++) {
     m_workers[i] = new Worker(nof_tasks_per_worker);
   }
 }
@@ -312,8 +312,7 @@ TasksManager<Task>::TasksManager(int nof_workers, int min_nof_tasks) : m_workers
 template <class Task>
 TasksManager<Task>::~TasksManager()
 {
-  for (auto &&worker : m_workers)
-  {
+  for (auto&& worker : m_workers) {
     delete worker;
   }
 }

--- a/icicle/backend/cpu/src/curve/cpu_msm.hpp
+++ b/icicle/backend/cpu/src/curve/cpu_msm.hpp
@@ -240,8 +240,8 @@ public:
     const scalar_t* scalars, const A* bases, const unsigned int msm_size, const unsigned int batch_idx, P* results);
 
   /**
-   * @brief Calculate approximate value of c to minimize number of EC additions in the MSM calculation. Having said 
-   * that, the value of c might be suboptimal in the case of physical memory limitations (Due to required memory size 
+   * @brief Calculate approximate value of c to minimize number of EC additions in the MSM calculation. Having said
+   * that, the value of c might be suboptimal in the case of physical memory limitations (Due to required memory size
    * for the BMs, determined by c).
    * @param msm_size - Number of inputs in the MSM calculation.
    * @param precompute_factor - Precompute factor determined in the config.
@@ -253,13 +253,13 @@ public:
     int optimal_c = precompute_factor > 1
                       ? std::max((int)std::log2(msm_size) + (int)std::log2(precompute_factor) - 5, 8)
                       : std::max((int)std::log2(msm_size) - 5, 8);
-    
+
     // Get physical memory limitation (by some factor < 1 - chosen to be 3/4)
     uint64_t point_size = 3 * scalar_t::NBITS; // NOTE this is valid under the assumption of projective points in BMs
     uint64_t _0_75_of_mem_size = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE) * 3 / 4;
     uint64_t max_nof_points_in_mem = _0_75_of_mem_size / point_size;
 
-    // Reduce c until it doens't exceed the memory limitation
+    // Reduce c until it doesn't exceed the memory limitation
     int c = optimal_c + 1;
     uint64_t total_num_of_points;
     do {

--- a/icicle/backend/cpu/src/curve/cpu_msm.hpp
+++ b/icicle/backend/cpu/src/curve/cpu_msm.hpp
@@ -247,8 +247,7 @@ public:
                       : std::max((int)std::log2(msm_size) - 5, 8);
     // To avoid mem limitation c is limited
     uint64_t point_size = 3 * scalar_t::NBITS; // NOTE this is valid under the assumption of projective points in BMs
-    uint64_t _0_75_of_mem_size =
-      sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE) * 3 / 4;
+    uint64_t _0_75_of_mem_size = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE) * 3 / 4;
     uint64_t max_nof_points_in_mem = _0_75_of_mem_size / point_size;
 
     int c = optimal_c + 1;
@@ -373,10 +372,11 @@ private:
 
 template <typename A, typename P>
 Msm<A, P>::Msm(const MSMConfig& config, const int c, const int nof_threads)
-    : manager(nof_threads, 
-              // Minimal number of tasks required in phase 2 - 2 Tasks for each BM
-              (((scalar_t::NBITS - 1) / (config.precompute_factor * c)) + 1) * 2),
-    
+    : manager(
+        nof_threads,
+        // Minimal number of tasks required in phase 2 - 2 Tasks for each BM
+        (((scalar_t::NBITS - 1) / (config.precompute_factor * c)) + 1) * 2),
+
       m_curr_task(nullptr),
 
       m_c(c), m_num_bkts(1 << (m_c - 1)), m_precompute_factor(config.precompute_factor),

--- a/icicle/tests/test_curve_api.cpp
+++ b/icicle/tests/test_curve_api.cpp
@@ -69,8 +69,8 @@ public:
   {
     const int logn = 12;
     const int batch = 3;
-    const int N = 1 << logn - rand() % (5 * logn);  // make it not always power of two
-    const int precompute_factor = (rand() & 7) + 1; // between 1 and 8
+    const int N = (1 << logn) - rand() % (5 * logn); // make it not always power of two
+    const int precompute_factor = (rand() & 7) + 1;  // between 1 and 8
     const int total_nof_elemets = batch * N;
 
     auto scalars = std::make_unique<scalar_t[]>(total_nof_elemets);

--- a/icicle/tests/test_curve_api.cpp
+++ b/icicle/tests/test_curve_api.cpp
@@ -119,12 +119,12 @@ public:
     const int c = 3;
     // Low c to have a large amount of tasks required in phase 2
     // For example for bn254: #bms = ceil(254/3)=85
-    // #tasks in phase 2 = 2 * #bms = 170 > 64 = TASK_PER_THREAD 
-    // As such the default amount of tasks and 1 thread shouldn't be enough and the program should readjust the task 
+    // #tasks in phase 2 = 2 * #bms = 170 > 64 = TASK_PER_THREAD
+    // As such the default amount of tasks and 1 thread shouldn't be enough and the program should readjust the task
     // number per thread.
     const int batch = 3;
     const int N = (1 << logn) - rand() % (5 * logn); // make it not always power of two
-    const int precompute_factor = 1;  // Precompute is 1 to increase number of BMs
+    const int precompute_factor = 1;                 // Precompute is 1 to increase number of BMs
     const int total_nof_elemets = batch * N;
 
     auto scalars = std::make_unique<scalar_t[]>(total_nof_elemets);
@@ -154,8 +154,7 @@ public:
       }
       END_TIMER(MSM_sync, oss.str().c_str(), measure);
     };
-    if (s_ref_target == "CPU")
-    {
+    if (s_ref_target == "CPU") {
       run(s_ref_target, result_multi_thread.get(), "msm", VERBOSE /*=measure*/, 1 /*=iters*/);
       // Adjust config to have one worker thread
       ConfigExtension ext;

--- a/wrappers/golang/hash/include/hash.h
+++ b/wrappers/golang/hash/include/hash.h
@@ -22,12 +22,7 @@ typedef struct HashConfig HashConfig;
  * @return eIcicleError indicating success or failure.
  */
 int icicle_hasher_hash(
-  Hash* hash_ptr,
-  const uint8_t* input_ptr,
-  uint64_t input_len,
-  const HashConfig* config,
-  uint8_t* output_ptr
-);
+  Hash* hash_ptr, const uint8_t* input_ptr, uint64_t input_len, const HashConfig* config, uint8_t* output_ptr);
 
 /**
  * @brief Returns the output size in bytes for the hash operation.

--- a/wrappers/golang/merkle-tree/include/merkletree.h
+++ b/wrappers/golang/merkle-tree/include/merkletree.h
@@ -33,17 +33,13 @@ uint8_t* icicle_merkle_proof_get_root(MerkleProof* proof, size_t* out_size);
 
 // Create a new MerkleTree object
 MerkleTree* icicle_merkle_tree_create(
-  Hash** layer_hashes,
-  size_t layer_hashes_len,
-  uint64_t leaf_element_size,
-  uint64_t output_store_min_layer);
+  Hash** layer_hashes, size_t layer_hashes_len, uint64_t leaf_element_size, uint64_t output_store_min_layer);
 
 // Delete the MerkleTree object and free its resources
 int icicle_merkle_tree_delete(MerkleTree* tree);
 
 // Build the Merkle tree from the provided leaves
-int icicle_merkle_tree_build(
-  MerkleTree* tree, uint8_t* leaves, uint64_t size, MerkleTreeConfig* config);
+int icicle_merkle_tree_build(MerkleTree* tree, uint8_t* leaves, uint64_t size, MerkleTreeConfig* config);
 
 // Get the Merkle root as a pointer to the root data and its size
 const uint8_t* icicle_merkle_tree_get_root(MerkleTree* tree, size_t* out_size);
@@ -60,7 +56,6 @@ int icicle_merkle_tree_get_proof(
 
 // Verify a Merkle proof
 int icicle_merkle_tree_verify(MerkleTree* tree, MerkleProof* merkle_proof, bool* valid);
-
 
   #ifdef __cplusplus
 }


### PR DESCRIPTION
## Describe the changes

Fixed 2 bugs in MSM:
- Now c is limited to avoid exceeding memory.
- TasksManager now accepts the minimal number of required tasks upon creation. MSM utilizes it to avoid crashes due to insufficient tasks in phase 2.

CMake:
- Added address sanitizer as an optional CMake flag (SANITIZE) to ease debugging of segfaults.

Other minor changes:
- test_curve_api.cpp: changed randomization of N to adhere to the comment and be potentially different than a power of 2.

## Linked Issues

Resolves #
