### PR TITLE
docs: fix broken links in libraries and poseidon sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ eIcicleError result = icicle_set_device(device);
 // Any call will now execute on GPU-0
 ```
 
-Full details can be found in our [getting started docs](https://dev.ingonyama.com/icicle/introduction)
+Full details can be found in our [getting started docs](https://dev.ingonyama.com/icicle/getting_started)
 
 ## Contributions
 

--- a/docs/docs/icicle/libraries.md
+++ b/docs/docs/icicle/libraries.md
@@ -37,7 +37,7 @@ Each library has a corresponding crate. See [programmers guide](./programmers_gu
 
 #### Supported fields and operations
 
-| Operation\Field                           | [babybear](https://eprint.iacr.org/2023/824.pdf) | [Stark252](https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/p-value/) |  m31  |  Koalabear  |
+| Operation\Field                           | [babybear](https://eprint.iacr.org/2023/824.pdf) | [Stark252](https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-field) |  m31  |  Koalabear  |
 | ----------------------------------------- | :----------------------------------------------: | :------------------------------------------------------------------------------------------------: | :---: | :---: |
 | [Vector operations](./primitives/vec_ops) |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
 | [Polynomials](./polynomials/overview)     |                        ✅                         |                                                 ✅                                                  |   ❌     |   ✅   |

--- a/docs/docs/icicle/primitives/poseidon.md
+++ b/docs/docs/icicle/primitives/poseidon.md
@@ -62,9 +62,9 @@ So for Poseidon of arity 2 and input of size 1024 * 2, we would expect 1024 elem
 
 Poseidon is extremely customizable and using different constants will produce different hashes, security levels and performance results.
 
-We support pre-calculated and optimized constants for each of the [supported curves](../libraries#supported-curves-and-operations).The constants can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/poseidon/constants) and are labeled clearly per curve `<curve_name>_poseidon.h`.
+We support pre-calculated and optimized constants for each of the [supported curves](../libraries#supported-curves-and-operations).The constants can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/icicle/hash/poseidon_constants/constants) and are labeled clearly per curve `<curve_name>_poseidon.h`.
 
-If you wish to generate your own constants you can use our python script which can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/poseidon/constants/generate_parameters.py).
+If you wish to generate your own constants you can use our python script which can be found [here](https://github.com/ingonyama-zk/icicle/blob/main/icicle/include/icicle/hash/poseidon_constants/constants/generate_parameters.py).
 
 Prerequisites:
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -309,7 +309,7 @@ export default {
         {
           type: "link",
           label: "Ingopedia",
-          href: "https://www.ingonyama.com/ingopedia/communityguide"
+          href: "https://www.ingonyama.com/ingopedia/glossary"
         },
         {
           href: 'https://github.com/ingonyama-zk',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -309,7 +309,7 @@ export default {
         {
           type: "link",
           label: "Ingopedia",
-          href: "https://www.ingonyama.com/ingopedia"
+          href: "https://www.ingonyama.com/ingopedia/communityguide"
         },
         {
           href: 'https://github.com/ingonyama-zk',

--- a/docs/versioned_docs/version-3.2.0/icicle/libraries.md
+++ b/docs/versioned_docs/version-3.2.0/icicle/libraries.md
@@ -36,7 +36,7 @@ Each library has a corresponding crate. See [programmers guide](./programmers_gu
 
 #### Supported fields and operations
 
-| Operation\Field                           | [babybear](https://eprint.iacr.org/2023/824.pdf) | [Stark252](https://docs.starknet.io/documentation/architecture_and_concepts/Cryptography/p-value/) |  m31  |
+| Operation\Field                           | [babybear](https://eprint.iacr.org/2023/824.pdf) | [Stark252](https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-field) |  m31  |
 | ----------------------------------------- | :----------------------------------------------: | :------------------------------------------------------------------------------------------------: | :---: |
 | [Vector operations](./primitives/vec_ops) |                        ✅                         |                                                 ✅                                                  |   ✅   |
 | [Polynomials](./polynomials/overview)     |                        ✅                         |                                                 ✅                                                  |   ❌   |

--- a/docs/versioned_docs/version-3.2.0/icicle/primitives/poseidon.md
+++ b/docs/versioned_docs/version-3.2.0/icicle/primitives/poseidon.md
@@ -62,9 +62,9 @@ So for Poseidon of arity 2 and input of size 1024 * 2, we would expect 1024 elem
 
 Poseidon is extremely customizable and using different constants will produce different hashes, security levels and performance results.
 
-We support pre-calculated and optimized constants for each of the [supported curves](../libraries#supported-curves-and-operations).The constants can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/poseidon/constants) and are labeled clearly per curve `<curve_name>_poseidon.h`.
+We support pre-calculated and optimized constants for each of the [supported curves](../libraries#supported-curves-and-operations).The constants can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/icicle/hash/poseidon_constants/constants) and are labeled clearly per curve `<curve_name>_poseidon.h`.
 
-If you wish to generate your own constants you can use our python script which can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/poseidon/constants/generate_parameters.py).
+If you wish to generate your own constants you can use our python script which can be found [here](https://github.com/ingonyama-zk/icicle/blob/main/icicle/include/icicle/hash/poseidon_constants/constants/generate_parameters.py).
 
 Prerequisites:
 


### PR DESCRIPTION
Hi! Fixed several broken links in the documentation that pointed to outdated or non-existent pages. Key changes:

- Updated links to Stark252 in `libraries.md`.
- Fixed paths to Poseidon constants in `poseidon.md`, now pointing to the correct files.
- Updated the link to the Ingopedia community guide in `sidebars.ts`.

Everything should now open correctly.