### PR TITLE
naming alignemnt for default_input_chunk_size

### DIFF
--- a/icicle/include/icicle/backend/hash/hash_backend.h
+++ b/icicle/include/icicle/backend/hash/hash_backend.h
@@ -51,7 +51,7 @@ namespace icicle {
      * @brief Get the default input chunk size.
      * @return The size of the input chunk in bytes.
      */
-    inline uint64_t input_default_chunk_size() const { return m_default_input_chunk_size; }
+    inline uint64_t default_input_chunk_size() const { return m_default_input_chunk_size; }
 
     /**
      * @brief Get the output size in bytes for a single hash chunk.
@@ -68,7 +68,7 @@ namespace icicle {
 
     inline uint64_t get_single_chunk_size(uint64_t size_or_zero) const
     {
-      const uint64_t size = (size_or_zero == 0) ? input_default_chunk_size() : size_or_zero;
+      const uint64_t size = (size_or_zero == 0) ? default_input_chunk_size() : size_or_zero;
       ICICLE_ASSERT(size > 0) << "Cannot infer hash size. Make sure to pass it to hasher.hash(...size...) or have "
                                  "default size for the hasher";
       return size;

--- a/icicle/include/icicle/backend/merkle/merkle_tree_backend.h
+++ b/icicle/include/icicle/backend/merkle/merkle_tree_backend.h
@@ -36,7 +36,7 @@ namespace icicle {
            "(nof_layers="
         << layer_hashes.size() << ", output_store_min_layer=" << output_store_min_layer << ")\n";
 
-      ICICLE_ASSERT(layer_hashes[0].input_default_chunk_size() % leaf_element_size == 0)
+      ICICLE_ASSERT(layer_hashes[0].default_input_chunk_size() % leaf_element_size == 0)
         << "A whole number of leaves must be fitted into the hashes of the first layer.\n";
     }
 

--- a/icicle/include/icicle/hash/hash.h
+++ b/icicle/include/icicle/hash/hash.h
@@ -65,7 +65,7 @@ namespace icicle {
      * @brief Get the default input chunk size.
      * @return The size of the default input chunk in bytes.
      */
-    inline uint64_t input_default_chunk_size() const { return m_backend->input_default_chunk_size(); }
+    inline uint64_t default_input_chunk_size() const { return m_backend->default_input_chunk_size(); }
 
     /**
      * @brief Get the output size in bytes.

--- a/icicle/include/icicle/merkle/merkle_tree.h
+++ b/icicle/include/icicle/merkle/merkle_tree.h
@@ -161,7 +161,7 @@ namespace icicle {
         leaf_element_start = (leaf_element_start / hash_input_size) * hash_output_size;
 
         // Calculate the previous hash result offset inside the current hash input
-        hash_input_size = layer_hashes[layer_idx].input_default_chunk_size();
+        hash_input_size = layer_hashes[layer_idx].default_input_chunk_size();
         hash_output_size = layer_hashes[layer_idx].output_size();
         const int element_offset_in_path = leaf_element_start % hash_input_size;
 

--- a/icicle/run
+++ b/icicle/run
@@ -1,0 +1,4 @@
+#rm -rf build
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DSANITIZE=ON -DFIELD=babybear -S . -B build
+cmake --build build -j
+build/tests/test_hash_api --gtest_filter="*Merkle*"

--- a/icicle/run
+++ b/icicle/run
@@ -1,4 +1,0 @@
-#rm -rf build
-cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DSANITIZE=ON -DFIELD=babybear -S . -B build
-cmake --build build -j
-build/tests/test_hash_api --gtest_filter="*Merkle*"

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -323,7 +323,7 @@ void assert_valid_tree(
   const MerkleTreeConfig& config)
 {
   ICICLE_ASSERT(!hashes.empty());
-  int output_size = input_size * hashes[0].output_size() / hashes[0].input_default_chunk_size();
+  int output_size = input_size * hashes[0].output_size() / hashes[0].default_input_chunk_size();
   auto layer_in =
     std::make_unique<std::byte[]>(input_size); // Going layer by layer - having the input layer as the largest
   auto layer_out =
@@ -334,12 +334,12 @@ void assert_valid_tree(
 
   int side_inputs_offset = 0;
   for (auto& layer_hash : hashes) {
-    output_size = input_size * layer_hash.output_size() / layer_hash.input_default_chunk_size();
-    const int nof_hashes = input_size / layer_hash.input_default_chunk_size();
+    output_size = input_size * layer_hash.output_size() / layer_hash.default_input_chunk_size();
+    const int nof_hashes = input_size / layer_hash.default_input_chunk_size();
 
     auto config = default_hash_config();
     config.batch = nof_hashes;
-    layer_hash.hash(layer_in.get(), layer_hash.input_default_chunk_size(), config, layer_out.get());
+    layer_hash.hash(layer_in.get(), layer_hash.default_input_chunk_size(), config, layer_out.get());
 
     // copy output outputs to inputs before moving to the next layer
     memcpy(layer_in.get(), layer_out.get(), output_size);


### PR DESCRIPTION
align the name of the function default_input_chunk_size across all.

cuda-backend-branch: naming-alignment