### PR TITLE
FEAT: allow setting CUDA-specific in the extended config for ntt/msm

### DIFF
--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -49,8 +49,22 @@ pub struct MSMConfig {
 }
 
 // backend specific options
-pub const CUDA_MSM_LARGE_BUCKET_FACTOR: &str = "large_bucket_factor";
-pub const CUDA_MSM_IS_BIG_TRIANGLE: &str = "is_big_triangle";
+const CUDA_MSM_LARGE_BUCKET_FACTOR: &str = "large_bucket_factor";
+const CUDA_MSM_IS_BIG_TRIANGLE: &str = "is_big_triangle";
+
+pub enum CUDA_option {
+    CudaMsmLargeBucketFactor(i32),
+    CudaMsmIsBigTriangle(bool)
+}
+
+impl MSMConfig {
+    pub fn set_cuda_option(&self, option : CUDA_option) -> () {
+        match option {
+            CUDA_option::CudaMsmLargeBucketFactor(value) => self.ext.set_int(CUDA_MSM_LARGE_BUCKET_FACTOR, value),
+            CUDA_option::CudaMsmIsBigTriangle(flag) => self.ext.set_bool(CUDA_MSM_IS_BIG_TRIANGLE, flag),
+        }
+    }
+}
 
 impl Default for MSMConfig {
     fn default() -> Self {

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -61,14 +61,21 @@ pub enum Ordering {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NttAlgorithm {
-    Auto,
-    Radix2,
-    MixedRadix,
+    Auto =0,
+    Radix2 =1,
+    MixedRadix =2,
 }
 
 // CUDA backend specific flags
-pub const CUDA_NTT_FAST_TWIDDLES_MODE: &str = "fast_twiddles";
-pub const CUDA_NTT_ALGORITHM: &str = "ntt_algorithm";
+const CUDA_NTT_FAST_TWIDDLES_MODE: &str = "fast_twiddles";
+const CUDA_NTT_ALGORITHM: &str = "ntt_algorithm";
+
+pub enum CUDA_option {
+    CudaNttFastTwiddleMode(bool),
+    CudaNttAlgorithm(NttAlgorithm)
+}
+
+
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -104,6 +111,14 @@ impl<S: FieldImpl> NTTConfig<S> {
             ext: ConfigExtension::new(),
         }
     }
+
+    pub fn set_cuda_option(&self, option : CUDA_option) -> () {
+        match option {
+            CUDA_option::CudaNttFastTwiddleMode(flag) => self.ext.set_bool(CUDA_NTT_FAST_TWIDDLES_MODE, flag),
+            CUDA_option::CudaNttAlgorithm(ntt_algorithm) => self.ext.set_int(CUDA_NTT_ALGORITHM, ntt_algorithm as i32) ,
+        }
+    }
+
 }
 
 #[repr(C)]


### PR DESCRIPTION
## Describe the changes

This PR allows specifiying the extended config for MSM/NTT via Rust

## Linked Issues

Resolves #

## (optional) CUDA backend branch
# cuda-backend-branch: main # specify the branch here
