### PR TITLE
Fix incorrect clang-format flag

### DIFF
--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -81,7 +81,7 @@ fi
 echo "$FILES" | while read -r file; do
     if [ "$CHECK_ONLY" = true ]; then
         # Check if the file is properly formatted
-        if ! clang-format -output-replacements-xml "$file" | grep -q "<replacement "; then
+        if ! clang-format --output-replacements-xml "$file" | grep -q "<replacement "; then
             echo "✅ $file is properly formatted."
         else
             echo "❌ $file needs formatting."


### PR DESCRIPTION
## Describe the changes

Fixed an issue with the `-output-replacements-xml` flag, which should have two dashes: `--output-replacements-xml`.  

With a single dash, it was interpreted as a series of separate flags (`-o`, `-u`, `-t`, `-p`, etc.), causing incorrect behavior. 
The command now works as expected.
