### PR TITLE
Fix/pow misaligned

### DIFF
--- a/icicle/backend/cpu/src/hash/cpu_pow.cpp
+++ b/icicle/backend/cpu/src/hash/cpu_pow.cpp
@@ -33,8 +33,8 @@ namespace icicle {
     update_chunks(uint8_t* challenge, uint64_t num_chunks, uint64_t offset, uint32_t challenge_size, uint32_t full_size)
     {
       for (uint64_t idx = 0; idx < num_chunks; ++idx) {
-        uint64_t* nonce_ptr = (uint64_t*)(challenge + idx * full_size + challenge_size);
-        *nonce_ptr = offset + idx;
+        uint64_t res = idx + offset;
+        memcpy(challenge + idx * full_size + challenge_size, &res, sizeof(uint64_t));
       }
     }
 

--- a/wrappers/rust/icicle-hash/src/tests.rs
+++ b/wrappers/rust/icicle-hash/src/tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::{
         blake2s::Blake2s,
         blake3::Blake3,
-        keccak::Keccak256,
+        keccak::{Keccak256, Keccak512},
         pow::{pow_solver, pow_verify, PowConfig},
         sha3::Sha3_256,
     };

--- a/wrappers/rust/icicle-hash/src/tests.rs
+++ b/wrappers/rust/icicle-hash/src/tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::{
         blake2s::Blake2s,
         blake3::Blake3,
-        keccak::{Keccak256, Keccak512},
+        keccak::Keccak256,
         pow::{pow_solver, pow_verify, PowConfig},
         sha3::Sha3_256,
     };
@@ -358,6 +358,86 @@ mod tests {
         );
         assert_eq!(err, eIcicleError::Success);
         assert_eq!(cpu_mined_hash, golden_hash);
+        assert!(cpu_is_correct);
+    }
+    #[test]
+    fn keccak_pow() {
+        initialize();
+        test_utilities::test_set_main_device();
+        const BITS: u8 = 25;
+        let input: [u8; 21] = [20; 21];
+
+        let input_host = HostSlice::from_slice(&input);
+        let mut cfg = PowConfig::default();
+        cfg.padding_size = 3;
+
+        let mut gpu_found = false;
+        let mut gpu_nonce = 0;
+        let mut gpu_mined_hash = 0;
+
+        let hasher = Keccak256::new(0).unwrap();
+
+        let err = pow_solver(
+            &hasher,
+            input_host,
+            BITS,
+            &cfg,
+            &mut gpu_found,
+            &mut gpu_nonce,
+            &mut gpu_mined_hash,
+        );
+        assert_eq!(err, eIcicleError::Success);
+        assert!(gpu_found);
+
+        let mut gpu_is_correct = false;
+        let mut gpu_mined_hash_check = 0;
+
+        let err = pow_verify(
+            &hasher,
+            input_host,
+            BITS,
+            &cfg,
+            gpu_nonce,
+            &mut gpu_is_correct,
+            &mut gpu_mined_hash_check,
+        );
+        assert_eq!(err, eIcicleError::Success);
+        assert_eq!(gpu_mined_hash_check, gpu_mined_hash);
+        assert!(gpu_is_correct);
+
+        test_utilities::test_set_ref_device();
+        let mut cpu_found = false;
+        let mut cpu_nonce = 0;
+        let mut cpu_mined_hash = 0;
+        let hasher = Keccak256::new(0).unwrap();
+        let err = pow_solver(
+            &hasher,
+            input_host,
+            BITS,
+            &cfg,
+            &mut cpu_found,
+            &mut cpu_nonce,
+            &mut cpu_mined_hash,
+        );
+        assert_eq!(err, eIcicleError::Success);
+        assert!(cpu_found);
+        assert_eq!(cpu_nonce, gpu_nonce);
+        assert_eq!(cpu_mined_hash, gpu_mined_hash);
+
+        let mut cpu_is_correct = false;
+        let mut cpu_mined_hash_check = 0;
+
+        let err = pow_verify(
+            &hasher,
+            input_host,
+            BITS,
+            &cfg,
+            cpu_nonce,
+            &mut cpu_is_correct,
+            &mut cpu_mined_hash_check,
+        );
+        assert_eq!(err, eIcicleError::Success);
+        assert_eq!(cpu_mined_hash, cpu_mined_hash_check);
         assert!(cpu_is_correct);
     }
 }


### PR DESCRIPTION
This PR fixes the misaligned address error that occurs when using a custom challenge_size and padding_size.

cuda-backend-branch: fix/pow-misaligned 
