### PR TITLE
performance: (~3x) optimize field multiplier and EC-adder for improved MSM and ECNTT

### DIFF
--- a/icicle/include/icicle/curves/projective.h
+++ b/icicle/include/icicle/curves/projective.h
@@ -191,7 +191,7 @@ public:
 
     Projective res = zero();
 
-    const int nof_windows = (SCALAR_FF::NBITS + window_size - 1) / window_size;
+    constexpr int nof_windows = (SCALAR_FF::NBITS + window_size - 1) / window_size;
     bool res_is_not_zero = false;
     for (int w = nof_windows - 1; w >= 0; w -= 1) {
       // Extract the next window_size bits from the scalar

--- a/icicle/include/icicle/fields/host_math.h
+++ b/icicle/include/icicle/fields/host_math.h
@@ -132,6 +132,7 @@ namespace host_math {
   {
     uint32_t carry = 0;
     carry_chain<NLIMBS, false, CARRY_OUT> chain;
+#pragma unroll
     for (unsigned i = 0; i < NLIMBS; i++)
       r[i] = SUBTRACT ? chain.sub(x[i], y[i], carry) : chain.add(x[i], y[i], carry);
     return CARRY_OUT ? carry : 0;
@@ -142,6 +143,7 @@ namespace host_math {
   {
     uint64_t carry = 0;
     carry_chain<NLIMBS, false, CARRY_OUT> chain;
+#pragma unroll
     for (unsigned i = 0; i < NLIMBS / 2; i++)
       r[i] = SUBTRACT ? chain.sub(x[i], y[i], carry) : chain.add(x[i], y[i], carry);
     return CARRY_OUT ? carry : 0;
@@ -178,8 +180,10 @@ namespace host_math {
     const uint32_t* a = as.limbs;
     const uint32_t* b = bs.limbs;
     uint32_t* r = rs.limbs;
+#pragma unroll
     for (unsigned i = 0; i < NLIMBS_B; i++) {
       uint32_t carry = 0;
+#pragma unroll
       for (unsigned j = 0; j < NLIMBS_A; j++)
         r[j + i] = host_math::madc_cc(a[j], b[i], r[j + i], carry);
       r[NLIMBS_A + i] = carry;
@@ -189,8 +193,10 @@ namespace host_math {
   template <unsigned NLIMBS_A, unsigned NLIMBS_B = NLIMBS_A>
   static HOST_INLINE void multiply_raw_64(const uint64_t* a, const uint64_t* b, uint64_t* r)
   {
+#pragma unroll
     for (unsigned i = 0; i < NLIMBS_B / 2; i++) {
       uint64_t carry = 0;
+#pragma unroll
       for (unsigned j = 0; j < NLIMBS_A / 2; j++)
         r[j + i] = host_math::madc_cc_64(a[j], b[i], r[j + i], carry);
       r[NLIMBS_A / 2 + i] = carry;
@@ -247,6 +253,7 @@ namespace host_math {
       storage<NLIMBS> out{};
       if constexpr (LIMBS_GAP < NLIMBS) {
         out.limbs[LIMBS_GAP] = xs.limbs[0] << BITS32;
+#pragma unroll
         for (unsigned i = 1; i < NLIMBS - LIMBS_GAP; i++)
           out.limbs[i + LIMBS_GAP] = (xs.limbs[i] << BITS32) + (xs.limbs[i - 1] >> (32 - BITS32));
       }
@@ -264,6 +271,7 @@ namespace host_math {
       constexpr unsigned LIMBS_GAP = BITS / 32;
       storage<NLIMBS> out{};
       if constexpr (LIMBS_GAP < NLIMBS - 1) {
+#pragma unroll
         for (unsigned i = 0; i < NLIMBS - LIMBS_GAP - 1; i++)
           out.limbs[i] = (xs.limbs[i + LIMBS_GAP] >> BITS32) + (xs.limbs[i + LIMBS_GAP + 1] << (32 - BITS32));
       }
@@ -281,7 +289,9 @@ namespace host_math {
     const storage<NLIMBS_NUM>& num, const storage<NLIMBS_DENOM>& denom, storage<NLIMBS_Q>& q, storage<NLIMBS_DENOM>& r)
   {
     storage<NLIMBS_DENOM> temp = {};
+#pragma unroll
     for (int limb_idx = NLIMBS_NUM - 1; limb_idx >= 0; limb_idx--) {
+#pragma unroll
       for (int bit_idx = 31; bit_idx >= 0; bit_idx--) {
         r = left_shift<NLIMBS_DENOM, 1>(r);
         r.limbs[0] |= ((num.limbs[limb_idx] >> bit_idx) & 1);

--- a/icicle/include/icicle/utils/modifiers.h
+++ b/icicle/include/icicle/utils/modifiers.h
@@ -16,13 +16,12 @@
   #define DEVICE_INLINE      __device__ INLINE_MACRO
   #define HOST_DEVICE        __host__ __device__
   #define HOST_DEVICE_INLINE HOST_DEVICE INLINE_MACRO
-#else // not CUDA
-  #define INLINE_MACRO
+#else // not NVCC
   #define UNROLL
-  #define HOST_INLINE
-  #define DEVICE_INLINE
   #define HOST_DEVICE
-  #define HOST_DEVICE_INLINE
+  #define HOST_INLINE __attribute__((always_inline))
+  #define DEVICE_INLINE
+  #define HOST_DEVICE_INLINE HOST_INLINE
   #define __host__
   #define __device__
 #endif


### PR DESCRIPTION
## Describe the changes

1. fix: ECNTT 5<logn<14 was single threaded. Now multi threaded.

2. This PR is using inlining and loop unrolling to improve CPU for:

- scalar multiplication
- scalar * ECpoint
- EC addition
- and consequently ECNTT and and MSM.


ECNTT (MULTI-THREAD) {size=2^14, curve=BN254}:

- For i9-13900k ubuntu22, clang-14: ~1200ms -> ~450ms (~2.6x)
- For m1-pro macos-15, clang-16: ~3500ms -> ~1200ms (~2.9x)


MSM (SINGLE-THREAD!) BLS12-377 logn=20:

- For i9-13900k ubuntu22, clang-14: ~32s -> ~10s (~3.2x)
- For m1-pro macos-15, clang-16:  ~36.5S  -> 13.3s (~2.7x)

MSM (MULTI-THREAD!) BLS12-377 logn=20:
- For i9-13900k ubuntu22, clang-14: ~1.9s -> ~1.9s (~1x) 
- For m1-pro macos-15, clang-16: ~5500ms -> ~3100ms (~1.8x)


CONCLUSION: ICICLE msm is bound by the manager thread. This is why for single thread we see 3X but for multi-thread mac (8-10 cores) improves 1.8x but i9 (32 cores) show no improvement. @LeonHibnik @mickeyasa @Koren-Brand 


