### PR TITLE
Resolve Documentation Errors and Link Issues

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The developer docs for ICICLE is a static website built using [Docusaurus](https
 
 Docusaurus is written in Typescript and distributed as npm packages. npm is a prerequisite as is node.js
 
-If node.js or npm aren't installed, its suggested to use [nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) to [install both](https://github.com/nvm-sh/nvm?tab=readme-ov-file#usage) at the same time.
+If node.js or npm aren't installed, it's suggested to use [nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) to [install both](https://github.com/nvm-sh/nvm?tab=readme-ov-file#usage) at the same time.
 
 ## Install
 
@@ -70,7 +70,7 @@ Read more on this [here](https://docusaurus.io/docs/static-assets)
 
 ### Adding a new static directory
 
-To update where Docusaurus looks for static directories, add the directory name to the `statidDirectories` list in the config:
+To update where Docusaurus looks for static directories, add the directory name to the `staticDirectories` list in the config:
 
 ```ts
 const config: Config = {
@@ -109,7 +109,7 @@ const ingoPreset = {
   docs: {
     .
     .
-    includeCurrentVersion: false, // Update this to true to render the next verion's docs
+    includeCurrentVersion: false, // Update this to true to render the next version's docs
     .
     .
     .

--- a/docs/docs/icicle/libraries.md
+++ b/docs/docs/icicle/libraries.md
@@ -14,7 +14,7 @@ See programmers guide for more details. [C++](./programmers_guide/cpp#device-man
 
 ICICLE Core is a template library written in C++ that implements fundamental cryptographic operations, including field and curve arithmetic, as well as higher-level APIs such as MSM and NTT.
 
-The Core can be [instantiated](./build_from_source) for different fields, curves, and other cryptographic components, allowing you to tailor it to your specific needs. You can link your application to one or more ICICLE libraries, depending on the requirements of your project. For example, you might only need the babybear library or a combination of babybear and a Merkle tree builder.
+The Core can be [instantiated](./build_from_source.md) for different fields, curves, and other cryptographic components, allowing you to tailor it to your specific needs. You can link your application to one or more ICICLE libraries, depending on the requirements of your project. For example, you might only need the babybear library or a combination of babybear and a Merkle tree builder.
 
 
 ### Rust

--- a/examples/c++/msm/README.md
+++ b/examples/c++/msm/README.md
@@ -1,4 +1,4 @@
-# Icicle example: Muli-Scalar Multiplication (MSM)
+# Icicle example: Multi-Scalar Multiplication (MSM)
 
 ## Key-Takeaway
 


### PR DESCRIPTION
### 1. Fixed spelling in examples/c++/msm/README.md:
-Icicle example: Muli-Scalar Multiplication (MSM)
+Icicle example: Multi-Scalar Multiplication (MSM)

### 2. Fixed spelling in docs/docs/icicle/libraries.md:
-Update this to true to render the next verion's docs
+Update this to true to render the next version's docs

### 3. Fixed configuration property name:
-statidDirectories
+staticDirectories

> Corrected it to staticDirectories, which is the intended property name. This change aligns the documentation with the actual configuration syntax and prevents possible errors when users attempt to configure their projects.

### 4.Fixed broken link in docs/docs/icicle/libraries.md:
-The Core can be [instantiated](./build_from_source) for different fields...
+The Core can be [instantiated](./build_from_source.md) for different fields...