### PR TITLE
Change constant data of some poseidon2 tests to be random.

### DIFF
--- a/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
+++ b/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
@@ -354,8 +354,11 @@ namespace icicle {
       }
 
       delete[] tmp_fields;
-      if (padding_size != 0) delete[] padding;
       tmp_fields = nullptr;
+      if (padding_size != 0) {
+        delete[] padding;
+        padding = nullptr;
+      }
 
       return eIcicleError::SUCCESS;
     } // eIcicleError hash(const std::byte* input, uint64_t size, const HashConfig& config, std::byte* output) const

--- a/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
+++ b/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
@@ -181,7 +181,7 @@ namespace icicle {
 
     s_cpu_backend_poseidon2_constants_initialized = true;
     return eIcicleError::SUCCESS;
-  }   // static eIcicleError init_default_constants()
+  } // static eIcicleError init_default_constants()
 
   template <typename S>
   class Poseidon2BackendCPU : public HashBackend

--- a/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
+++ b/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
@@ -181,7 +181,7 @@ namespace icicle {
 
     s_cpu_backend_poseidon2_constants_initialized = true;
     return eIcicleError::SUCCESS;
-  }
+  }   // static eIcicleError init_default_constants()
 
   template <typename S>
   class Poseidon2BackendCPU : public HashBackend

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -52,7 +52,7 @@ TYPED_TEST_SUITE(FieldApiTest, FTImplementations);
 // Note: this is testing host arithmetic. Other tests against CPU backend should guarantee correct device arithmetic too
 TYPED_TEST(FieldApiTest, FieldSanityTest)
 {
-  icicle_set_device("CPU");    // Use CPU only for now.
+  icicle_set_device("CPU"); // Use CPU only for now.
   auto a = TypeParam::rand_host();
   auto b = TypeParam::rand_host();
   auto b_inv = TypeParam::inverse(b);
@@ -1193,7 +1193,7 @@ TEST_F(FieldApiTestBase, ProgramExecutorVecOpDataOnDevice)
 
 TEST_F(FieldApiTestBase, Sumcheck)
 {
-  icicle_set_device("CPU");    // Use CPU only for now.
+  icicle_set_device("CPU"); // Use CPU only for now.
   int log_mle_poly_size = 13;
   int mle_poly_size = 1 << log_mle_poly_size;
   int nof_mle_poly = 4;

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -52,6 +52,7 @@ TYPED_TEST_SUITE(FieldApiTest, FTImplementations);
 // Note: this is testing host arithmetic. Other tests against CPU backend should guarantee correct device arithmetic too
 TYPED_TEST(FieldApiTest, FieldSanityTest)
 {
+  icicle_set_device("CPU");    // Use CPU only for now.
   auto a = TypeParam::rand_host();
   auto b = TypeParam::rand_host();
   auto b_inv = TypeParam::inverse(b);

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -1192,6 +1192,7 @@ TEST_F(FieldApiTestBase, ProgramExecutorVecOpDataOnDevice)
 
 TEST_F(FieldApiTestBase, Sumcheck)
 {
+  icicle_set_device("CPU");    // Use CPU only for now.
   int log_mle_poly_size = 13;
   int mle_poly_size = 1 << log_mle_poly_size;
   int nof_mle_poly = 4;

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1165,7 +1165,6 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   //   input[i] = scalar_t::from(i % t);
   // }
   scalar_t::rand_host_many(input.get(), t * config.batch);
-  bool use_random = true;
   // for (int i = 0; i < config.batch * t; i++) {
   // std::cout << "poseidon2_3_single_hasher input " << input[i] << std::endl;
   // }
@@ -1189,13 +1188,11 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   std::cout << "Run CPU only test " << std::endl;
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch);
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
-  #if FIELD_ID == BN254
-  if (!use_random) {
-    scalar_t expected_res =
-      scalar_t::hex_str2scalar("0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570");
-    ASSERT_EQ(expected_res, *(output_cpu.get()));
-  }
-  #endif
+  // #if FIELD_ID == BN254
+  // scalar_t expected_res =
+  //   scalar_t::hex_str2scalar("0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570");
+  // ASSERT_EQ(expected_res, *(output_cpu.get()));
+  // #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
     std::cout << "Run CUDA test " << std::endl;
@@ -1266,7 +1263,6 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_without_dt)
   //   }
   // }
   scalar_t::rand_host_many(input.get(), nof_inputs);
-  bool use_random = true;
   // for (int i = 0; i < t + (nof_hashers-1) * (t-1); i++) {
   //   std::cout << "poseidon2_3_sponge_2_hashers_without_dt input " << input[i] << std::endl;
   // }
@@ -1290,13 +1286,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_without_dt)
   std::cout << "Run CPU test " << std::endl;
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
-  #if FIELD_ID == BN254
-  if (!use_random) {
-    scalar_t expected_res =
-      scalar_t::hex_str2scalar("0x0d54b4b71781dc4f30afe3a90f76559379f6f75aea6968d4c986512e2711ad20");
-    ASSERT_EQ(expected_res, *(output_cpu.get()));
-  }
-  #endif
+  // #if FIELD_ID == BN254
+  // scalar_t expected_res =
+  //   scalar_t::hex_str2scalar("0x0d54b4b71781dc4f30afe3a90f76559379f6f75aea6968d4c986512e2711ad20");
+  // ASSERT_EQ(expected_res, *(output_cpu.get()));
+  // #endif
 
   std::string main_device = IcicleTestBase::main_device();
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1324,7 +1318,6 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_with_dt)
   //   input[i] = scalar_t::from(5 + i);
   // }
   scalar_t::rand_host_many(input.get(), nof_valid_inputs);
-  bool use_random = true;
   // for (int i = 0; i < nof_valid_inputs; i++) {
   //   std::cout << "poseidon2_3_sponge_2_hashers_with_dt input " << input[i] << std::endl;
   // }
@@ -1348,13 +1341,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_with_dt)
   std::cout << "Run CPU test " << std::endl;
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
-  #if FIELD_ID == BN254
-  if (!use_random) {
-    scalar_t expected_res =
-      scalar_t::hex_str2scalar("0x286786cd695dbe838456c72a5edb4d2717a17a0971006671c26c0219c3de5abe");
-    ASSERT_EQ(expected_res, *(output_cpu.get()));
-  }
-  #endif
+  // #if FIELD_ID == BN254
+  // scalar_t expected_res =
+  //   scalar_t::hex_str2scalar("0x286786cd695dbe838456c72a5edb4d2717a17a0971006671c26c0219c3de5abe");
+  // ASSERT_EQ(expected_res, *(output_cpu.get()));
+  // #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
     std::cout << "Run CUDA test " << std::endl;
@@ -1377,7 +1368,6 @@ TEST_F(HashApiTest, poseidon2_3_sponge_1_hasher_without_dt_with_padding)
   //   input[i] = scalar_t::from(4 + i);          // Valid inputs are 4,5
   // }
   scalar_t::rand_host_many(input.get(), nof_valid_inputs);
-  bool use_random = true;
   // for (int i = 0; i < nof_valid_inputs; i++) {
   //   std::cout << "poseidon2_3_sponge_1_hasher_without_dt_with_padding input " << input[i] << std::endl;
   // }
@@ -1401,13 +1391,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_1_hasher_without_dt_with_padding)
   std::cout << "Run CPU test " << std::endl;
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
-  #if FIELD_ID == BN254
-  if (!use_random) {
-    scalar_t expected_res =
-      scalar_t::hex_str2scalar("0x2645a6e432f38bb4f197b1b4a69d6fac977cdb4927cfbb62f133a9e427dee146");
-    ASSERT_EQ(expected_res, *(output_cpu.get()));
-  }
-  #endif
+  // #if FIELD_ID == BN254
+  // scalar_t expected_res =
+  //   scalar_t::hex_str2scalar("0x2645a6e432f38bb4f197b1b4a69d6fac977cdb4927cfbb62f133a9e427dee146");
+  // ASSERT_EQ(expected_res, *(output_cpu.get()));
+  // #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
     std::cout << "Run CUDA test " << std::endl;
@@ -1430,7 +1418,6 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt_with_padding)
   //   input[i] = scalar_t::from(4 + i);          // Valid inputs are 4,5
   // }
   scalar_t::rand_host_many(input.get(), nof_valid_inputs);
-  bool use_random = true;
   // for (int i = 0; i < nof_valid_inputs; i++) {
   //   std::cout << "poseidon2_4_sponge_2_hashers_without_dt_with_padding input " << input[i] << std::endl;
   // }
@@ -1454,13 +1441,11 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt_with_padding)
   std::cout << "Run CPU test " << std::endl;
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
-  #if FIELD_ID == BN254
-  if (!use_random) {
-    scalar_t expected_res =
-      scalar_t::hex_str2scalar("0x0353fae9638ef80c9a80786ce24c42d6e087695a40cd5ca29207f20b72f25379");
-    ASSERT_EQ(expected_res, *(output_cpu.get()));
-  }
-  #endif
+  // #if FIELD_ID == BN254
+  // scalar_t expected_res =
+  //   scalar_t::hex_str2scalar("0x0353fae9638ef80c9a80786ce24c42d6e087695a40cd5ca29207f20b72f25379");
+  // ASSERT_EQ(expected_res, *(output_cpu.get()));
+  // #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
     std::cout << "Run CUDA test " << std::endl;

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1190,11 +1190,11 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch);
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-    if (!use_random) {
-      scalar_t expected_res =
-        scalar_t::hex_str2scalar("0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570");
-      ASSERT_EQ(expected_res, *(output_cpu.get()));
-    }
+  if (!use_random) {
+    scalar_t expected_res =
+      scalar_t::hex_str2scalar("0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570");
+    ASSERT_EQ(expected_res, *(output_cpu.get()));
+  }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1291,11 +1291,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_without_dt)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-    if (!use_random) {
-      scalar_t expected_res =
-        scalar_t::hex_str2scalar("0x0d54b4b71781dc4f30afe3a90f76559379f6f75aea6968d4c986512e2711ad20");
-      ASSERT_EQ(expected_res, *(output_cpu.get()));
-    }
+  if (!use_random) {
+    scalar_t expected_res =
+      scalar_t::hex_str2scalar("0x0d54b4b71781dc4f30afe3a90f76559379f6f75aea6968d4c986512e2711ad20");
+    ASSERT_EQ(expected_res, *(output_cpu.get()));
+  }
   #endif
 
   std::string main_device = IcicleTestBase::main_device();
@@ -1349,11 +1349,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_with_dt)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-    if (!use_random) {
-      scalar_t expected_res =
-        scalar_t::hex_str2scalar("0x286786cd695dbe838456c72a5edb4d2717a17a0971006671c26c0219c3de5abe");
-      ASSERT_EQ(expected_res, *(output_cpu.get()));
-    }
+  if (!use_random) {
+    scalar_t expected_res =
+      scalar_t::hex_str2scalar("0x286786cd695dbe838456c72a5edb4d2717a17a0971006671c26c0219c3de5abe");
+    ASSERT_EQ(expected_res, *(output_cpu.get()));
+  }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1402,11 +1402,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_1_hasher_without_dt_with_padding)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-    if (!use_random) {
-      scalar_t expected_res =
-        scalar_t::hex_str2scalar("0x2645a6e432f38bb4f197b1b4a69d6fac977cdb4927cfbb62f133a9e427dee146");
-      ASSERT_EQ(expected_res, *(output_cpu.get()));
-    }
+  if (!use_random) {
+    scalar_t expected_res =
+      scalar_t::hex_str2scalar("0x2645a6e432f38bb4f197b1b4a69d6fac977cdb4927cfbb62f133a9e427dee146");
+    ASSERT_EQ(expected_res, *(output_cpu.get()));
+  }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1455,11 +1455,11 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt_with_padding)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-    if (!use_random) {
-      scalar_t expected_res =
-        scalar_t::hex_str2scalar("0x0353fae9638ef80c9a80786ce24c42d6e087695a40cd5ca29207f20b72f25379");
-      ASSERT_EQ(expected_res, *(output_cpu.get()));
-    }
+  if (!use_random) {
+    scalar_t expected_res =
+      scalar_t::hex_str2scalar("0x0353fae9638ef80c9a80786ce24c42d6e087695a40cd5ca29207f20b72f25379");
+    ASSERT_EQ(expected_res, *(output_cpu.get()));
+  }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1809,4 +1809,4 @@ TEST_F(SumcheckTest, InitializeWithByteVector)
   EXPECT_EQ(config.get_seed_rng(), seed);
 }
 #endif // SUMCHECK
-// 
+       //

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1149,7 +1149,7 @@ TEST_F(HashApiTest, poseidon_tree)
 
 #endif // POSEIDON
 
-#ifdef POSEIDON2
+#ifdef POSEIDON2222
   // DEBUG. This test could run only with bn254 curve. Dont remove!!!
   // bn254: p = 0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570
   #include "icicle/fields/field_config.h"

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1161,9 +1161,11 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   config.batch = 1;
 
   auto input = std::make_unique<scalar_t[]>(config.batch * t);
-  for (int i = 0; i < config.batch * t; i++) {
-    input[i] = scalar_t::from(i % t);
-  }
+  // for (int i = 0; i < config.batch * t; i++) {
+  //   input[i] = scalar_t::from(i % t);
+  // }
+  scalar_t::rand_host_many(input.get(), t * config.batch);
+  bool use_random = true;
   // for (int i = 0; i < config.batch * t; i++) {
   // std::cout << "poseidon2_3_single_hasher input " << input[i] << std::endl;
   // }
@@ -1188,9 +1190,11 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch);
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-  scalar_t expected_res =
-    scalar_t::hex_str2scalar("0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570");
-  ASSERT_EQ(expected_res, *(output_cpu.get()));
+    if (!use_random) {
+      scalar_t expected_res =
+        scalar_t::hex_str2scalar("0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570");
+      ASSERT_EQ(expected_res, *(output_cpu.get()));
+    }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1250,16 +1254,19 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_without_dt)
   const unsigned t = 3;
   auto config = default_hash_config();
   int nof_hashers = 2;
+  int nof_inputs = 1 + nof_hashers * (t - 1);
 
-  auto input = std::make_unique<scalar_t[]>(1 + nof_hashers * (t - 1));
-  for (int i = 0; i < t; i++) { // First hasher has t inputs.
-    input[i] = scalar_t::from(i);
-  }
-  for (int hasher_idx = 1; hasher_idx < nof_hashers; hasher_idx++) {
-    for (int i = 1; i < t; i++) { // Non-first hashers have t-1 inputs.
-      input[hasher_idx * (t - 1) + i] = scalar_t::from(i);
-    }
-  }
+  auto input = std::make_unique<scalar_t[]>(nof_inputs);
+  // for (int i = 0; i < t; i++) { // First hasher has t inputs.
+  //   input[i] = scalar_t::from(i);
+  // }
+  // for (int hasher_idx = 1; hasher_idx < nof_hashers; hasher_idx++) {
+  //   for (int i = 1; i < t; i++) { // Non-first hashers have t-1 inputs.
+  //     input[hasher_idx * (t - 1) + i] = scalar_t::from(i);
+  //   }
+  // }
+  scalar_t::rand_host_many(input.get(), nof_inputs);
+  bool use_random = true;
   // for (int i = 0; i < t + (nof_hashers-1) * (t-1); i++) {
   //   std::cout << "poseidon2_3_sponge_2_hashers_without_dt input " << input[i] << std::endl;
   // }
@@ -1284,9 +1291,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_without_dt)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-  scalar_t expected_res =
-    scalar_t::hex_str2scalar("0x0d54b4b71781dc4f30afe3a90f76559379f6f75aea6968d4c986512e2711ad20");
-  ASSERT_EQ(expected_res, *(output_cpu.get()));
+    if (!use_random) {
+      scalar_t expected_res =
+        scalar_t::hex_str2scalar("0x0d54b4b71781dc4f30afe3a90f76559379f6f75aea6968d4c986512e2711ad20");
+      ASSERT_EQ(expected_res, *(output_cpu.get()));
+    }
   #endif
 
   std::string main_device = IcicleTestBase::main_device();
@@ -1311,9 +1320,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_with_dt)
   // Input will be 4,5,6,8.
   // With dt and padding it will be 4,5,6,7,8,1,0.
   auto input = std::make_unique<scalar_t[]>(nof_valid_inputs);
-  for (int i = 0; i < nof_valid_inputs; i++) { // First hasher has t inputs.
-    input[i] = scalar_t::from(5 + i);
-  }
+  // for (int i = 0; i < nof_valid_inputs; i++) { // First hasher has t inputs.
+  //   input[i] = scalar_t::from(5 + i);
+  // }
+  scalar_t::rand_host_many(input.get(), nof_valid_inputs);
+  bool use_random = true;
   // for (int i = 0; i < nof_valid_inputs; i++) {
   //   std::cout << "poseidon2_3_sponge_2_hashers_with_dt input " << input[i] << std::endl;
   // }
@@ -1338,9 +1349,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_2_hashers_with_dt)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-  scalar_t expected_res =
-    scalar_t::hex_str2scalar("0x286786cd695dbe838456c72a5edb4d2717a17a0971006671c26c0219c3de5abe");
-  ASSERT_EQ(expected_res, *(output_cpu.get()));
+    if (!use_random) {
+      scalar_t expected_res =
+        scalar_t::hex_str2scalar("0x286786cd695dbe838456c72a5edb4d2717a17a0971006671c26c0219c3de5abe");
+      ASSERT_EQ(expected_res, *(output_cpu.get()));
+    }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1360,9 +1373,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_1_hasher_without_dt_with_padding)
   int nof_valid_inputs = 2;
 
   auto input = std::make_unique<scalar_t[]>(nof_valid_inputs);
-  for (int i = 0; i < nof_valid_inputs; i++) { // First hasher has t inputs.
-    input[i] = scalar_t::from(4 + i);          // Valid inputs are 4,5
-  }
+  // for (int i = 0; i < nof_valid_inputs; i++) { // First hasher has t inputs.
+  //   input[i] = scalar_t::from(4 + i);          // Valid inputs are 4,5
+  // }
+  scalar_t::rand_host_many(input.get(), nof_valid_inputs);
+  bool use_random = true;
   // for (int i = 0; i < nof_valid_inputs; i++) {
   //   std::cout << "poseidon2_3_sponge_1_hasher_without_dt_with_padding input " << input[i] << std::endl;
   // }
@@ -1387,9 +1402,11 @@ TEST_F(HashApiTest, poseidon2_3_sponge_1_hasher_without_dt_with_padding)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-  scalar_t expected_res =
-    scalar_t::hex_str2scalar("0x2645a6e432f38bb4f197b1b4a69d6fac977cdb4927cfbb62f133a9e427dee146");
-  ASSERT_EQ(expected_res, *(output_cpu.get()));
+    if (!use_random) {
+      scalar_t expected_res =
+        scalar_t::hex_str2scalar("0x2645a6e432f38bb4f197b1b4a69d6fac977cdb4927cfbb62f133a9e427dee146");
+      ASSERT_EQ(expected_res, *(output_cpu.get()));
+    }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1409,9 +1426,11 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt_with_padding)
   int nof_valid_inputs = 5;
 
   auto input = std::make_unique<scalar_t[]>(nof_valid_inputs);
-  for (int i = 0; i < nof_valid_inputs; i++) { // First hasher has t inputs.
-    input[i] = scalar_t::from(4 + i);          // Valid inputs are 4,5
-  }
+  // for (int i = 0; i < nof_valid_inputs; i++) { // First hasher has t inputs.
+  //   input[i] = scalar_t::from(4 + i);          // Valid inputs are 4,5
+  // }
+  scalar_t::rand_host_many(input.get(), nof_valid_inputs);
+  bool use_random = true;
   // for (int i = 0; i < nof_valid_inputs; i++) {
   //   std::cout << "poseidon2_4_sponge_2_hashers_without_dt_with_padding input " << input[i] << std::endl;
   // }
@@ -1436,9 +1455,11 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt_with_padding)
   auto output_cpu = std::make_unique<scalar_t[]>(config.batch); // config.batch = 1 here.
   run(IcicleTestBase::reference_device(), output_cpu.get(), VERBOSE /*=measure*/, "poseidon2", ITERS);
   #if FIELD_ID == BN254
-  scalar_t expected_res =
-    scalar_t::hex_str2scalar("0x0353fae9638ef80c9a80786ce24c42d6e087695a40cd5ca29207f20b72f25379");
-  ASSERT_EQ(expected_res, *(output_cpu.get()));
+    if (!use_random) {
+      scalar_t expected_res =
+        scalar_t::hex_str2scalar("0x0353fae9638ef80c9a80786ce24c42d6e087695a40cd5ca29207f20b72f25379");
+      ASSERT_EQ(expected_res, *(output_cpu.get()));
+    }
   #endif
 
   if (IcicleTestBase::main_device() == "CUDA") {
@@ -1501,9 +1522,10 @@ TEST_F(HashApiTest, poseidon2_3_sponge_hash_2_without_dt)
   const unsigned t = 3;
   auto config = default_hash_config();
   int nof_hashers = 2;
+  int nof_valid_inputs = 5;
 
-  auto input = std::make_unique<scalar_t[]>(1 + nof_hashers * (t - 1));
-  scalar_t::rand_host_many(input.get(), 1 + nof_hashers * (t - 1));
+  auto input = std::make_unique<scalar_t[]>(nof_valid_inputs);
+  scalar_t::rand_host_many(input.get(), nof_valid_inputs);
   // // DEBUG - sets known inputs. Do not remove!!!
   // for (int i=0; i<t; i++) {    // First hasher has t inputs.
   //   input[i] = scalar_t::from(i);
@@ -1549,9 +1571,10 @@ TEST_F(HashApiTest, poseidon2_3_sponge_hash_1K_without_dt)
   const unsigned t = 3;
   auto config = default_hash_config();
   int nof_hashers = 1 << 10;
+  int nof_valid_inputs = 1 + nof_hashers * (t - 1);
 
-  auto input = std::make_unique<scalar_t[]>(1 + nof_hashers * (t - 1));
-  scalar_t::rand_host_many(input.get(), 1 + nof_hashers * (t - 1));
+  auto input = std::make_unique<scalar_t[]>(nof_valid_inputs);
+  scalar_t::rand_host_many(input.get(), nof_valid_inputs);
   // // DEBUG - sets known inputs. Do not remove!!!
   // for (int i=0; i<t; i++) {    // First hasher has t inputs.
   //   input[i] = scalar_t::from(i);
@@ -1786,3 +1809,4 @@ TEST_F(SumcheckTest, InitializeWithByteVector)
   EXPECT_EQ(config.get_seed_rng(), seed);
 }
 #endif // SUMCHECK
+// 

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1149,7 +1149,7 @@ TEST_F(HashApiTest, poseidon_tree)
 
 #endif // POSEIDON
 
-#ifdef POSEIDON2222
+#ifdef POSEIDON2
   // DEBUG. This test could run only with bn254 curve. Dont remove!!!
   // bn254: p = 0x303b6f7c86d043bfcbcc80214f26a30277a15d3f74ca654992defe7ff8d03570
   #include "icicle/fields/field_config.h"


### PR DESCRIPTION
## Describe the changes

This PR changes the Poseidon2 inputs data to be random instead of constant.

## Linked Issues

Resolves #

## (optional) CUDA backend branch
cuda-backend-branch:danny/poseidon2_sponge
