### PR TITLE
Replace rand() with rand_uint_32b() for reproducibility

### DIFF
--- a/icicle/include/icicle/utils/rand_gen.h
+++ b/icicle/include/icicle/utils/rand_gen.h
@@ -10,8 +10,8 @@ static void seed_rand_generator(unsigned seed) { rand_generator.seed(seed); }
  * @param max Upper limit.
  * @return Random (uniform distribution) unsigned integer s.t. min <= integer <= max.
  */
-static uint32_t rand_int(uint32_t min = 0, uint32_t max = UINT32_MAX)
+static uint32_t rand_uint_32b(uint32_t min = 0, uint32_t max = UINT32_MAX)
 {
-  std::uniform_int_distribution<int> dist(min, max);
+  std::uniform_int_distribution<uint32_t> dist(min, max);
   return dist(rand_generator);
 }

--- a/icicle/include/icicle/utils/rand_gen.h
+++ b/icicle/include/icicle/utils/rand_gen.h
@@ -3,3 +3,15 @@
 
 inline std::mt19937 rand_generator = std::mt19937{std::random_device{}()};
 static void seed_rand_generator(unsigned seed) { rand_generator.seed(seed); }
+
+/**
+ * @brief Generate random unsigned integer in range (inclusive)
+ * @param min Lower limit.
+ * @param max Upper limit.
+ * @return Random (uniform distribution) unsigned integer s.t. min <= integer <= max.
+ */
+static uint32_t rand_int(uint32_t min = 0, uint32_t max = UINT32_MAX)
+{
+  std::uniform_int_distribution<int> dist(min, max);
+  return dist(rand_generator);
+}

--- a/icicle/tests/test_base.h
+++ b/icicle/tests/test_base.h
@@ -52,8 +52,7 @@ public:
   void SetUp() override
   {
     unsigned seed = time(NULL);
-    srand(seed);
-    ICICLE_LOG_INFO << "Seed for tests is: " << seed;
+    ICICLE_LOG_INFO << "Seed for test is: " << seed;
     seed_rand_generator(seed);
   }
   void TearDown() override {}

--- a/icicle/tests/test_base.h
+++ b/icicle/tests/test_base.h
@@ -28,10 +28,6 @@ public:
   // SetUpTestSuite/TearDownTestSuite are called once for the entire test suite
   static void SetUpTestSuite()
   {
-    unsigned seed = time(NULL);
-    srand(seed);
-    ICICLE_LOG_INFO << "Seed for tests is: " << seed;
-    seed_rand_generator(seed);
 #ifdef BACKEND_BUILD_DIR
     setenv("ICICLE_BACKEND_INSTALL_DIR", BACKEND_BUILD_DIR, 0 /*=replace*/);
 #endif
@@ -53,7 +49,13 @@ public:
   static void TearDownTestSuite() {}
 
   // SetUp/TearDown are called before and after each test
-  void SetUp() override {}
+  void SetUp() override
+  {
+    unsigned seed = time(NULL);
+    srand(seed);
+    ICICLE_LOG_INFO << "Seed for tests is: " << seed;
+    seed_rand_generator(seed);
+  }
   void TearDown() override {}
 
   bool is_main_device_available() const { return s_main_device != UNKOWN_DEVICE && s_main_device != "CPU"; }

--- a/icicle/tests/test_curve_api.cpp
+++ b/icicle/tests/test_curve_api.cpp
@@ -15,6 +15,7 @@
 #include "icicle/backend/ntt_config.h"
 
 #include "test_base.h"
+#include "icicle/utils/rand_gen.h"
 
 using namespace curve_config;
 using namespace icicle;
@@ -36,8 +37,8 @@ public:
   {
     const int logn = 12;
     const int batch = 3;
-    const int N = (1 << logn) - rand() % (5 * logn); // make it not always power of two
-    const int precompute_factor = (rand() & 7) + 1;  // between 1 and 8
+    const int N = (1 << logn) - rand_int(0, 5 * logn); // make it not always power of two
+    const int precompute_factor = rand_int(0, 7) + 1;  // between 1 and 8
     const int total_nof_elemets = batch * N;
 
     auto scalars = std::make_unique<scalar_t[]>(total_nof_elemets);
@@ -90,8 +91,8 @@ public:
     // As such the default amount of tasks and 1 thread shouldn't be enough and the program should readjust the task
     // number per thread.
     const int batch = 3;
-    const int N = (1 << logn) - rand() % (5 * logn); // make it not always power of two
-    const int precompute_factor = 1;                 // Precompute is 1 to increase number of BMs
+    const int N = (1 << logn) - rand_int(0, 5 * logn); // make it not always power of two
+    const int precompute_factor = 1;                   // Precompute is 1 to increase number of BMs
     const int total_nof_elemets = batch * N;
 
     auto scalars = std::make_unique<scalar_t[]>(total_nof_elemets);

--- a/icicle/tests/test_curve_api.cpp
+++ b/icicle/tests/test_curve_api.cpp
@@ -37,8 +37,8 @@ public:
   {
     const int logn = 12;
     const int batch = 3;
-    const int N = (1 << logn) - rand_int(0, 5 * logn); // make it not always power of two
-    const int precompute_factor = rand_int(0, 7) + 1;  // between 1 and 8
+    const int N = (1 << logn) - rand_uint_32b(0, 5 * logn); // make it not always power of two
+    const int precompute_factor = rand_uint_32b(0, 7) + 1;  // between 1 and 8
     const int total_nof_elemets = batch * N;
 
     auto scalars = std::make_unique<scalar_t[]>(total_nof_elemets);
@@ -91,7 +91,7 @@ public:
     // As such the default amount of tasks and 1 thread shouldn't be enough and the program should readjust the task
     // number per thread.
     const int batch = 3;
-    const int N = (1 << logn) - rand_int(0, 5 * logn); // make it not always power of two
+    const int N = (1 << logn) - rand_uint_32b(0, 5 * logn); // make it not always power of two
     const int precompute_factor = 1;                   // Precompute is 1 to increase number of BMs
     const int total_nof_elemets = batch * N;
 

--- a/icicle/tests/test_curve_api.cpp
+++ b/icicle/tests/test_curve_api.cpp
@@ -92,7 +92,7 @@ public:
     // number per thread.
     const int batch = 3;
     const int N = (1 << logn) - rand_uint_32b(0, 5 * logn); // make it not always power of two
-    const int precompute_factor = 1;                   // Precompute is 1 to increase number of BMs
+    const int precompute_factor = 1;                        // Precompute is 1 to increase number of BMs
     const int total_nof_elemets = batch * N;
 
     auto scalars = std::make_unique<scalar_t[]>(total_nof_elemets);

--- a/icicle/tests/test_device_api.cpp
+++ b/icicle/tests/test_device_api.cpp
@@ -184,7 +184,7 @@ TEST_F(DeviceApiTest, memoryTracker)
   START_TIMER(lookup);
   for (auto& it : allocated_addresses) {
     // identify addresses identified correctly (to active device)
-    const void* addr = (void*)((size_t)it + rand_int(0, RAND_MAX) % ALLOC_SIZE);
+    const void* addr = (void*)((size_t)it + rand_uint_32b(0, RAND_MAX) % ALLOC_SIZE);
     ICICLE_CHECK(icicle_is_active_device_memory(addr));
   }
   END_TIMER_AVERAGE(lookup, "memory-tracker: lookup (and compare) average", true, NOF_ALLOCS);
@@ -196,7 +196,7 @@ TEST_F(DeviceApiTest, memoryTracker)
 
   // test that we still identify correctly after switching device
   icicle_set_device({"CPU", 0});
-  const void* addr = (void*)((size_t)*allocated_addresses.begin() + rand_int(0, RAND_MAX) % ALLOC_SIZE);
+  const void* addr = (void*)((size_t)*allocated_addresses.begin() + rand_uint_32b(0, RAND_MAX) % ALLOC_SIZE);
   ASSERT_EQ(eIcicleError::INVALID_POINTER, icicle_is_active_device_memory(addr));
   ASSERT_EQ(eIcicleError::INVALID_POINTER, icicle_is_active_device_memory(host_mem.get()));
   auto it = tracker.identify(addr);

--- a/icicle/tests/test_device_api.cpp
+++ b/icicle/tests/test_device_api.cpp
@@ -5,6 +5,7 @@
 #include "icicle/runtime.h"
 #include "icicle/memory_tracker.h"
 #include "test_base.h"
+#include "icicle/utils/rand_gen.h"
 
 using namespace icicle;
 
@@ -183,7 +184,7 @@ TEST_F(DeviceApiTest, memoryTracker)
   START_TIMER(lookup);
   for (auto& it : allocated_addresses) {
     // identify addresses identified correctly (to active device)
-    const void* addr = (void*)((size_t)it + rand() % ALLOC_SIZE);
+    const void* addr = (void*)((size_t)it + rand_int(0, RAND_MAX) % ALLOC_SIZE);
     ICICLE_CHECK(icicle_is_active_device_memory(addr));
   }
   END_TIMER_AVERAGE(lookup, "memory-tracker: lookup (and compare) average", true, NOF_ALLOCS);
@@ -195,7 +196,7 @@ TEST_F(DeviceApiTest, memoryTracker)
 
   // test that we still identify correctly after switching device
   icicle_set_device({"CPU", 0});
-  const void* addr = (void*)((size_t)*allocated_addresses.begin() + rand() % ALLOC_SIZE);
+  const void* addr = (void*)((size_t)*allocated_addresses.begin() + rand_int(0, RAND_MAX) % ALLOC_SIZE);
   ASSERT_EQ(eIcicleError::INVALID_POINTER, icicle_is_active_device_memory(addr));
   ASSERT_EQ(eIcicleError::INVALID_POINTER, icicle_is_active_device_memory(host_mem.get()));
   auto it = tracker.identify(addr);

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -419,10 +419,10 @@ TEST_F(FieldApiTestBase, scalarVectorOps)
 
 TYPED_TEST(FieldApiTest, matrixAPIsAsync)
 {
-  const int R =
-    1 << rand_uint_32b(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
-  const int C =
-    1 << rand_uint_32b(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
+  const int R = 1 << rand_uint_32b(
+                  2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
+  const int C = 1 << rand_uint_32b(
+                  2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
   const int batch_size = 1 << rand_uint_32b(0, 3);
   const bool columns_batch = rand_uint_32b(0, 1);
   const bool is_in_place = IcicleTestBase::is_main_device_available() ? 0 : rand_uint_32b(0, 1);

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -61,9 +61,9 @@ TYPED_TEST(FieldApiTest, FieldSanityTest)
 
 TYPED_TEST(FieldApiTest, vectorVectorOps)
 {
-  const uint64_t N = 1 << rand_int(3, 17);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
+  const uint64_t N = 1 << rand_uint_32b(3, 17);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
 
   ICICLE_LOG_DEBUG << "N = " << N;
   ICICLE_LOG_DEBUG << "batch_size = " << batch_size;
@@ -176,10 +176,10 @@ TYPED_TEST(FieldApiTest, vectorVectorOps)
 
 TYPED_TEST(FieldApiTest, montgomeryConversion)
 {
-  const uint64_t N = 1 << rand_int(3, 17);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
-  const bool is_to_montgomery = rand_int(0, 1);
+  const uint64_t N = 1 << rand_uint_32b(3, 17);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
+  const bool is_to_montgomery = rand_uint_32b(0, 1);
   ICICLE_LOG_DEBUG << "N = " << N;
   ICICLE_LOG_DEBUG << "batch_size = " << batch_size;
   ICICLE_LOG_DEBUG << "columns_batch = " << columns_batch;
@@ -228,9 +228,9 @@ TYPED_TEST(FieldApiTest, montgomeryConversion)
 
 TEST_F(FieldApiTestBase, VectorReduceOps)
 {
-  const uint64_t N = 1 << rand_int(3, 17);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
+  const uint64_t N = 1 << rand_uint_32b(3, 17);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
   const int total_size = N * batch_size;
 
   ICICLE_LOG_DEBUG << "N = " << N;
@@ -310,9 +310,9 @@ TEST_F(FieldApiTestBase, VectorReduceOps)
 
 TEST_F(FieldApiTestBase, scalarVectorOps)
 {
-  const uint64_t N = 1 << rand_int(3, 17);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
+  const uint64_t N = 1 << rand_uint_32b(3, 17);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
 
   ICICLE_LOG_DEBUG << "N = " << N;
   ICICLE_LOG_DEBUG << "batch_size = " << batch_size;
@@ -420,12 +420,12 @@ TEST_F(FieldApiTestBase, scalarVectorOps)
 TYPED_TEST(FieldApiTest, matrixAPIsAsync)
 {
   const int R =
-    1 << rand_int(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
+    1 << rand_uint_32b(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
   const int C =
-    1 << rand_int(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
-  const int batch_size = 1 << rand_int(0, 3);
-  const bool columns_batch = rand_int(0, 1);
-  const bool is_in_place = IcicleTestBase::is_main_device_available() ? 0 : rand_int(0, 1);
+    1 << rand_uint_32b(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
+  const int batch_size = 1 << rand_uint_32b(0, 3);
+  const bool columns_batch = rand_uint_32b(0, 1);
+  const bool is_in_place = IcicleTestBase::is_main_device_available() ? 0 : rand_uint_32b(0, 1);
 
   ICICLE_LOG_DEBUG << "rows = " << R;
   ICICLE_LOG_DEBUG << "cols = " << C;
@@ -518,10 +518,10 @@ TYPED_TEST(FieldApiTest, matrixAPIsAsync)
 
 TYPED_TEST(FieldApiTest, bitReverse)
 {
-  const uint64_t N = 1 << rand_int(3, 17);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
-  const bool is_in_place = rand_int(0, 1);
+  const uint64_t N = 1 << rand_uint_32b(3, 17);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
+  const bool is_in_place = rand_uint_32b(0, 1);
   const int total_size = N * batch_size;
 
   ICICLE_LOG_DEBUG << "N = " << N;
@@ -591,12 +591,12 @@ TYPED_TEST(FieldApiTest, bitReverse)
 
 TYPED_TEST(FieldApiTest, Slice)
 {
-  const uint64_t size_in = 1 << rand_int(3, 17);
-  const uint64_t offset = rand_int(0, 14);
-  const uint64_t stride = rand_int(1, 4);
-  const uint64_t size_out = rand_int(0, ((size_in - offset) / stride) - 1);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
+  const uint64_t size_in = 1 << rand_uint_32b(3, 17);
+  const uint64_t offset = rand_uint_32b(0, 14);
+  const uint64_t stride = rand_uint_32b(1, 4);
+  const uint64_t size_out = rand_uint_32b(0, ((size_in - offset) / stride) - 1);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
 
   ICICLE_LOG_DEBUG << "size_in = " << size_in;
   ICICLE_LOG_DEBUG << "size_out = " << size_out;
@@ -652,9 +652,9 @@ TYPED_TEST(FieldApiTest, Slice)
 
 TEST_F(FieldApiTestBase, highestNonZeroIdx)
 {
-  const uint64_t N = 1 << rand_int(3, 17);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
+  const uint64_t N = 1 << rand_uint_32b(3, 17);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
   const int total_size = N * batch_size;
 
   auto in_a = std::make_unique<scalar_t[]>(total_size);
@@ -690,10 +690,10 @@ TEST_F(FieldApiTestBase, highestNonZeroIdx)
 
 TEST_F(FieldApiTestBase, polynomialEval)
 {
-  const uint64_t coeffs_size = 1 << rand_int(4, 13);
-  const uint64_t domain_size = 1 << rand_int(2, 9);
-  const int batch_size = 1 << rand_int(0, 4);
-  const bool columns_batch = rand_int(0, 1);
+  const uint64_t coeffs_size = 1 << rand_uint_32b(4, 13);
+  const uint64_t domain_size = 1 << rand_uint_32b(2, 9);
+  const int batch_size = 1 << rand_uint_32b(0, 4);
+  const bool columns_batch = rand_uint_32b(0, 1);
 
   ICICLE_LOG_DEBUG << "coeffs_size = " << coeffs_size;
   ICICLE_LOG_DEBUG << "domain_size = " << domain_size;
@@ -735,11 +735,11 @@ TEST_F(FieldApiTestBase, polynomialEval)
 
 TEST_F(FieldApiTestBase, polynomialDivision)
 {
-  const uint64_t numerator_size = 1 << rand_int(5, 7);
-  const uint64_t denominator_size = 1 << rand_int(3, 4);
+  const uint64_t numerator_size = 1 << rand_uint_32b(5, 7);
+  const uint64_t denominator_size = 1 << rand_uint_32b(3, 4);
   const uint64_t q_size = numerator_size - denominator_size + 1;
   const uint64_t r_size = numerator_size;
-  const int batch_size = rand_int(10, 19);
+  const int batch_size = rand_uint_32b(10, 19);
 
   // basically we compute q(x),r(x) for a(x)=q(x)b(x)+r(x) by dividing a(x)/b(x)
 
@@ -811,22 +811,22 @@ TEST_F(FieldApiTestBase, polynomialDivision)
 TYPED_TEST(FieldApiTest, ntt)
 {
   // Randomize configuration
-  const bool inplace = rand_int(0, 1);
-  const int logn = rand_int(3, 17);
+  const bool inplace = rand_uint_32b(0, 1);
+  const int logn = rand_uint_32b(3, 17);
   const uint64_t N = 1 << logn;
   const int log_ntt_domain_size = logn + 1;
-  const int log_batch_size = rand_int(0, 2);
+  const int log_batch_size = rand_uint_32b(0, 2);
   const int batch_size = 1 << log_batch_size;
-  const int _ordering = rand_int(0, 3);
+  const int _ordering = rand_uint_32b(0, 3);
   const Ordering ordering = static_cast<Ordering>(_ordering);
   bool columns_batch;
   if (logn == 7 || logn < 4) {
     columns_batch = false; // currently not supported (icicle_v3/backend/cuda/src/ntt/ntt.cuh line 578)
   } else {
-    columns_batch = rand_int(0, 1);
+    columns_batch = rand_uint_32b(0, 1);
   }
-  const NTTDir dir = static_cast<NTTDir>(rand_int(0, 1)); // 0: forward, 1: inverse
-  const int log_coset_stride = rand_int(0, 2);
+  const NTTDir dir = static_cast<NTTDir>(rand_uint_32b(0, 1)); // 0: forward, 1: inverse
+  const int log_coset_stride = rand_uint_32b(0, 2);
   scalar_t coset_gen;
   if (log_coset_stride) {
     coset_gen = scalar_t::omega(logn + log_coset_stride);

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -61,12 +61,9 @@ TYPED_TEST(FieldApiTest, FieldSanityTest)
 
 TYPED_TEST(FieldApiTest, vectorVectorOps)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t N = 1 << (rand() % 15 + 3);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
+  const uint64_t N = 1 << rand_int(3, 17);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
 
   ICICLE_LOG_DEBUG << "N = " << N;
   ICICLE_LOG_DEBUG << "batch_size = " << batch_size;
@@ -179,13 +176,10 @@ TYPED_TEST(FieldApiTest, vectorVectorOps)
 
 TYPED_TEST(FieldApiTest, montgomeryConversion)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t N = 1 << (rand() % 15 + 3);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
-  const bool is_to_montgomery = rand() % 2;
+  const uint64_t N = 1 << rand_int(3, 17);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
+  const bool is_to_montgomery = rand_int(0, 1);
   ICICLE_LOG_DEBUG << "N = " << N;
   ICICLE_LOG_DEBUG << "batch_size = " << batch_size;
   ICICLE_LOG_DEBUG << "columns_batch = " << columns_batch;
@@ -234,12 +228,9 @@ TYPED_TEST(FieldApiTest, montgomeryConversion)
 
 TEST_F(FieldApiTestBase, VectorReduceOps)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t N = 1 << (rand() % 15 + 3);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
+  const uint64_t N = 1 << rand_int(3, 17);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
   const int total_size = N * batch_size;
 
   ICICLE_LOG_DEBUG << "N = " << N;
@@ -319,12 +310,9 @@ TEST_F(FieldApiTestBase, VectorReduceOps)
 
 TEST_F(FieldApiTestBase, scalarVectorOps)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t N = 1 << (rand() % 15 + 3);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
+  const uint64_t N = 1 << rand_int(3, 17);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
 
   ICICLE_LOG_DEBUG << "N = " << N;
   ICICLE_LOG_DEBUG << "batch_size = " << batch_size;
@@ -431,20 +419,13 @@ TEST_F(FieldApiTestBase, scalarVectorOps)
 
 TYPED_TEST(FieldApiTest, matrixAPIsAsync)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
   const int R =
-    1
-    << (rand() % 8 + 2); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
+    1 << rand_int(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
   const int C =
-    1
-    << (rand() % 8 + 2); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
-  const int batch_size = 1 << (rand() % 4);
-  const bool columns_batch = rand() % 2;
-  const bool is_in_place = IcicleTestBase::is_main_device_available()
-                             ? 0
-                             : rand() % 2; // TODO - fix inplace (Hadar: I'm not sure we should support it)
+    1 << rand_int(2, 9); // cpu implementation for out of place transpose also supports sizes which are not powers of 2
+  const int batch_size = 1 << rand_int(0, 3);
+  const bool columns_batch = rand_int(0, 1);
+  const bool is_in_place = IcicleTestBase::is_main_device_available() ? 0 : rand_int(0, 1);
 
   ICICLE_LOG_DEBUG << "rows = " << R;
   ICICLE_LOG_DEBUG << "cols = " << C;
@@ -537,13 +518,10 @@ TYPED_TEST(FieldApiTest, matrixAPIsAsync)
 
 TYPED_TEST(FieldApiTest, bitReverse)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t N = 1 << (rand() % 15 + 3);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
-  const bool is_in_place = rand() % 2;
+  const uint64_t N = 1 << rand_int(3, 17);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
+  const bool is_in_place = rand_int(0, 1);
   const int total_size = N * batch_size;
 
   ICICLE_LOG_DEBUG << "N = " << N;
@@ -613,15 +591,12 @@ TYPED_TEST(FieldApiTest, bitReverse)
 
 TYPED_TEST(FieldApiTest, Slice)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t size_in = 1 << (rand() % 15 + 5);
-  const uint64_t offset = rand() % 15;
-  const uint64_t stride = rand() % 4 + 1;
-  const uint64_t size_out = rand() % (((size_in - offset) / stride) - 1) + 1;
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
+  const uint64_t size_in = 1 << rand_int(3, 17);
+  const uint64_t offset = rand_int(0, 14);
+  const uint64_t stride = rand_int(1, 4);
+  const uint64_t size_out = rand_int(0, ((size_in - offset) / stride) - 1);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
 
   ICICLE_LOG_DEBUG << "size_in = " << size_in;
   ICICLE_LOG_DEBUG << "size_out = " << size_out;
@@ -677,12 +652,9 @@ TYPED_TEST(FieldApiTest, Slice)
 
 TEST_F(FieldApiTestBase, highestNonZeroIdx)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t N = 1 << (rand() % 15 + 3);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
+  const uint64_t N = 1 << rand_int(3, 17);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
   const int total_size = N * batch_size;
 
   auto in_a = std::make_unique<scalar_t[]>(total_size);
@@ -718,13 +690,10 @@ TEST_F(FieldApiTestBase, highestNonZeroIdx)
 
 TEST_F(FieldApiTestBase, polynomialEval)
 {
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const uint64_t coeffs_size = 1 << (rand() % 10 + 4);
-  const uint64_t domain_size = 1 << (rand() % 8 + 2);
-  const int batch_size = 1 << (rand() % 5);
-  const bool columns_batch = rand() % 2;
+  const uint64_t coeffs_size = 1 << rand_int(4, 13);
+  const uint64_t domain_size = 1 << rand_int(2, 9);
+  const int batch_size = 1 << rand_int(0, 4);
+  const bool columns_batch = rand_int(0, 1);
 
   ICICLE_LOG_DEBUG << "coeffs_size = " << coeffs_size;
   ICICLE_LOG_DEBUG << "domain_size = " << domain_size;
@@ -766,13 +735,11 @@ TEST_F(FieldApiTestBase, polynomialEval)
 
 TEST_F(FieldApiTestBase, polynomialDivision)
 {
-  int seed = time(0);
-  srand(seed);
-  const uint64_t numerator_size = 1 << (rand() % 3 + 5);
-  const uint64_t denominator_size = 1 << (rand() % 2 + 3);
+  const uint64_t numerator_size = 1 << rand_int(5, 7);
+  const uint64_t denominator_size = 1 << rand_int(3, 4);
   const uint64_t q_size = numerator_size - denominator_size + 1;
   const uint64_t r_size = numerator_size;
-  const int batch_size = 10 + rand() % 10;
+  const int batch_size = rand_int(10, 19);
 
   // basically we compute q(x),r(x) for a(x)=q(x)b(x)+r(x) by dividing a(x)/b(x)
 
@@ -844,26 +811,22 @@ TEST_F(FieldApiTestBase, polynomialDivision)
 TYPED_TEST(FieldApiTest, ntt)
 {
   // Randomize configuration
-
-  int seed = time(0);
-  srand(seed);
-  ICICLE_LOG_DEBUG << "seed = " << seed;
-  const bool inplace = rand() % 2;
-  const int logn = rand() % 15 + 3;
+  const bool inplace = rand_int(0, 1);
+  const int logn = rand_int(3, 17);
   const uint64_t N = 1 << logn;
   const int log_ntt_domain_size = logn + 1;
-  const int log_batch_size = rand() % 3;
+  const int log_batch_size = rand_int(0, 2);
   const int batch_size = 1 << log_batch_size;
-  const int _ordering = rand() % 4;
+  const int _ordering = rand_int(0, 3);
   const Ordering ordering = static_cast<Ordering>(_ordering);
   bool columns_batch;
   if (logn == 7 || logn < 4) {
     columns_batch = false; // currently not supported (icicle_v3/backend/cuda/src/ntt/ntt.cuh line 578)
   } else {
-    columns_batch = rand() % 2;
+    columns_batch = rand_int(0, 1);
   }
-  const NTTDir dir = static_cast<NTTDir>(rand() % 2); // 0: forward, 1: inverse
-  const int log_coset_stride = rand() % 3;
+  const NTTDir dir = static_cast<NTTDir>(rand_int(0, 1)); // 0: forward, 1: inverse
+  const int log_coset_stride = rand_int(0, 2);
   scalar_t coset_gen;
   if (log_coset_stride) {
     coset_gen = scalar_t::omega(logn + log_coset_stride);

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -591,10 +591,10 @@ TYPED_TEST(FieldApiTest, bitReverse)
 
 TYPED_TEST(FieldApiTest, Slice)
 {
-  const uint64_t size_in = 1 << rand_uint_32b(3, 17);
+  const uint64_t size_in = 1 << rand_uint_32b(4, 17);
   const uint64_t offset = rand_uint_32b(0, 14);
   const uint64_t stride = rand_uint_32b(1, 4);
-  const uint64_t size_out = rand_uint_32b(0, ((size_in - offset) / stride) - 1);
+  const uint64_t size_out = rand_uint_32b(0, (size_in - offset) / stride);
   const int batch_size = 1 << rand_uint_32b(0, 4);
   const bool columns_batch = rand_uint_32b(0, 1);
 

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -481,7 +481,7 @@ void test_merkle_tree(
     // int leaf_idx = (wrong_indices[i] % (nof_leaves * leaf_size)) / leaf_size;
     int leaf_idx = (wrong_indices[i] % (nof_leaves * leaf_size)) / leaf_size;
     ICICLE_LOG_DEBUG << "Checking proof of index " << leaf_idx << " (Byte idx "
-                    << (wrong_indices[i] % (nof_leaves * leaf_size)) << ")";
+                     << (wrong_indices[i] % (nof_leaves * leaf_size)) << ")";
 
     // get root and merkle-path for a leaf
     auto [root, root_size] = prover_tree.get_merkle_root();

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -28,12 +28,10 @@ public:
   template <typename T>
   static void randomize(T* arr, uint64_t size)
   {
-    std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX); // Range of random numbers
-
     // Fill the array with random values
     uint32_t* u32_arr = (uint32_t*)arr;
     for (int i = 0; i < (size * sizeof(T) / sizeof(uint32_t)); ++i) {
-      u32_arr[i] = dist(rand_generator);
+      u32_arr[i] = rand_uint_32b();
     }
   }
 
@@ -461,7 +459,7 @@ void test_merkle_tree(
 
     uint8_t new_worng_val;
     do {
-      new_worng_val = rand_int(0, UINT8_MAX);
+      new_worng_val = rand_uint_32b(0, UINT8_MAX);
     } while (new_worng_val == wrong_leaves_byte_ptr[wrong_byte_index]);
 
     wrong_leaves_byte_ptr[wrong_byte_index] = new_worng_val;
@@ -482,7 +480,7 @@ void test_merkle_tree(
   for (int i = 0; i < nof_indices_modified; i++) {
     // int leaf_idx = (wrong_indices[i] % (nof_leaves * leaf_size)) / leaf_size;
     int leaf_idx = (wrong_indices[i] % (nof_leaves * leaf_size)) / leaf_size;
-    ICICLE_LOG_INFO << "Checking proof of index " << leaf_idx << " (Byte idx "
+    ICICLE_LOG_DEBUG << "Checking proof of index " << leaf_idx << " (Byte idx "
                     << (wrong_indices[i] % (nof_leaves * leaf_size)) << ")";
 
     // get root and merkle-path for a leaf
@@ -608,12 +606,12 @@ TEST_F(HashApiTest, MerkleTreeZeroPadding)
   test_merkle_tree(hashes, config, output_store_min_layer, 1, leaves);
 
   ICICLE_LOG_DEBUG << "A whole number of hashes is missing";
-  int nof_hashes = rand_int(1, total_nof_input_hashes - 1);
+  int nof_hashes = rand_uint_32b(1, total_nof_input_hashes - 1);
   ICICLE_LOG_DEBUG << "Number of used hashes: " << nof_hashes << " / " << total_nof_input_hashes;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_hashes * nof_leaves_in_hash, leaves);
 
   ICICLE_LOG_DEBUG << "Random amount of leaves";
-  int nof_partial_leaves = rand_int(0, nof_leaves - 1);
+  int nof_partial_leaves = rand_uint_32b(0, nof_leaves - 1);
   ICICLE_LOG_DEBUG << "Random amount of leaves: " << nof_partial_leaves << " / " << nof_leaves;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_partial_leaves, leaves);
 
@@ -621,7 +619,7 @@ TEST_F(HashApiTest, MerkleTreeZeroPadding)
   auto byte_leaves = reinterpret_cast<const std::byte*>(leaves);
   int byte_size;
   do {
-    byte_size = rand_int(1, nof_leaves * leaf_size);
+    byte_size = rand_uint_32b(1, nof_leaves * leaf_size);
   } while (byte_size % leaf_size == 0);
   byte_size = 327;
   ICICLE_LOG_DEBUG << "Size of input in bytes: " << byte_size << "\t(" << float(byte_size) / leaf_size << " / "
@@ -640,7 +638,7 @@ TEST_F(HashApiTest, MerkleTreeZeroPadding)
   auto wrong_bytes = std::make_unique<std::byte[]>(byte_size);
   memcpy(wrong_bytes.get(), byte_leaves, byte_size);
   // Modify the last byte as the only difference of this test from the previous is proof for the partial index
-  wrong_bytes[byte_size - 1] = static_cast<std::byte>(rand_int(0, UINT8_MAX));
+  wrong_bytes[byte_size - 1] = static_cast<std::byte>(rand_uint_32b(0, UINT8_MAX));
 
   int leaf_idx = byte_size / leaf_size;
   ICICLE_LOG_DEBUG << "Checking proof of index " << leaf_idx << " (Byte idx " << leaf_idx * leaf_size << ")";
@@ -729,12 +727,12 @@ TEST_F(HashApiTest, MerkleTreeLastValuePadding)
   test_merkle_tree(hashes, config, output_store_min_layer, 1, leaves);
 
   ICICLE_LOG_DEBUG << "A whole number of hashes is missing";
-  int nof_hashes = rand_int(1, total_nof_input_hashes - 1);
+  int nof_hashes = rand_uint_32b(1, total_nof_input_hashes - 1);
   ICICLE_LOG_DEBUG << "Number of used hashes: " << nof_hashes << " / " << total_nof_input_hashes;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_hashes * nof_leaves_in_hash, leaves);
 
   ICICLE_LOG_DEBUG << "Random amount of leaves";
-  int nof_partial_leaves = rand_int(1, nof_leaves - 1);
+  int nof_partial_leaves = rand_uint_32b(1, nof_leaves - 1);
   ICICLE_LOG_DEBUG << "Random amount of leaves: " << nof_partial_leaves << " / " << nof_leaves;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_partial_leaves, leaves);
 
@@ -742,7 +740,7 @@ TEST_F(HashApiTest, MerkleTreeLastValuePadding)
   auto byte_leaves = reinterpret_cast<const std::byte*>(leaves);
   int byte_size;
   do {
-    byte_size = rand_int(1, nof_leaves * leaf_size - 1);
+    byte_size = rand_uint_32b(1, nof_leaves * leaf_size - 1);
   } while (byte_size % leaf_size == 0);
   byte_size = 327;
   ICICLE_LOG_DEBUG << "Size of input in bytes: " << byte_size << "\t(" << float(byte_size) / leaf_size << " / "
@@ -780,7 +778,7 @@ TEST_F(HashApiTest, MerkleTreeMixMediumSize)
 
     const std::vector<Hash> hashes = {layer0_hash, layer1_hash, layer2_hash, layer3_hash, layer4_hash};
 
-    const int output_store_min_layer = rand_int(0, hashes.size() - 1);
+    const int output_store_min_layer = rand_uint_32b(0, hashes.size() - 1);
     ICICLE_LOG_DEBUG << "Min store layer:\t" << output_store_min_layer;
 
     test_merkle_tree(hashes, config, output_store_min_layer, nof_leaves, leaves.get());

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 
 #include "test_base.h"
+#include "icicle/utils/rand_gen.h"
 
 using namespace icicle;
 
@@ -27,15 +28,12 @@ public:
   template <typename T>
   static void randomize(T* arr, uint64_t size)
   {
-    // Create a random number generator
-    std::random_device rd;                                       // Non-deterministic random number generator
-    std::mt19937 gen(rd());                                      // Mersenne Twister engine seeded with rd()
     std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX); // Range of random numbers
 
     // Fill the array with random values
     uint32_t* u32_arr = (uint32_t*)arr;
     for (int i = 0; i < (size * sizeof(T) / sizeof(uint32_t)); ++i) {
-      u32_arr[i] = dist(gen);
+      u32_arr[i] = dist(rand_generator);
     }
   }
 
@@ -463,7 +461,7 @@ void test_merkle_tree(
 
     uint8_t new_worng_val;
     do {
-      new_worng_val = rand();
+      new_worng_val = rand_int(0, UINT8_MAX);
     } while (new_worng_val == wrong_leaves_byte_ptr[wrong_byte_index]);
 
     wrong_leaves_byte_ptr[wrong_byte_index] = new_worng_val;
@@ -484,8 +482,8 @@ void test_merkle_tree(
   for (int i = 0; i < nof_indices_modified; i++) {
     // int leaf_idx = (wrong_indices[i] % (nof_leaves * leaf_size)) / leaf_size;
     int leaf_idx = (wrong_indices[i] % (nof_leaves * leaf_size)) / leaf_size;
-    ICICLE_LOG_DEBUG << "Checking proof of index " << leaf_idx << " (Byte idx "
-                     << (wrong_indices[i] % (nof_leaves * leaf_size)) << ")";
+    ICICLE_LOG_INFO << "Checking proof of index " << leaf_idx << " (Byte idx "
+                    << (wrong_indices[i] % (nof_leaves * leaf_size)) << ")";
 
     // get root and merkle-path for a leaf
     auto [root, root_size] = prover_tree.get_merkle_root();
@@ -610,12 +608,12 @@ TEST_F(HashApiTest, MerkleTreeZeroPadding)
   test_merkle_tree(hashes, config, output_store_min_layer, 1, leaves);
 
   ICICLE_LOG_DEBUG << "A whole number of hashes is missing";
-  int nof_hashes = ((rand() % (total_nof_input_hashes - 2)) + 1);
+  int nof_hashes = rand_int(1, total_nof_input_hashes - 1);
   ICICLE_LOG_DEBUG << "Number of used hashes: " << nof_hashes << " / " << total_nof_input_hashes;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_hashes * nof_leaves_in_hash, leaves);
 
   ICICLE_LOG_DEBUG << "Random amount of leaves";
-  int nof_partial_leaves = ((rand() % nof_leaves) + 1);
+  int nof_partial_leaves = rand_int(0, nof_leaves - 1);
   ICICLE_LOG_DEBUG << "Random amount of leaves: " << nof_partial_leaves << " / " << nof_leaves;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_partial_leaves, leaves);
 
@@ -623,7 +621,7 @@ TEST_F(HashApiTest, MerkleTreeZeroPadding)
   auto byte_leaves = reinterpret_cast<const std::byte*>(leaves);
   int byte_size;
   do {
-    byte_size = rand() % (nof_leaves * leaf_size);
+    byte_size = rand_int(1, nof_leaves * leaf_size);
   } while (byte_size % leaf_size == 0);
   byte_size = 327;
   ICICLE_LOG_DEBUG << "Size of input in bytes: " << byte_size << "\t(" << float(byte_size) / leaf_size << " / "
@@ -642,7 +640,7 @@ TEST_F(HashApiTest, MerkleTreeZeroPadding)
   auto wrong_bytes = std::make_unique<std::byte[]>(byte_size);
   memcpy(wrong_bytes.get(), byte_leaves, byte_size);
   // Modify the last byte as the only difference of this test from the previous is proof for the partial index
-  wrong_bytes[byte_size - 1] = static_cast<std::byte>(rand());
+  wrong_bytes[byte_size - 1] = static_cast<std::byte>(rand_int(0, UINT8_MAX));
 
   int leaf_idx = byte_size / leaf_size;
   ICICLE_LOG_DEBUG << "Checking proof of index " << leaf_idx << " (Byte idx " << leaf_idx * leaf_size << ")";
@@ -731,12 +729,12 @@ TEST_F(HashApiTest, MerkleTreeLastValuePadding)
   test_merkle_tree(hashes, config, output_store_min_layer, 1, leaves);
 
   ICICLE_LOG_DEBUG << "A whole number of hashes is missing";
-  int nof_hashes = ((rand() % (total_nof_input_hashes - 2)) + 1);
+  int nof_hashes = rand_int(1, total_nof_input_hashes - 1);
   ICICLE_LOG_DEBUG << "Number of used hashes: " << nof_hashes << " / " << total_nof_input_hashes;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_hashes * nof_leaves_in_hash, leaves);
 
   ICICLE_LOG_DEBUG << "Random amount of leaves";
-  int nof_partial_leaves = ((rand() % nof_leaves) + 1);
+  int nof_partial_leaves = rand_int(1, nof_leaves - 1);
   ICICLE_LOG_DEBUG << "Random amount of leaves: " << nof_partial_leaves << " / " << nof_leaves;
   test_merkle_tree(hashes, config, output_store_min_layer, nof_partial_leaves, leaves);
 
@@ -744,7 +742,7 @@ TEST_F(HashApiTest, MerkleTreeLastValuePadding)
   auto byte_leaves = reinterpret_cast<const std::byte*>(leaves);
   int byte_size;
   do {
-    byte_size = rand() % (nof_leaves * leaf_size);
+    byte_size = rand_int(1, nof_leaves * leaf_size - 1);
   } while (byte_size % leaf_size == 0);
   byte_size = 327;
   ICICLE_LOG_DEBUG << "Size of input in bytes: " << byte_size << "\t(" << float(byte_size) / leaf_size << " / "
@@ -782,7 +780,7 @@ TEST_F(HashApiTest, MerkleTreeMixMediumSize)
 
     const std::vector<Hash> hashes = {layer0_hash, layer1_hash, layer2_hash, layer3_hash, layer4_hash};
 
-    const int output_store_min_layer = rand() % hashes.size();
+    const int output_store_min_layer = rand_int(0, hashes.size() - 1);
     ICICLE_LOG_DEBUG << "Min store layer:\t" << output_store_min_layer;
 
     test_merkle_tree(hashes, config, output_store_min_layer, nof_leaves, leaves.get());


### PR DESCRIPTION
Continuation of the previous rand PR - replacing every place rand() is called with a new rand_int function based on the same rand_generator in rand_gen.h - making test runs deterministic when given a fixed seed (Aiding debugging).

