### PR TITLE
docs: typos correction

### DIFF
--- a/docs/docs/icicle/golang-bindings/merkle.md
+++ b/docs/docs/icicle/golang-bindings/merkle.md
@@ -151,7 +151,7 @@ A Merkle proof contains:
 - **Index** (leaf_idx): The position of the leaf in the original dataset.
 - **Path**: A sequence of sibling hashes (tree nodes) needed to recompute the path from the leaf to the root.
 
-![Merkle Pruned Phat Diagram](../primitives/merkle_diagrams/diagram1_path.png)
+![Merkle Pruned Path Diagram](../primitives/merkle_diagrams/diagram1_path.png)
 
 ```go
 /// * `leaves` - A slice of leaves (input data).

--- a/docs/docs/icicle/primitives/merkle.md
+++ b/docs/docs/icicle/primitives/merkle.md
@@ -179,7 +179,7 @@ A Merkle proof contains:
 - **Index** (leaf_idx): The position of the leaf in the original dataset.
 - **Path**: A sequence of sibling hashes (tree nodes) needed to recompute the path from the leaf to the root.
 
-![Merkle Pruned Phat Diagram](./merkle_diagrams/diagram1_path.png)
+![Merkle Pruned Path Diagram](./merkle_diagrams/diagram1_path.png)
 
 
 ```cpp

--- a/docs/docs/icicle/primitives/ntt.md
+++ b/docs/docs/icicle/primitives/ntt.md
@@ -169,7 +169,7 @@ To compute a batch, set the `batch_size` and `columns_batch` fields of the confi
 
 ### Example
 
-The following example demonstartes how to use ntt and how pass custom configurations to the CUDA backend. Details are discussed below.
+The following example demonstrates how to use ntt and how pass custom configurations to the CUDA backend. Details are discussed below.
 
 ```cpp
 #include "icicle/backend/ntt_config.h"


### PR DESCRIPTION
This PR fixes a few small but noticeable typos in the ICICLE documentation and improves the clarity of some examples. Here's a quick rundown:

1. **Typos Fixed:**
   - Changed "Merkle Pruned Phat Diagram" to the correct "Merkle Pruned Path Diagram" in the Merkle docs.
   - Fixed "demonstartes" to "demonstrates" in the NTT section.