### PR TITLE
Make sumcheck tests able to run without cuda backend

### DIFF
--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -246,7 +246,7 @@ TEST_F(FieldTestBase, SumcheckDataOnDevice)
     data_main[idx] = tmp;
   }
   std::ostringstream oss;
-  oss << "CUDA" << " " << "Sumcheck";
+  oss << IcicleTestBase::main_device() << " " << "Sumcheck";
 
   SumcheckProof<scalar_t> sumcheck_proof;
 


### PR DESCRIPTION
Add ifdef to cuda specific sumcheck test

