### PR TITLE
Example/sumcheck

### DIFF
--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "polynomials",
     "arkworks-icicle-conversions",
     "hash-and-merkle", 
-    "poseidon2",
+    "poseidon2", 
+    "sumcheck",
 ]
 
 [workspace.dependencies]

--- a/examples/rust/sumcheck/Cargo.toml
+++ b/examples/rust/sumcheck/Cargo.toml
@@ -13,3 +13,23 @@ icicle-hash = { path = "../../../wrappers/rust/icicle-hash" }
 merlin = {version = "3.0.0"}
 log = "0.4.25"
 env_logger = "0.11.6"
+clap = { version = "<=4.4.12", features = ["derive"] }
+
+[features]
+cuda = [
+        "icicle-runtime/cuda_backend",
+        "icicle-bn254/cuda_backend",
+        "icicle-hash/cuda_backend"
+]
+
+metal = [
+         "icicle-runtime/metal_backend",
+        "icicle-bn254/metal_backend",
+        "icicle-hash/metal_backend"
+]
+
+vulkan = [
+        "icicle-runtime/vulkan_backend",
+        "icicle-bn254/vulkan_backend",
+        "icicle-hash/vulkan_backend"
+]

--- a/examples/rust/sumcheck/Cargo.toml
+++ b/examples/rust/sumcheck/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sumcheck"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+icicle-runtime = { path = "../../../wrappers/rust/icicle-runtime" }
+icicle-core = { path = "../../../wrappers/rust/icicle-core" }
+icicle-bn254 = { path = "../../../wrappers/rust/icicle-curves/icicle-bn254" }
+icicle-hash = { path = "../../../wrappers/rust/icicle-hash" }
+
+
+merlin = {version = "3.0.0"}
+log = "0.4.25"
+env_logger = "0.11.6"

--- a/examples/rust/sumcheck/README.md
+++ b/examples/rust/sumcheck/README.md
@@ -1,0 +1,20 @@
+# Sumcheck benches
+
+This example, instantiates a R1CS sumcheck instance with the parameters 
+* `Sample size = 1<<22` field: BN254 scalar.
+* Sumcheck IOP is part of a more general protocol, we use merlin to "simulate" a previous state of the transcript, and generate a seed randomness based on the previous state.
+* The verifier also simulates the previous state of the transcript using Merlin to generate an identical seed randomness.
+* In this example, we configured the Fiat Shamir protocol to run with the blake3 hash. Experiment with different hashes such as Keccak, blake2s , Poseidon etc. 
+* Experiment with different sizes, fields, etc.
+* The code runs in both CPU and GPU in a device agnostic manner. It assumes that the cuda backend is installed in the `icicle/backend/cuda/` folder, defaults to CPU in the absence of a device.
+* Run the example with `RUST_LOG=info cargo run --release cargo--package sumcheck --bin sumcheck`
+
+Sample outputs: M1 mac
+```rust
+[2025-02-17T20:57:25Z INFO  sumcheck] Generate e,A,B,C of log size 22, time 954.447375ms
+[2025-02-17T20:57:26Z INFO  sumcheck] Compute claimed sum time 439.200917ms
+[2025-02-17T20:57:28Z INFO  sumcheck] Prover time 2.383280625s
+Valid proof!
+[2025-02-17T20:57:28Z INFO  sumcheck] verify time 201.666µs
+[2025-02-17T20:57:28Z INFO  sumcheck] total time 3.777288875s
+```

--- a/examples/rust/sumcheck/README.md
+++ b/examples/rust/sumcheck/README.md
@@ -1,4 +1,4 @@
-# Sumcheck benches
+# Sumcheck example
 
 This example, instantiates a R1CS sumcheck instance with the parameters 
 * `Sample size = 1<<22` field: BN254 scalar.

--- a/examples/rust/sumcheck/README.md
+++ b/examples/rust/sumcheck/README.md
@@ -7,7 +7,16 @@ This example, instantiates a R1CS sumcheck instance with the parameters
 * In this example, we configured the Fiat Shamir protocol to run with the blake3 hash. Experiment with different hashes such as Keccak, blake2s , Poseidon etc. 
 * Experiment with different sizes, fields, etc.
 * The code runs in both CPU/GPU in a device agnostic manner. It assumes that the cuda backend is installed in the `icicle/backend/cuda/` folder, defaults to CPU in the absence of a device backend.
-* Run the example with `RUST_LOG=info cargo run --release cargo--package sumcheck --bin sumcheck`
+
+Running the example with script
+```sh
+# for CPU
+./run.sh -d CPU
+# for CUDA
+./run.sh -d CUDA -b /path/to/cuda/backend/install/dir
+# for METAL (not supported yet)
+./run.sh -d METAL -b /path/to/cuda/backend/install/dir
+```
 
 Sample outputs: M1 mac
 ```rust
@@ -29,3 +38,4 @@ Valid proof!
 [2025-02-17T21:10:34Z INFO  sumcheck] verify time 183.244µs
 [2025-02-17T21:10:34Z INFO  sumcheck] total time 1.489436224s
 ```
+

--- a/examples/rust/sumcheck/README.md
+++ b/examples/rust/sumcheck/README.md
@@ -6,7 +6,7 @@ This example, instantiates a R1CS sumcheck instance with the parameters
 * The verifier also simulates the previous state of the transcript using Merlin to generate an identical seed randomness.
 * In this example, we configured the Fiat Shamir protocol to run with the blake3 hash. Experiment with different hashes such as Keccak, blake2s , Poseidon etc. 
 * Experiment with different sizes, fields, etc.
-* The code runs in both CPU and GPU in a device agnostic manner. It assumes that the cuda backend is installed in the `icicle/backend/cuda/` folder, defaults to CPU in the absence of a device.
+* The code runs in both CPU/GPU in a device agnostic manner. It assumes that the cuda backend is installed in the `icicle/backend/cuda/` folder, defaults to CPU in the absence of a device backend.
 * Run the example with `RUST_LOG=info cargo run --release cargo--package sumcheck --bin sumcheck`
 
 Sample outputs: M1 mac
@@ -17,4 +17,15 @@ Sample outputs: M1 mac
 Valid proof!
 [2025-02-17T20:57:28Z INFO  sumcheck] verify time 201.666µs
 [2025-02-17T20:57:28Z INFO  sumcheck] total time 3.777288875s
+```
+
+Sample outputs: Ubuntu Desktop 22.04 128GB RAM	GPU: RTX 4080
+```rust
+[WARNING] Defaulting to Ingonyama icicle-cuda-license-server at `5053@license.icicle.ingonyama.com`. For more information about icicle-cuda-license, please contact support@ingonyama.com.
+[2025-02-17T21:10:33Z INFO  sumcheck] Generate e,A,B,C of log size 22, time 890.615763ms
+[2025-02-17T21:10:33Z INFO  sumcheck] Compute claimed sum time 374.166708ms
+[2025-02-17T21:10:34Z INFO  sumcheck] Prover time 224.319171ms
+Valid proof!
+[2025-02-17T21:10:34Z INFO  sumcheck] verify time 183.244µs
+[2025-02-17T21:10:34Z INFO  sumcheck] total time 1.489436224s
 ```

--- a/examples/rust/sumcheck/run.sh
+++ b/examples/rust/sumcheck/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Function to display usage information
+show_help() {
+  echo "Usage: $0 [-d DEVICE_TYPE] [-b BACKEND_INSTALL_DIR]"
+  echo
+  echo "Options:"
+  echo "  -d DEVICE_TYPE            Specify the device type (default: CPU)"
+  echo "  -b BACKEND_INSTALL_DIR    Specify the backend installation directory (default: empty)"
+  echo "  -h                        Show this help message"
+  exit 0
+}
+
+# Parse command line options
+while getopts ":d:b:h" opt; do
+  case ${opt} in
+    d )
+      DEVICE_TYPE=$OPTARG
+      ;;
+    b )
+      ICICLE_BACKEND_INSTALL_DIR="$(realpath ${OPTARG})"
+      ;;
+    h )
+      show_help
+      ;;
+    \? )
+      echo "Invalid option: -$OPTARG" 1>&2
+      show_help
+      ;;
+    : )
+      echo "Invalid option: -$OPTARG requires an argument" 1>&2
+      show_help
+      ;;
+  esac
+done
+
+# Set default values if not provided
+: "${DEVICE_TYPE:=CPU}"
+: "${ICICLE_BACKEND_INSTALL_DIR:=}"
+
+DEVICE_TYPE_LOWERCASE=$(echo "$DEVICE_TYPE" | tr '[:upper:]' '[:lower:]')
+
+ICILE_DIR=$(realpath "../../../icicle/")
+ICICLE_BACKEND_SOURCE_DIR="${ICILE_DIR}/backend/${DEVICE_TYPE_LOWERCASE}"
+
+# Build Icicle and the example app that links to it
+if [ "$DEVICE_TYPE" != "CPU" ] && [ ! -d "${ICICLE_BACKEND_INSTALL_DIR}" ] && [ -d "${ICICLE_BACKEND_SOURCE_DIR}" ]; then
+  echo "Building icicle and ${DEVICE_TYPE} backend"
+  cargo build --release --features="${DEVICE_TYPE_LOWERCASE}"
+  export ICICLE_BACKEND_INSTALL_DIR=$(realpath "../target/release/deps/icicle/lib/backend")
+ RUST_LOG=info cargo run --release --package sumcheck --bin sumcheck --features="${DEVICE_TYPE_LOWERCASE}" -- --device-type "${DEVICE_TYPE}" 
+else
+  echo "Building icicle without backend, ICICLE_BACKEND_INSTALL_DIR=${ICICLE_BACKEND_INSTALL_DIR}"
+  export ICICLE_BACKEND_INSTALL_DIR="${ICICLE_BACKEND_INSTALL_DIR}"
+  RUST_LOG=info cargo run --release --package sumcheck --bin sumcheck -- --device-type "${DEVICE_TYPE}" 
+fi
+

--- a/examples/rust/sumcheck/src/main.rs
+++ b/examples/rust/sumcheck/src/main.rs
@@ -112,6 +112,7 @@ let proof= sumcheck.prove(
         &transcript_config, 
         &sumcheck_config); 
 info!("Prover time {:?}", prover_time.elapsed());
+set_backend_cpu();
 let verify_time = Instant::now();
 verify_proof(sumcheck,proof, claimed_sum);
 info!("verify time {:?}", verify_time.elapsed());

--- a/examples/rust/sumcheck/src/main.rs
+++ b/examples/rust/sumcheck/src/main.rs
@@ -1,0 +1,119 @@
+pub mod utils;
+pub mod transcript;
+
+
+use icicle_bn254::curve::ScalarField as Fr;
+use icicle_bn254::sumcheck::SumcheckWrapper;
+use icicle_core::traits::FieldImpl;
+use icicle_hash::blake3::Blake3;
+use icicle_runtime::memory::HostSlice;
+use icicle_core::sumcheck::{Sumcheck,SumcheckConfig,SumcheckTranscriptConfig};
+use icicle_core::program::{PreDefinedProgram, ReturningValueProgram};
+use merlin::Transcript;
+
+use crate::transcript::*;
+use crate::utils::*;
+use log::info;
+use std::convert::TryInto;
+use std::time::Instant;
+
+
+const SAMPLES: usize = 1<<22;
+
+pub fn verify_proof(sumcheck:SumcheckWrapper,proof:icicle_bn254::sumcheck::SumcheckProof,claimed_sum:Fr ) {
+    let mut verifier_previous_transcript =  Transcript::new(b"my_sumcheck");
+    <Transcript as TranscriptProtocol::<Fr>>::append_data(&mut verifier_previous_transcript, b"public", &claimed_sum);
+    //get seed based on previous state
+    let verifier_seed_rng = <Transcript as TranscriptProtocol::<Fr>>::challenge_scalar(&mut verifier_previous_transcript, b"seeded");
+    
+    //define verifier FS config
+    let leaf_size = (Fr::one()).to_bytes_le().len().try_into().unwrap();
+    let hasher = Blake3::new(leaf_size).unwrap();
+    let verifier_transcript_config = SumcheckTranscriptConfig::new(
+          &hasher, 
+          b"start_sumcheck".to_vec(), 
+          b"round_poly".to_vec(), 
+          b"round_challenge".to_vec(), 
+          true, 
+          verifier_seed_rng);
+
+    let sumcheck = <icicle_bn254::sumcheck::SumcheckWrapper as Sumcheck>::new().unwrap();
+    let proof_validty = sumcheck.verify(&proof, claimed_sum, &verifier_transcript_config);
+
+match proof_validty {
+        Ok(true) => eprintln!("Valid proof!"), // Verification succeeded
+        Ok(false) => {
+            eprintln!(
+                "Sumcheck proof not valid",
+            );
+        }
+        Err(err) => {
+            eprintln!("Error in verification");
+        }
+    }
+}
+
+//RUST_LOG=info cargo run --release cargo--package sumcheck --bin sumcheck
+pub fn main(){
+env_logger::init();
+
+try_load_and_set_backend_gpu();
+//simulate previous state
+let mut prover_previous_transcript = Transcript::new(b"my_sumcheck");
+
+let gen_data_time = Instant::now();
+let poly_a = generate_random_vector::<Fr>(SAMPLES);
+let poly_b = generate_random_vector::<Fr>(SAMPLES);
+let poly_c = generate_random_vector::<Fr>(SAMPLES);
+let poly_e = generate_random_vector::<Fr>(SAMPLES);
+
+info!("Generate e,A,B,C of log size {:?}, time {:?}",SAMPLES.ilog2(),gen_data_time.elapsed());
+let compute_sum_time = Instant::now();
+    //compute claimed sum
+let temp:Vec<Fr> = poly_a
+    .iter()
+    .zip(poly_b.iter())
+    .zip(poly_c.iter())
+    .zip(poly_e.iter())
+    .map(|(((a, b), c), e)| *a * *b * *e - *c * *e)
+    .collect();  
+    let claimed_sum = temp.iter().fold(Fr::zero(), |acc, &a| acc + a);
+info!("Compute claimed sum time {:?}",compute_sum_time.elapsed());
+
+    //add claimed sum to transcript to simulate previous state
+    <Transcript as TranscriptProtocol::<Fr>>::append_data(&mut prover_previous_transcript, b"public", &claimed_sum);
+    //get seed based on previous state
+    let seed_rng = <Transcript as TranscriptProtocol::<Fr>>::challenge_scalar(&mut prover_previous_transcript, b"seeded");
+
+    let leaf_size = (Fr::one()).to_bytes_le().len().try_into().unwrap();
+    let hasher = Blake3::new(leaf_size).unwrap();
+
+    //define sumcheck config
+    let sumcheck_config = SumcheckConfig::default();
+
+    let mle_poly_hosts = vec![HostSlice::<Fr>::from_slice(&poly_a),
+    HostSlice::<Fr>::from_slice(&poly_b),HostSlice::<Fr>::from_slice(&poly_c),HostSlice::<Fr>::from_slice(&poly_e)];
+    let sumcheck = <icicle_bn254::sumcheck::SumcheckWrapper as Sumcheck>::new().unwrap();
+
+    let transcript_config = SumcheckTranscriptConfig::new(
+            &hasher, 
+            b"start_sumcheck".to_vec(), 
+            b"round_poly".to_vec(), 
+            b"round_challenge".to_vec(), 
+            true, 
+            seed_rng);
+    let combine_function = <icicle_bn254::program::FieldReturningValueProgram as ReturningValueProgram>::new_predefined(PreDefinedProgram::EQtimesABminusC).unwrap();
+let prover_time = Instant::now();
+let proof= sumcheck.prove(
+        &mle_poly_hosts, 
+        SAMPLES.try_into().unwrap(), 
+        claimed_sum, 
+        combine_function, 
+        &transcript_config, 
+        &sumcheck_config); 
+info!("Prover time {:?}", prover_time.elapsed());
+let verify_time = Instant::now();
+verify_proof(sumcheck,proof, claimed_sum);
+info!("verify time {:?}", verify_time.elapsed());
+info!("total time {:?}", gen_data_time.elapsed());
+}

--- a/examples/rust/sumcheck/src/main.rs
+++ b/examples/rust/sumcheck/src/main.rs
@@ -48,10 +48,12 @@ pub fn verify_proof(sumcheck: SumcheckWrapper, proof: icicle_bn254::sumcheck::Su
     match proof_validty {
         Ok(true) => println!("Valid proof!"), // Verification succeeded
         Ok(false) => {
-            eprintln!("Sumcheck proof not valid",);
+            eprintln!("Sumcheck proof not valid");
+            assert!(false, "Sumcheck proof verification failed!");
         }
         Err(err) => {
-            eprintln!("Error in verification");
+            eprintln!("Error in verification {:?}",err);
+            assert!(false, "Sumcheck proof verification encountered an error!");
         }
     }
 }
@@ -121,6 +123,7 @@ pub fn main() {
         true,
         seed_rng,
     );
+    //try different combine functions!
     let combine_function =
         <icicle_bn254::program::FieldReturningValueProgram as ReturningValueProgram>::new_predefined(
             PreDefinedProgram::EQtimesABminusC,
@@ -139,6 +142,7 @@ pub fn main() {
     );
     info!("Prover time {:?}", prover_time.elapsed());
     set_backend_cpu();
+    //experiment with fake sum or fake proof
     let verify_time = Instant::now();
     verify_proof(sumcheck, proof, claimed_sum);
     info!("verify time {:?}", verify_time.elapsed());

--- a/examples/rust/sumcheck/src/main.rs
+++ b/examples/rust/sumcheck/src/main.rs
@@ -1,51 +1,54 @@
-pub mod utils;
 pub mod transcript;
-
+pub mod utils;
 
 use icicle_bn254::curve::ScalarField as Fr;
 use icicle_bn254::sumcheck::SumcheckWrapper;
+use icicle_core::program::{PreDefinedProgram, ReturningValueProgram};
+use icicle_core::sumcheck::{Sumcheck, SumcheckConfig, SumcheckTranscriptConfig};
 use icicle_core::traits::FieldImpl;
 use icicle_hash::blake3::Blake3;
 use icicle_runtime::memory::HostSlice;
-use icicle_core::sumcheck::{Sumcheck,SumcheckConfig,SumcheckTranscriptConfig};
-use icicle_core::program::{PreDefinedProgram, ReturningValueProgram};
 use merlin::Transcript;
 
 use crate::transcript::*;
 use crate::utils::*;
+use clap::Parser;
 use log::info;
 use std::convert::TryInto;
 use std::time::Instant;
 
+const SAMPLES: usize = 1 << 22;
 
-const SAMPLES: usize = 1<<22;
-
-pub fn verify_proof(sumcheck:SumcheckWrapper,proof:icicle_bn254::sumcheck::SumcheckProof,claimed_sum:Fr ) {
-    let mut verifier_previous_transcript =  Transcript::new(b"my_sumcheck");
-    <Transcript as TranscriptProtocol::<Fr>>::append_data(&mut verifier_previous_transcript, b"public", &claimed_sum);
+pub fn verify_proof(sumcheck: SumcheckWrapper, proof: icicle_bn254::sumcheck::SumcheckProof, claimed_sum: Fr) {
+    let mut verifier_previous_transcript = Transcript::new(b"my_sumcheck");
+    <Transcript as TranscriptProtocol<Fr>>::append_data(&mut verifier_previous_transcript, b"public", &claimed_sum);
     //get seed based on previous state
-    let verifier_seed_rng = <Transcript as TranscriptProtocol::<Fr>>::challenge_scalar(&mut verifier_previous_transcript, b"seeded");
-    
+    let verifier_seed_rng =
+        <Transcript as TranscriptProtocol<Fr>>::challenge_scalar(&mut verifier_previous_transcript, b"seeded");
+
     //define verifier FS config
-    let leaf_size = (Fr::one()).to_bytes_le().len().try_into().unwrap();
+    let leaf_size = (Fr::one())
+        .to_bytes_le()
+        .len()
+        .try_into()
+        .unwrap();
     let hasher = Blake3::new(leaf_size).unwrap();
     let verifier_transcript_config = SumcheckTranscriptConfig::new(
-          &hasher, 
-          b"start_sumcheck".to_vec(), 
-          b"round_poly".to_vec(), 
-          b"round_challenge".to_vec(), 
-          true, 
-          verifier_seed_rng);
+        &hasher,
+        b"start_sumcheck".to_vec(),
+        b"round_poly".to_vec(),
+        b"round_challenge".to_vec(),
+        true,
+        verifier_seed_rng,
+    );
 
     let sumcheck = <icicle_bn254::sumcheck::SumcheckWrapper as Sumcheck>::new().unwrap();
     let proof_validty = sumcheck.verify(&proof, claimed_sum, &verifier_transcript_config);
 
-match proof_validty {
-        Ok(true) => eprintln!("Valid proof!"), // Verification succeeded
+    match proof_validty {
+        Ok(true) => println!("Valid proof!"), // Verification succeeded
         Ok(false) => {
-            eprintln!(
-                "Sumcheck proof not valid",
-            );
+            eprintln!("Sumcheck proof not valid",);
         }
         Err(err) => {
             eprintln!("Error in verification");
@@ -53,68 +56,91 @@ match proof_validty {
     }
 }
 
-//RUST_LOG=info cargo run --release cargo--package sumcheck --bin sumcheck
-pub fn main(){
-env_logger::init();
+//RUST_LOG=info cargo run --release --package sumcheck --bin sumcheck
+pub fn main() {
+    env_logger::init();
 
-try_load_and_set_backend_gpu();
-//simulate previous state
-let mut prover_previous_transcript = Transcript::new(b"my_sumcheck");
+    let args = Args::parse();
+    try_load_and_set_backend_device(&args);
+    //simulate previous state
+    let mut prover_previous_transcript = Transcript::new(b"my_sumcheck");
 
-let gen_data_time = Instant::now();
-let poly_a = generate_random_vector::<Fr>(SAMPLES);
-let poly_b = generate_random_vector::<Fr>(SAMPLES);
-let poly_c = generate_random_vector::<Fr>(SAMPLES);
-let poly_e = generate_random_vector::<Fr>(SAMPLES);
+    let gen_data_time = Instant::now();
+    let poly_a = generate_random_vector::<Fr>(SAMPLES);
+    let poly_b = generate_random_vector::<Fr>(SAMPLES);
+    let poly_c = generate_random_vector::<Fr>(SAMPLES);
+    let poly_e = generate_random_vector::<Fr>(SAMPLES);
 
-info!("Generate e,A,B,C of log size {:?}, time {:?}",SAMPLES.ilog2(),gen_data_time.elapsed());
-let compute_sum_time = Instant::now();
+    info!(
+        "Generate e,A,B,C of log size {:?}, time {:?}",
+        SAMPLES.ilog2(),
+        gen_data_time.elapsed()
+    );
+    let compute_sum_time = Instant::now();
     //compute claimed sum
-let temp:Vec<Fr> = poly_a
-    .iter()
-    .zip(poly_b.iter())
-    .zip(poly_c.iter())
-    .zip(poly_e.iter())
-    .map(|(((a, b), c), e)| *a * *b * *e - *c * *e)
-    .collect();  
-    let claimed_sum = temp.iter().fold(Fr::zero(), |acc, &a| acc + a);
-info!("Compute claimed sum time {:?}",compute_sum_time.elapsed());
+    let temp: Vec<Fr> = poly_a
+        .iter()
+        .zip(poly_b.iter())
+        .zip(poly_c.iter())
+        .zip(poly_e.iter())
+        .map(|(((a, b), c), e)| *a * *b * *e - *c * *e)
+        .collect();
+    let claimed_sum = temp
+        .iter()
+        .fold(Fr::zero(), |acc, &a| acc + a);
+    info!("Compute claimed sum time {:?}", compute_sum_time.elapsed());
 
     //add claimed sum to transcript to simulate previous state
-    <Transcript as TranscriptProtocol::<Fr>>::append_data(&mut prover_previous_transcript, b"public", &claimed_sum);
+    <Transcript as TranscriptProtocol<Fr>>::append_data(&mut prover_previous_transcript, b"public", &claimed_sum);
     //get seed based on previous state
-    let seed_rng = <Transcript as TranscriptProtocol::<Fr>>::challenge_scalar(&mut prover_previous_transcript, b"seeded");
+    let seed_rng = <Transcript as TranscriptProtocol<Fr>>::challenge_scalar(&mut prover_previous_transcript, b"seeded");
 
-    let leaf_size = (Fr::one()).to_bytes_le().len().try_into().unwrap();
+    let leaf_size = (Fr::one())
+        .to_bytes_le()
+        .len()
+        .try_into()
+        .unwrap();
     let hasher = Blake3::new(leaf_size).unwrap();
 
     //define sumcheck config
     let sumcheck_config = SumcheckConfig::default();
 
-    let mle_poly_hosts = vec![HostSlice::<Fr>::from_slice(&poly_a),
-    HostSlice::<Fr>::from_slice(&poly_b),HostSlice::<Fr>::from_slice(&poly_c),HostSlice::<Fr>::from_slice(&poly_e)];
+    let mle_poly_hosts = vec![
+        HostSlice::<Fr>::from_slice(&poly_a),
+        HostSlice::<Fr>::from_slice(&poly_b),
+        HostSlice::<Fr>::from_slice(&poly_c),
+        HostSlice::<Fr>::from_slice(&poly_e),
+    ];
     let sumcheck = <icicle_bn254::sumcheck::SumcheckWrapper as Sumcheck>::new().unwrap();
 
     let transcript_config = SumcheckTranscriptConfig::new(
-            &hasher, 
-            b"start_sumcheck".to_vec(), 
-            b"round_poly".to_vec(), 
-            b"round_challenge".to_vec(), 
-            true, 
-            seed_rng);
-    let combine_function = <icicle_bn254::program::FieldReturningValueProgram as ReturningValueProgram>::new_predefined(PreDefinedProgram::EQtimesABminusC).unwrap();
-let prover_time = Instant::now();
-let proof= sumcheck.prove(
-        &mle_poly_hosts, 
-        SAMPLES.try_into().unwrap(), 
-        claimed_sum, 
-        combine_function, 
-        &transcript_config, 
-        &sumcheck_config); 
-info!("Prover time {:?}", prover_time.elapsed());
-set_backend_cpu();
-let verify_time = Instant::now();
-verify_proof(sumcheck,proof, claimed_sum);
-info!("verify time {:?}", verify_time.elapsed());
-info!("total time {:?}", gen_data_time.elapsed());
+        &hasher,
+        b"start_sumcheck".to_vec(),
+        b"round_poly".to_vec(),
+        b"round_challenge".to_vec(),
+        true,
+        seed_rng,
+    );
+    let combine_function =
+        <icicle_bn254::program::FieldReturningValueProgram as ReturningValueProgram>::new_predefined(
+            PreDefinedProgram::EQtimesABminusC,
+        )
+        .unwrap();
+    let prover_time = Instant::now();
+    let proof = sumcheck.prove(
+        &mle_poly_hosts,
+        SAMPLES
+            .try_into()
+            .unwrap(),
+        claimed_sum,
+        combine_function,
+        &transcript_config,
+        &sumcheck_config,
+    );
+    info!("Prover time {:?}", prover_time.elapsed());
+    set_backend_cpu();
+    let verify_time = Instant::now();
+    verify_proof(sumcheck, proof, claimed_sum);
+    info!("verify time {:?}", verify_time.elapsed());
+    info!("total time {:?}", gen_data_time.elapsed());
 }

--- a/examples/rust/sumcheck/src/transcript.rs
+++ b/examples/rust/sumcheck/src/transcript.rs
@@ -1,0 +1,21 @@
+use merlin::Transcript;
+use icicle_core::traits::FieldImpl;
+
+pub trait TranscriptProtocol<F:FieldImpl> {
+       fn challenge_scalar(&mut self, label: &'static [u8]) -> F;
+        /// Append a `scalar` with the given `label`.
+    fn append_data(&mut self, label: &'static [u8], scalar: &F);
+ 
+}
+
+
+impl<F: FieldImpl> TranscriptProtocol<F> for Transcript {
+    fn challenge_scalar(&mut self, label: &'static [u8]) -> F {
+        let mut buf = [0u8; 64];
+        self.challenge_bytes(label, &mut buf);
+        F::from_bytes_le(&buf)
+    }
+    fn append_data(&mut self, label: &'static [u8], scalar: &F) {
+        self.append_message(label, &scalar.to_bytes_le());
+    }
+}

--- a/examples/rust/sumcheck/src/transcript.rs
+++ b/examples/rust/sumcheck/src/transcript.rs
@@ -1,13 +1,11 @@
-use merlin::Transcript;
 use icicle_core::traits::FieldImpl;
+use merlin::Transcript;
 
-pub trait TranscriptProtocol<F:FieldImpl> {
-       fn challenge_scalar(&mut self, label: &'static [u8]) -> F;
-        /// Append a `scalar` with the given `label`.
+pub trait TranscriptProtocol<F: FieldImpl> {
+    fn challenge_scalar(&mut self, label: &'static [u8]) -> F;
+    /// Append a `scalar` with the given `label`.
     fn append_data(&mut self, label: &'static [u8], scalar: &F);
- 
 }
-
 
 impl<F: FieldImpl> TranscriptProtocol<F> for Transcript {
     fn challenge_scalar(&mut self, label: &'static [u8]) -> F {

--- a/examples/rust/sumcheck/src/utils.rs
+++ b/examples/rust/sumcheck/src/utils.rs
@@ -1,0 +1,25 @@
+use icicle_runtime::{Device,runtime};
+use icicle_core::traits::{FieldImpl,GenerateRandom};
+
+pub fn set_backend_cpu() {
+    let device_cpu = Device::new("CPU", 0);
+    icicle_runtime::set_device(&device_cpu).unwrap();
+}
+
+
+pub fn try_load_and_set_backend_gpu() {
+    runtime::load_backend("../../../icicle/backend/cuda").unwrap();
+    let device_gpu = Device::new("CUDA", 0);
+    let is_cuda_device_available = icicle_runtime::is_device_available(&device_gpu);
+    if is_cuda_device_available {
+        icicle_runtime::set_device(&device_gpu).unwrap();
+    } else {
+        set_backend_cpu();
+}
+}
+pub fn generate_random_vector<F:FieldImpl> (size:usize) -> Vec<F> 
+    where 
+    <F as FieldImpl>::Config: GenerateRandom<F>,
+    {
+    F::Config::generate_random(size)
+    }

--- a/examples/rust/sumcheck/src/utils.rs
+++ b/examples/rust/sumcheck/src/utils.rs
@@ -1,25 +1,32 @@
-use icicle_runtime::{Device,runtime};
-use icicle_core::traits::{FieldImpl,GenerateRandom};
+use clap::Parser;
+use icicle_core::traits::{FieldImpl, GenerateRandom};
+use icicle_runtime::{runtime, Device};
 
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Device type (e.g., "CPU", "CUDA")
+    #[arg(short, long, default_value = "CPU")]
+    device_type: String,
+}
+
+// Load backend and set device
+pub fn try_load_and_set_backend_device(args: &Args) {
+    if args.device_type != "CPU" {
+        icicle_runtime::runtime::load_backend_from_env_or_default().unwrap();
+    }
+    println!("Setting device {}", args.device_type);
+    let device = icicle_runtime::Device::new(&args.device_type, 0 /* =device_id*/);
+    icicle_runtime::set_device(&device).unwrap();
+}
+//we want verifier to run in CPU
 pub fn set_backend_cpu() {
     let device_cpu = Device::new("CPU", 0);
     icicle_runtime::set_device(&device_cpu).unwrap();
 }
 
-
-pub fn try_load_and_set_backend_gpu() {
-    runtime::load_backend("../../../icicle/backend/cuda").unwrap();
-    let device_gpu = Device::new("CUDA", 0);
-    let is_cuda_device_available = icicle_runtime::is_device_available(&device_gpu);
-    if is_cuda_device_available {
-        icicle_runtime::set_device(&device_gpu).unwrap();
-    } else {
-        set_backend_cpu();
-}
-}
-pub fn generate_random_vector<F:FieldImpl> (size:usize) -> Vec<F> 
-    where 
+pub fn generate_random_vector<F: FieldImpl>(size: usize) -> Vec<F>
+where
     <F as FieldImpl>::Config: GenerateRandom<F>,
-    {
+{
     F::Config::generate_random(size)
-    }
+}


### PR DESCRIPTION
## Describe the changes

# Sumcheck example

This example, instantiates a R1CS sumcheck instance with the parameters 
* `Sample size = 1<<22` field: BN254 scalar.
* Sumcheck IOP is part of a more general protocol, we use merlin to "simulate" a previous state of the transcript, and generate a seed randomness based on the previous state.
* The verifier also simulates the previous state of the transcript using Merlin to generate an identical seed randomness.
* In this example, we configured the Fiat Shamir protocol to run with the blake3 hash. Experiment with different hashes such as Keccak, blake2s , Poseidon etc. 
* Experiment with different sizes, fields, etc.
* The code runs in both CPU/GPU in a device agnostic manner. It assumes that the cuda backend is installed in the `icicle/backend/cuda/` folder, defaults to CPU in the absence of a device backend.
* Run the example with `RUST_LOG=info cargo run --release cargo--package sumcheck --bin sumcheck`

Sample outputs: M1 mac
```rust
[2025-02-17T20:57:25Z INFO  sumcheck] Generate e,A,B,C of log size 22, time 954.447375ms
[2025-02-17T20:57:26Z INFO  sumcheck] Compute claimed sum time 439.200917ms
[2025-02-17T20:57:28Z INFO  sumcheck] Prover time 2.383280625s
Valid proof!
[2025-02-17T20:57:28Z INFO  sumcheck] verify time 201.666µs
[2025-02-17T20:57:28Z INFO  sumcheck] total time 3.777288875s
```

Sample outputs: Ubuntu Desktop 22.04 128GB RAM	GPU: RTX 4080
```rust
[WARNING] Defaulting to Ingonyama icicle-cuda-license-server at `5053@license.icicle.ingonyama.com`. For more information about icicle-cuda-license, please contact support@ingonyama.com.
[2025-02-17T21:10:33Z INFO  sumcheck] Generate e,A,B,C of log size 22, time 890.615763ms
[2025-02-17T21:10:33Z INFO  sumcheck] Compute claimed sum time 374.166708ms
[2025-02-17T21:10:34Z INFO  sumcheck] Prover time 224.319171ms
Valid proof!
[2025-02-17T21:10:34Z INFO  sumcheck] verify time 183.244µs
[2025-02-17T21:10:34Z INFO  sumcheck] total time 1.489436224s
```
## Linked Issues

Resolves #

## (optional) CUDA backend branch
uses cuda backend release 3.5.0
