### PR TITLE
install clang in release dockers

### DIFF
--- a/scripts/release/Dockerfile.ubi8
+++ b/scripts/release/Dockerfile.ubi8
@@ -1,7 +1,28 @@
-# Use the official NVIDIA CUDA development image for ubi8 - rhel compatible
+# Use the official NVIDIA CUDA development image for UBI8 (RHEL-compatible)
 FROM nvidia/cuda:12.2.2-devel-ubi8
 
-# install cmake
-RUN dnf update -y && dnf install -y cmake
-# install ninja-build
-RUN dnf install -y ninja-build
+# Set non-interactive mode for package installations
+ENV DNF_YES_CLEAN_ALL=1
+
+# Install necessary tools and dependencies
+RUN dnf update -y && dnf install -y \
+    cmake \
+    ninja-build \
+    wget \
+    gnupg2 \
+    && dnf clean all
+
+# Add the RPM-based LLVM repository for Clang
+# RUN wget https://rpm.llvm.org/llvm-snapshot.gpg.key -O /etc/pki/rpm-gpg/RPM-GPG-KEY-clang && \
+#     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-clang && \
+#     echo -e "[llvm]\nname=LLVM\nbaseurl=https://rpm.llvm.org/centos8/\nenabled=1\ngpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-clang" > /etc/yum.repos.d/llvm.repo
+
+# Install Clang, LLDB, and LLD
+RUN dnf update -y && dnf install -y \
+    clang \
+    lldb \
+    lld \
+    && dnf clean all
+
+# Verify installations
+RUN clang --version && cmake --version && ninja --version

--- a/scripts/release/Dockerfile.ubi9
+++ b/scripts/release/Dockerfile.ubi9
@@ -1,7 +1,31 @@
-# Use the official NVIDIA CUDA development image for ubi9 - rhel compatible
+# Use the official NVIDIA CUDA development image for UBI9 (RHEL-compatible)
 FROM nvidia/cuda:12.2.2-devel-ubi9
 
-# install cmake
-RUN dnf update -y && dnf install -y cmake
-# install ninja-build
-RUN dnf install -y ninja-build
+# Set non-interactive mode for package installations
+ENV DNF_YES_CLEAN_ALL=1
+
+# Install necessary packages
+RUN dnf update -y && dnf install -y \
+    cmake \
+    ninja-build \
+    wget \
+    tar \
+    gcc \
+    gcc-c++ \
+    make \
+    gnupg \
+    && dnf clean all
+
+# Add LLVM repository for Clang installation
+# RUN wget https://apt.llvm.org/llvm-snapshot.gpg.key -O /etc/pki/rpm-gpg/RPM-GPG-KEY-clang && \
+#     echo -e "[llvm]\nname=LLVM\nbaseurl=https://apt.llvm.org/centos/\$releasever/llvm-toolchain/15.x/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-clang" > /etc/yum.repos.d/llvm.repo
+
+# Install Clang, LLDB, and LLD
+RUN dnf update -y && dnf install -y \
+    clang \
+    lldb \
+    lld \
+    && dnf clean all
+
+# Verify installations
+RUN clang --version && cmake --version && ninja --version

--- a/scripts/release/Dockerfile.ubuntu20
+++ b/scripts/release/Dockerfile.ubuntu20
@@ -13,7 +13,19 @@ RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libarchive-dev \
     zlib1g-dev \
-    ninja-build
+    ninja-build \
+    software-properties-common \
+    gnupg \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" \
+    && apt-get update && apt-get install -y \
+    clang \
+    lldb \
+    lld \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Verify installations
+RUN clang --version && lldb --version
 
 # Install the latest stable version of CMake from source
 RUN CMAKE_VERSION=3.27.4 \
@@ -28,3 +40,6 @@ RUN CMAKE_VERSION=3.27.4 \
 
 # Set CMake as the default version
 RUN ln -sf /usr/local/bin/cmake /usr/bin/cmake
+
+# Verify CMake installation
+RUN cmake --version

--- a/scripts/release/Dockerfile.ubuntu22
+++ b/scripts/release/Dockerfile.ubuntu22
@@ -1,11 +1,23 @@
 # Use the official NVIDIA development runtime image for Ubuntu 22.04
 FROM nvidia/cuda:12.2.2-devel-ubuntu22.04
 
-# Install necessary packages
+# Set noninteractive mode for apt to prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Add LLVM's official repository and GPG key
 RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     tar \
-    ninja-build
+    ninja-build \
+    software-properties-common \
+    wget \
+    gnupg \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
 
-RUN apt install cargo -y
+# Install the latest version of Clang
+RUN apt-get update && apt-get install -y clang lldb lld && apt-get clean
+
+# Verify installations
+RUN clang --version && lldb --version

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -8,8 +8,7 @@ We use docker to represent the target environment for the release. Each Docker i
 To build all tars:
 ```bash
 # from icicle root dir
-mkdir -p release_output && rm -rf release_output/* # output dir where tars will be placed
-./scripts/release/build_all.sh release_output # release_output is the output dir where tar files will be generated to
+./scripts/release/build_all.sh 3.2.0 <optional: output-dir> # replace with any version
 ```
 
 ### Build Docker Image

--- a/scripts/release/build_all.sh
+++ b/scripts/release/build_all.sh
@@ -2,20 +2,24 @@
 
 set -e 
 
-# Use provided release_output directory or default to "release_output"
-output_dir="${1:-./release_output}"
-version="$2"
-
-if [[ -z $version ]]; then
-  echo "Usage: You must supply a version for release tar files"
+# Check if sufficient arguments are provided
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <version> [output_dir]"
+  echo
+  echo "Arguments:"
+  echo "  <version>       The version for release tar files (required)."
+  echo "  [output_dir]    The directory to store release output files (optional, defaults to './release_output')."
   exit 1
 fi
+
+# Use provided release_output directory or default to "release_output"
+version="$1"
+output_dir="${2:-./release_output}"
 
 first_char=${version:0:1}
 if [[ "${first_char,,}" == "v" ]]; then
     version="${version:1}"
 fi
-
 
 version="${version//./_}"
 
@@ -26,7 +30,7 @@ if [[ ! -d "./icicle" || ! -d "./scripts" ]]; then
 fi
 
 # Build Docker images
-
+echo "Building Docker images..."
 # Ubuntu 22.04, CUDA 12.2.2
 docker build -t icicle-release-ubuntu22-cuda122 -f ./scripts/release/Dockerfile.ubuntu22 .
 # Ubuntu 20.04, CUDA 12.2.2
@@ -37,6 +41,11 @@ docker build -t icicle-release-ubi8-cuda122 -f ./scripts/release/Dockerfile.ubi8
 docker build -t icicle-release-ubi9-cuda122 -f ./scripts/release/Dockerfile.ubi9 .
 
 # Compile and tar release in each
+
+# Inform the user of what is being done
+echo "Preparing release files..."
+echo "Version: $version"
+echo "Output Directory: $output_dir"
 
 # Create the output directory if it doesn't exist, and clean it
 mkdir -p "$output_dir" && rm -rf "$output_dir/*"


### PR DESCRIPTION
install clang in release dockers to build release with clang instead of gcc