### PR TITLE
Handle rou errors on the Rust side

### DIFF
--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -341,7 +341,7 @@ macro_rules! impl_ntt {
                 fn get_root_of_unity(max_size: u64) -> $field {
                     let mut rou = std::mem::MaybeUninit::<$field>::uninit(); // Prepare uninitialized memory for rou
                     unsafe {
-                        get_root_of_unity(max_size, rou.as_mut_ptr());
+                        get_root_of_unity(max_size, rou.as_mut_ptr()).wrap().unwrap();
                         return rou.assume_init();
                     }
                 }


### PR DESCRIPTION
## Describe the changes

This PR adds a check to the get_root_of_unity function to ensure that rou is correctly determined on the backend.
