### PR TITLE
Allow loaded backend to override default device for all threads

### DIFF
--- a/icicle/include/icicle/device_api.h
+++ b/icicle/include/icicle/device_api.h
@@ -252,7 +252,7 @@ namespace icicle {
       std::shared_ptr<DeviceAPI> apiInstance = std::make_shared<API_CLASS>();                                          \
       register_deviceAPI(DEVICE_TYPE, apiInstance);                                                                    \
       ICICLE_CHECK(icicle_set_default_device(icicle::Device(DEVICE_TYPE)));                                            \
-      ICICLE_LOG_INFO << "Succesfully loaded " << DEVICE_TYPE << " as default device";                                 \
+      ICICLE_LOG_INFO << "Successfully loaded " << DEVICE_TYPE << " as default device";                                \
       return true;                                                                                                     \
     }();                                                                                                               \
   }

--- a/icicle/include/icicle/device_api.h
+++ b/icicle/include/icicle/device_api.h
@@ -246,4 +246,15 @@ namespace icicle {
     }();                                                                                                               \
   }
 
+#define REGISTER_DEVICE_API_AND_SET_AS_DEFAULT(DEVICE_TYPE, API_CLASS)                                                 \
+  namespace {                                                                                                          \
+    static bool UNIQUE(_reg_device_##API_CLASS) = []() -> bool {                                                       \
+      std::shared_ptr<DeviceAPI> apiInstance = std::make_shared<API_CLASS>();                                          \
+      register_deviceAPI(DEVICE_TYPE, apiInstance);                                                                    \
+      ICICLE_CHECK(icicle_set_default_device(icicle::Device(DEVICE_TYPE)));                                            \
+      ICICLE_LOG_INFO << "Succesfully loaded " << DEVICE_TYPE << " as default device";                                 \
+      return true;                                                                                                     \
+    }();                                                                                                               \
+  }
+
 } // namespace icicle

--- a/wrappers/rust/icicle-core/src/sumcheck/mod.rs
+++ b/wrappers/rust/icicle-core/src/sumcheck/mod.rs
@@ -213,15 +213,31 @@ macro_rules! impl_sumcheck_tests {
     ($field:ident) => {
         use icicle_core::sumcheck::tests::*;
         use icicle_hash::keccak::Keccak256;
+        use icicle_runtime::{device::Device, runtime, test_utilities};
+        use std::sync::Once;
+
+        const MAX_SIZE: u64 = 1 << 18;
+        static INIT: Once = Once::new();
+        const FAST_TWIDDLES_MODE: bool = false;
+
+        pub fn initialize() {
+            INIT.call_once(move || {
+                test_utilities::test_load_and_init_devices();
+            });
+            // TODO loop over devices once we implement for CUDA
+            test_utilities::test_set_ref_device();
+        }
 
         #[test]
         fn test_sumcheck_transcript_config() {
+            initialize();
             let hash = Keccak256::new(0).unwrap();
             check_sumcheck_transcript_config::<$field>(&hash);
         }
 
         #[test]
         fn test_sumcheck_simple() {
+            initialize();
             let hash = Keccak256::new(0).unwrap();
             check_sumcheck_simple::<$field>(&hash);
         }


### PR DESCRIPTION

 cuda-backend-branch: yshekel/auto_default_device
