### PR TITLE
Add capability to set a default device for all threads

### DIFF
--- a/docs/docs/icicle/programmers_guide/cpp.md
+++ b/docs/docs/icicle/programmers_guide/cpp.md
@@ -32,6 +32,21 @@ eIcicleError result = icicle_set_device(device);
 eIcicleError result = icicle_get_active_device(device);
 ```
 
+### Setting and Getting the Default Device
+
+You can set the default device for all threads:
+
+```cpp
+icicle::Device device = {"CUDA", 0}; // or other
+eIcicleError result = icicle_set_default_device(device);
+```
+
+:::caution
+
+Setting a default device should be done **once** from the main thread of the application. If another device or backend is needed for a specific thread [icicle_set_device](#setting-and-getting-active-device) should be used instead.
+
+:::
+
 ### Querying Device Information
 
 Retrieve the number of available devices and check if a pointer is allocated on the host or on the active device:

--- a/docs/docs/icicle/programmers_guide/general.md
+++ b/docs/docs/icicle/programmers_guide/general.md
@@ -85,6 +85,7 @@ ICICLE provides a device abstraction layer that allows you to interact with diff
 
 - **Loading Backends**: Backends are loaded dynamically based on the environment configuration or a specified path.
 - **Setting Active Device**: The active device for a thread can be set, allowing for targeted computation on a specific device.
+- **Setting Default Device**: The default device for any thread without an active device can be set, removing the need to specify an alternative device on each thread. This is especially useful when running on a backend that is not the built-in CPU backend which is the default device to start.
 
 ## Streams
 

--- a/docs/docs/icicle/programmers_guide/go.md
+++ b/docs/docs/icicle/programmers_guide/go.md
@@ -27,11 +27,26 @@ result := runtime.LoadBackend("/path/to/backend/installdir", true)
 You can set the active device for the current thread and retrieve it when needed:
 
 ```go
-device = runtime.CreateDevice("CUDA", 0) // or other
+device := runtime.CreateDevice("CUDA", 0) // or other
 result := runtime.SetDevice(device)
 // or query current (thread) device 
 activeDevice := runtime.GetActiveDevice()
 ```
+
+### Setting and Getting the Default Device
+
+You can set the default device for all threads:
+
+```go
+device := runtime.CreateDevice("CUDA", 0) // or other
+defaultDevice := runtime.SetDefaultDevice(device);
+```
+
+:::caution
+
+Setting a default device should be done **once** from the main thread of the application. If another device or backend is needed for a specific thread [runtime.SetDevice](#setting-and-getting-active-device) should be used instead.
+
+:::
 
 ### Querying Device Information
 

--- a/docs/docs/icicle/programmers_guide/rust.md
+++ b/docs/docs/icicle/programmers_guide/rust.md
@@ -55,6 +55,21 @@ icicle_runtime::set_device(&device).unwrap();
 let active_device = icicle_runtime::get_active_device().unwrap();
 ```
 
+### Setting and Getting the Default Device
+
+You can set the default device for all threads:
+
+```caution
+let device = Device::new("CUDA", 0); // or other
+let default_device = icicle_runtime::set_default_device(device);
+```
+
+:::note
+
+Setting a default device should be done **once** from the main thread of the application. If another device or backend is needed for a specific thread [icicle_runtime::set_device](#setting-and-getting-active-device) should be used instead.
+
+:::
+
 ### Querying Device Information
 
 Retrieve the number of available devices and check if a pointer is allocated on the host or on the active device:

--- a/icicle/include/icicle/device_api.h
+++ b/icicle/include/icicle/device_api.h
@@ -188,6 +188,7 @@ namespace icicle {
 
   public:
     static eIcicleError set_thread_local_device(const Device& device);
+    static eIcicleError set_default_device(const Device& device);
     static const Device& get_thread_local_device();
     static const DeviceAPI* get_thread_local_deviceAPI();
     static DeviceTracker& get_global_memory_tracker() { return sMemTracker; }

--- a/icicle/include/icicle/runtime.h
+++ b/icicle/include/icicle/runtime.h
@@ -37,6 +37,14 @@ extern "C" eIcicleError icicle_load_backend_from_env_or_default();
 extern "C" eIcicleError icicle_set_device(const icicle::Device& device);
 
 /**
+ * @brief Set default device for all threads
+ *
+
+ * @return eIcicleError::SUCCESS if successful, otherwise throws INVALID_DEVICE
+ */
+extern "C" eIcicleError icicle_set_default_device(const icicle::Device& device);
+
+/**
  * @brief Get active device for thread
  *
 

--- a/icicle/src/device_api.cpp
+++ b/icicle/src/device_api.cpp
@@ -58,6 +58,15 @@ namespace icicle {
 
     const Device& get_default_device() { return m_default_device; }
 
+    eIcicleError set_default_device(const Device& dev)
+    {
+      if (!is_device_registered(dev.type)) {
+        THROW_ICICLE_ERR(eIcicleError::INVALID_DEVICE, "Device type " + std::string(dev.type) + " has not been registered");
+      }
+      m_default_device = dev;
+      return eIcicleError::SUCCESS;
+    }
+
     std::vector<std::string> get_registered_devices_list()
     {
       std::vector<std::string> registered_devices;
@@ -114,6 +123,11 @@ namespace icicle {
                                       "icicle_set_device(const icicle::Device& device)");
     }
     return default_deviceAPI.get();
+  }
+
+  eIcicleError DeviceAPI::set_default_device(const Device& dev)
+  {
+    return DeviceAPIRegistry::Global().set_default_device(dev);
   }
 
   /********************************************************************************** */

--- a/icicle/src/device_api.cpp
+++ b/icicle/src/device_api.cpp
@@ -61,7 +61,8 @@ namespace icicle {
     eIcicleError set_default_device(const Device& dev)
     {
       if (!is_device_registered(dev.type)) {
-        THROW_ICICLE_ERR(eIcicleError::INVALID_DEVICE, "Device type " + std::string(dev.type) + " has not been registered");
+        THROW_ICICLE_ERR(
+          eIcicleError::INVALID_DEVICE, "Device type " + std::string(dev.type) + " has not been registered");
       }
       m_default_device = dev;
       return eIcicleError::SUCCESS;

--- a/icicle/src/device_api.cpp
+++ b/icicle/src/device_api.cpp
@@ -61,9 +61,10 @@ namespace icicle {
     eIcicleError set_default_device(const Device& dev)
     {
       if (!is_device_registered(dev.type)) {
-        THROW_ICICLE_ERR(
-          eIcicleError::INVALID_DEVICE, "Device type " + std::string(dev.type) + " has not been registered");
+        ICICLE_LOG_ERROR << "Device type " + std::string(dev.type) + " is not valid as it has not been registered";
+        return eIcicleError::INVALID_DEVICE;
       }
+
       m_default_device = dev;
       return eIcicleError::SUCCESS;
     }

--- a/icicle/src/runtime.cpp
+++ b/icicle/src/runtime.cpp
@@ -14,6 +14,8 @@ using namespace icicle;
 
 extern "C" eIcicleError icicle_set_device(const Device& device) { return DeviceAPI::set_thread_local_device(device); }
 
+extern "C" eIcicleError icicle_set_default_device(const Device& device) { return DeviceAPI::set_default_device(device); }
+
 extern "C" eIcicleError icicle_get_active_device(icicle::Device& device)
 {
   const Device& active_device = DeviceAPI::get_thread_local_device();

--- a/icicle/src/runtime.cpp
+++ b/icicle/src/runtime.cpp
@@ -14,7 +14,10 @@ using namespace icicle;
 
 extern "C" eIcicleError icicle_set_device(const Device& device) { return DeviceAPI::set_thread_local_device(device); }
 
-extern "C" eIcicleError icicle_set_default_device(const Device& device) { return DeviceAPI::set_default_device(device); }
+extern "C" eIcicleError icicle_set_default_device(const Device& device)
+{
+  return DeviceAPI::set_default_device(device);
+}
 
 extern "C" eIcicleError icicle_get_active_device(icicle::Device& device)
 {

--- a/wrappers/golang/runtime/device.go
+++ b/wrappers/golang/runtime/device.go
@@ -50,6 +50,12 @@ func SetDevice(device *Device) EIcicleError {
 	return EIcicleError(cErr)
 }
 
+func SetDefaultDevice(device *Device) EIcicleError {
+	cDevice := (*C.Device)(unsafe.Pointer(device))
+	cErr := C.icicle_set_default_device(cDevice)
+	return EIcicleError(cErr)
+}
+
 func GetActiveDevice() (*Device, EIcicleError) {
 	device := CreateDevice("invalid", -1)
 	cDevice := (*C.Device)(unsafe.Pointer(&device))

--- a/wrappers/golang/runtime/include/runtime.h
+++ b/wrappers/golang/runtime/include/runtime.h
@@ -13,6 +13,7 @@ typedef struct DeviceProperties DeviceProperties;
 int icicle_load_backend(const char* path, bool is_recursive);
 int icicle_load_backend_from_env_or_default();
 int icicle_set_device(const Device* device);
+int icicle_set_default_device(const Device* device);
 int icicle_get_active_device(Device* device);
 int icicle_is_host_memory(const void* ptr);
 int icicle_is_active_device_memory(const void* ptr);

--- a/wrappers/golang/runtime/tests/main_test.go
+++ b/wrappers/golang/runtime/tests/main_test.go
@@ -6,19 +6,7 @@ import (
 	"github.com/ingonyama-zk/icicle/v3/wrappers/golang/runtime"
 )
 
-var DEVICE runtime.Device
-
 func TestMain(m *testing.M) {
 	runtime.LoadBackendFromEnvOrDefault()
-	devices, e := runtime.GetRegisteredDevices()
-	if e != runtime.Success {
-		panic("Failed to load registered devices")
-	}
-	for _, deviceType := range devices {
-		DEVICE = runtime.CreateDevice(deviceType, 0)
-		runtime.SetDevice(&DEVICE)
-
-		// execute tests
-		m.Run()
-	}
+	m.Run()
 }

--- a/wrappers/golang/runtime/tests/stream_test.go
+++ b/wrappers/golang/runtime/tests/stream_test.go
@@ -8,19 +8,15 @@ import (
 )
 
 func TestCreateStream(t *testing.T) {
-	err := runtime.LoadBackendFromEnvOrDefault()
-	assert.Equal(t, runtime.Success, err)
 	dev := runtime.CreateDevice("CUDA", 0)
 	assert.True(t, runtime.IsDeviceAvailable(&dev))
-	err = runtime.SetDevice(&dev)
+	err := runtime.SetDevice(&dev)
 	assert.Equal(t, runtime.Success, err)
 	_, err = runtime.CreateStream()
 	assert.Equal(t, runtime.Success, err, "Unable to create stream due to %d", err)
 }
 
 func TestDestroyStream(t *testing.T) {
-	err := runtime.LoadBackendFromEnvOrDefault()
-	assert.Equal(t, runtime.Success, err)
 	dev := runtime.CreateDevice("CUDA", 0)
 	assert.True(t, runtime.IsDeviceAvailable(&dev))
 	stream, err := runtime.CreateStream()
@@ -31,8 +27,6 @@ func TestDestroyStream(t *testing.T) {
 }
 
 func TestSyncStream(t *testing.T) {
-	err := runtime.LoadBackendFromEnvOrDefault()
-	assert.Equal(t, runtime.Success, err)
 	dev := runtime.CreateDevice("CUDA", 0)
 	assert.True(t, runtime.IsDeviceAvailable(&dev))
 	runtime.SetDevice(&dev)

--- a/wrappers/rust/icicle-runtime/src/device.rs
+++ b/wrappers/rust/icicle-runtime/src/device.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_char;
 
 const MAX_TYPE_SIZE: usize = 64;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 #[repr(C)]
 pub struct Device {
     device_type: [c_char; MAX_TYPE_SIZE],

--- a/wrappers/rust/icicle-runtime/src/runtime.rs
+++ b/wrappers/rust/icicle-runtime/src/runtime.rs
@@ -11,6 +11,7 @@ extern "C" {
     fn icicle_load_backend(path: *const c_char, is_recursive: bool) -> eIcicleError;
     fn icicle_load_backend_from_env_or_default() -> eIcicleError;
     fn icicle_set_device(device: &Device) -> eIcicleError;
+    fn icicle_set_default_device(device: &Device) -> eIcicleError;
     fn icicle_get_active_device(device: &mut Device) -> eIcicleError;
     fn icicle_is_host_memory(ptr: *const c_void) -> eIcicleError;
     fn icicle_is_active_device_memory(ptr: *const c_void) -> eIcicleError;
@@ -59,6 +60,15 @@ pub fn load_backend_non_recursive(path: &str) -> Result<(), eIcicleError> {
 
 pub fn set_device(device: &Device) -> Result<(), eIcicleError> {
     let result = unsafe { icicle_set_device(device) };
+    if result == eIcicleError::Success {
+        Ok(())
+    } else {
+        Err(result)
+    }
+}
+
+pub fn set_default_device(device: &Device) -> Result<(), eIcicleError> {
+    let result = unsafe { icicle_set_default_device(device) };
     if result == eIcicleError::Success {
         Ok(())
     } else {


### PR DESCRIPTION
## Describe the changes

This PR adds the capability to set a default device for all threads. Setting a default device does not override a thread's explicitly set device
