### PR TITLE
Fix typos and update outdated link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ eIcicleError result = icicle_set_device(device);
 // Any call will now execute on GPU-0
 ```
 
-Full details can be found in our [getting started docs](https://dev.ingonyama.com/icicle/introduction)
+Full details can be found in our [getting started docs](https://dev.ingonyama.com)
 
 ## Contributions
 

--- a/docs/docs/contributor-guide.md
+++ b/docs/docs/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 

--- a/docs/versioned_docs/version-1.10.1/contributor-guide.md
+++ b/docs/versioned_docs/version-1.10.1/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 

--- a/docs/versioned_docs/version-2.8.0/contributor-guide.md
+++ b/docs/versioned_docs/version-2.8.0/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 

--- a/docs/versioned_docs/version-3.0.0/contributor-guide.md
+++ b/docs/versioned_docs/version-3.0.0/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 

--- a/docs/versioned_docs/version-3.1.0/contributor-guide.md
+++ b/docs/versioned_docs/version-3.1.0/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 

--- a/docs/versioned_docs/version-3.2.0/contributor-guide.md
+++ b/docs/versioned_docs/version-3.2.0/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 

--- a/docs/versioned_docs/version-3.3.0/contributor-guide.md
+++ b/docs/versioned_docs/version-3.3.0/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 


### PR DESCRIPTION
This PR addresses minor typos in the `Contributor's Guide` across multiple versions and updates an outdated link in the `README.md`. These changes enhance readability and maintain consistency in the documentation.

### Changes made:
1. **Fixed grammar issue:**
   - Changed **"a ecosystem"** to **"an ecosystem"** in the `Contributor's Guide` across all the following files:
     - `docs/docs/contributor-guide.md`
     - `docs/versioned_docs/version-1.10.1/contributor-guide.md`
     - `docs/versioned_docs/version-2.8.0/contributor-guide.md`
     - `docs/versioned_docs/version-3.0.0/contributor-guide.md`
     - `docs/versioned_docs/version-3.1.0/contributor-guide.md`
     - `docs/versioned_docs/version-3.2.0/contributor-guide.md`
     - `docs/versioned_docs/version-3.3.0/contributor-guide.md`

2. **Updated link in `README.md`:**
   - Replaced the outdated link **`https://dev.ingonyama.com/icicle/introduction`** with the correct link **`https://dev.ingonyama.com`**.
