### PR TITLE
[FIX]: Add nodejs setup for release script

### DIFF
--- a/.github/workflows/build-release-docker-img.yml
+++ b/.github/workflows/build-release-docker-img.yml
@@ -1,0 +1,34 @@
+name: Build Release Docker Images
+
+on: workflow_dispatch
+    
+jobs:
+  build-and-publish:
+    name: Build and Publish Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        images:
+          - ubuntu22
+          - ubuntu20
+          - ubi8
+          - ubi9
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build, tag, and push docker image
+        uses: docker/build-push-action@v6
+        with:
+          # this label connects the icicle repo with the built package
+          # See more: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+          labels: |
+            org.opencontainers.image.source=https://github.com/ingonyama-zk/icicle
+          file: ./Dockerfile.${{ matrix.images }}
+          tags: ghcr.io/ingonyama-zk/icicle-release-${{ matrix.images }}-cuda122:latest
+          push: true

--- a/.github/workflows/build-release-docker-img.yml
+++ b/.github/workflows/build-release-docker-img.yml
@@ -29,6 +29,6 @@ jobs:
           # See more: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
           labels: |
             org.opencontainers.image.source=https://github.com/ingonyama-zk/icicle
-          file: ./Dockerfile.${{ matrix.images }}
+          file: ./scripts/release/Dockerfile.${{ matrix.images }}
           tags: ghcr.io/ingonyama-zk/icicle-release-${{ matrix.images }}-cuda122:latest
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
           git config user.name release-bot
           git config user.email release-bot@ingonyama.com
           cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - name: Bump docs version
         id: bump-docs-version
         if: inputs.releaseType != 'patch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, Linux, X64, icicle]    
+    runs-on: [self-hosted, Linux, X64, icicle]  
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,26 +30,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh-key: ${{ secrets.CUDA_PULL_KEY }}
           ref: main
-      # - name: Setup Cache
-      #   id: cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #     key: ${{ runner.os }}-cargo-${{ hashFiles('~/.cargo/bin/cargo-workspaces') }}
-      # - name: Install cargo-workspaces
-      #   if: steps.cache.outputs.cache-hit != 'true'
-      #   run: cargo install cargo-workspaces
-      # - name: Bump rust crate versions, commit, and tag
-      #   working-directory: wrappers/rust
-      #   # https://github.com/pksunkara/cargo-workspaces?tab=readme-ov-file#version
-      #   run: |
-      #     git config user.name release-bot
-      #     git config user.email release-bot@ingonyama.com
-      #     cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version"
+      - name: Setup Cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('~/.cargo/bin/cargo-workspaces') }}
+      - name: Install cargo-workspaces
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-workspaces
+      - name: Bump rust crate versions, commit, and tag
+        working-directory: wrappers/rust
+        # https://github.com/pksunkara/cargo-workspaces?tab=readme-ov-file#version
+        run: |
+          git config user.name release-bot
+          git config user.email release-bot@ingonyama.com
+          cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version" --allow-branch fix-release-script
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -59,17 +59,24 @@ jobs:
         working-directory: ./docs
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
-          LATEST_VERSION=$LATEST_TAG:0:1
+          LATEST_VERSION=${LATEST_TAG:1}
+          npm install
           npm run docusaurus docs:version $LATEST_VERSION
           git add --all
           git commit -m "Bump docs version"
-        # git push
-      # - name: Create draft release
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |          
-      #     LATEST_TAG=$(git describe --tags --abbrev=0)
-      #     gh release create $LATEST_TAG --generate-notes -d --verify-tag -t "Release $LATEST_TAG"
+          git push
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |          
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          gh release create $LATEST_TAG --generate-notes -d --verify-tag -t "Release $LATEST_TAG"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release tars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,6 +84,6 @@ jobs:
           mkdir -p release_output && rm -rf ./release_output/*
           LATEST_TAG=$(git describe --tags --abbrev=0)
           ./scripts/release/build_all.sh ./release_output $LATEST_TAG
-      # for file in ./release_output/*.tar.gz; do
-      #   gh release upload $LATEST_TAG "$file"
-      # done
+          for file in ./release_output/*.tar.gz; do
+            gh release upload $LATEST_TAG "$file"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           git config user.name release-bot
           git config user.email release-bot@ingonyama.com
-          cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version" --allow-branch fix-release-script
+          cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version"
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,26 +30,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh-key: ${{ secrets.CUDA_PULL_KEY }}
           ref: main
-      - name: Setup Cache
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('~/.cargo/bin/cargo-workspaces') }}
-      - name: Install cargo-workspaces
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-workspaces
-      - name: Bump rust crate versions, commit, and tag
-        working-directory: wrappers/rust
-        # https://github.com/pksunkara/cargo-workspaces?tab=readme-ov-file#version
-        run: |
-          git config user.name release-bot
-          git config user.email release-bot@ingonyama.com
-          cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version"
+      # - name: Setup Cache
+      #   id: cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       ~/.cargo/bin/
+      #       ~/.cargo/registry/index/
+      #       ~/.cargo/registry/cache/
+      #       ~/.cargo/git/db/
+      #     key: ${{ runner.os }}-cargo-${{ hashFiles('~/.cargo/bin/cargo-workspaces') }}
+      # - name: Install cargo-workspaces
+      #   if: steps.cache.outputs.cache-hit != 'true'
+      #   run: cargo install cargo-workspaces
+      # - name: Bump rust crate versions, commit, and tag
+      #   working-directory: wrappers/rust
+      #   # https://github.com/pksunkara/cargo-workspaces?tab=readme-ov-file#version
+      #   run: |
+      #     git config user.name release-bot
+      #     git config user.email release-bot@ingonyama.com
+      #     cargo workspaces version ${{ inputs.releaseType }} -y --no-individual-tags --no-git-push -m "Bump rust crates' version"
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -63,13 +63,13 @@ jobs:
           npm run docusaurus docs:version $LATEST_VERSION
           git add --all
           git commit -m "Bump docs version"
-          git push
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |          
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          gh release create $LATEST_TAG --generate-notes -d --verify-tag -t "Release $LATEST_TAG"
+        # git push
+      # - name: Create draft release
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |          
+      #     LATEST_TAG=$(git describe --tags --abbrev=0)
+      #     gh release create $LATEST_TAG --generate-notes -d --verify-tag -t "Release $LATEST_TAG"
       - name: Upload release tars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,6 +77,6 @@ jobs:
           mkdir -p release_output && rm -rf ./release_output/*
           LATEST_TAG=$(git describe --tags --abbrev=0)
           ./scripts/release/build_all.sh ./release_output $LATEST_TAG
-          for file in ./release_output/*.tar.gz; do
-            gh release upload $LATEST_TAG "$file"
-          done
+      # for file in ./release_output/*.tar.gz; do
+      #   gh release upload $LATEST_TAG "$file"
+      # done

--- a/scripts/release/build_all.sh
+++ b/scripts/release/build_all.sh
@@ -29,16 +29,11 @@ if [[ ! -d "./icicle" || ! -d "./scripts" ]]; then
   exit 1
 fi
 
-# Build Docker images
-echo "Building Docker images..."
-# Ubuntu 22.04, CUDA 12.2.2
-docker build -t icicle-release-ubuntu22-cuda122 -f ./scripts/release/Dockerfile.ubuntu22 .
-# Ubuntu 20.04, CUDA 12.2.2
-docker build -t icicle-release-ubuntu20-cuda122 -f ./scripts/release/Dockerfile.ubuntu20 .
-# ubi8 (rhel compatible), CUDA 12.2.2
-docker build -t icicle-release-ubi8-cuda122 -f ./scripts/release/Dockerfile.ubi8 .
-# ubi9 (rhel compatible), CUDA 12.2.2
-docker build -t icicle-release-ubi9-cuda122 -f ./scripts/release/Dockerfile.ubi9 .
+# Download latest build images
+docker pull ghcr.io/ingonyama-zk/icicle-release-ubuntu22-cuda122:latest
+docker pull ghcr.io/ingonyama-zk/icicle-release-ubuntu20-cuda122:latest
+docker pull ghcr.io/ingonyama-zk/icicle-release-ubi8-cuda122:latest
+docker pull ghcr.io/ingonyama-zk/icicle-release-ubi9-cuda122:latest
 
 # Compile and tar release in each
 
@@ -71,9 +66,13 @@ docker run --rm --gpus all                  \
             -v ./scripts:/scripts           \
             icicle-release-ubi8-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubi8 cuda122 &
 
+# NOTE: The last command should not be run in the background,
+# otherwise the script completes and the github action continues 
+# and may exit before the builds finish
+
 # ubi 9 (rhel compatible)
 docker run --rm --gpus all                  \
             -v ./icicle:/icicle             \
             -v "$output_dir:/output"        \
             -v ./scripts:/scripts           \
-            icicle-release-ubi9-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubi9 cuda122 &
+            icicle-release-ubi9-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubi9 cuda122

--- a/scripts/release/build_all.sh
+++ b/scripts/release/build_all.sh
@@ -52,12 +52,17 @@ docker run --rm --gpus all                  \
             -v ./scripts:/scripts           \
             icicle-release-ubuntu22-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubuntu22 cuda122 &
 
+# obtain the last backgrounded process' pid
+pid_ubuntu22=$!
+
 # ubuntu 20
 docker run --rm --gpus all                  \
             -v ./icicle:/icicle             \
             -v "$output_dir:/output"        \
             -v ./scripts:/scripts           \
             icicle-release-ubuntu20-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubuntu20 cuda122 &
+
+pid_ubuntu20=$!
 
 # ubi 8 (rhel compatible)
 docker run --rm --gpus all                  \
@@ -66,13 +71,21 @@ docker run --rm --gpus all                  \
             -v ./scripts:/scripts           \
             icicle-release-ubi8-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubi8 cuda122 &
 
-# NOTE: The last command should not be run in the background,
-# otherwise the script completes and the github action continues 
-# and may exit before the builds finish
+pid_ubi8=$!
 
 # ubi 9 (rhel compatible)
 docker run --rm --gpus all                  \
             -v ./icicle:/icicle             \
             -v "$output_dir:/output"        \
             -v ./scripts:/scripts           \
-            icicle-release-ubi9-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubi9 cuda122
+            icicle-release-ubi9-cuda122 bash /scripts/release/build_release_and_tar.sh icicle_$version ubi9 cuda122 &
+
+pid_ubi9=$!
+
+# NOTE: After launching all builds in background tasks, we wait for all to complete
+# otherwise the script completes and the calling process (potentially github actions)
+# continues and may exit before the builds finish
+wait $pid_ubuntu22
+wait $pid_ubuntu20
+wait $pid_ubi8
+wait $pid_ubi9


### PR DESCRIPTION
## Describe the changes

This PR:
- Fixes the release script by ensuring nodejs is installed before trying to bump the docs version
- Moves building docker images for releases into a separate workflow as they only need to be rebuilt if prerequisite packages change
- Updates the release workflow and the build_all script to pull and use the latest docker images
