### PR TITLE
add "release" tag to Release CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, Linux, X64, icicle]  
+    runs-on: [self-hosted, Linux, X64, icicle, release]  
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Lock Release CI to run on a dedicated machine