### PR TITLE
Feat/func univariatepolytrait

### DIFF
--- a/examples/rust/polynomials/src/main.rs
+++ b/examples/rust/polynomials/src/main.rs
@@ -65,6 +65,15 @@ where
     };
     p
 }
+//use UnivariatePolynomial trait to perform polynomial operations on arbitrary fields
+//fold_poly takes a polynomial and a scalar as input and returns a polynomial
+fn fold_poly<P: UnivariatePolynomial>(poly: P, beta: P::Field) -> P {
+    let o = poly.odd(); // Get the odd terms (in coeff form)
+    let e = poly.even(); // Get the even terms (in coeff form)
+                         // Perform the fold operation: e + (o * beta)
+    let o_beta = o.mul_by_scalar(&beta); // o * beta (polynomial * scalar)
+    e.add(&o_beta) // e + (o * beta) (addition of polynomials)
+}
 
 fn main() {
     let args = Args::parse();
@@ -118,7 +127,10 @@ fn main() {
     let fold = &e + &(&o * &q_at_five); // e(x) + o(x) * scalar
 
     let _coeff = fold.get_coeff(2); // Coeff of x^2
-
+                                    //using univariate poly trait, it inherits all methods from densepolynomial for specific fields
+    println!("Performing folding operation on h using Univariatepoly trait");
+    let fold_univariate = fold_poly(h, q_at_five);
+    assert_eq!(fold.eval(&five), fold_univariate.eval(&five));
     println!(
         "Polynomial computation on selected device took: {} ms",
         start

--- a/wrappers/rust/icicle-core/src/polynomials/mod.rs
+++ b/wrappers/rust/icicle-core/src/polynomials/mod.rs
@@ -1,7 +1,7 @@
 use crate::traits::{FieldConfig, FieldImpl};
 use icicle_runtime::memory::HostOrDeviceSlice;
 
-pub trait UnivariatePolynomial
+pub trait UnivariatePolynomial: Clone + Sized
 where
     Self::Field: FieldImpl,
     Self::FieldConfig: FieldConfig,
@@ -31,6 +31,13 @@ where
     fn get_nof_coeffs(&self) -> u64;
     fn get_coeff(&self, idx: u64) -> Self::Field;
     fn copy_coeffs<S: HostOrDeviceSlice<Self::Field> + ?Sized>(&self, start_idx: u64, coeffs: &mut S);
+    fn add(&self, rhs: &Self) -> Self;
+    fn add_assign(&mut self, rhs: &Self);
+    fn sub(&self, rhs: &Self) -> Self;
+    fn mul(&self, rhs: &Self) -> Self;
+    fn mul_by_scalar(&self, rhs: &Self::Field) -> Self;
+    fn div(&self, rhs: &Self) -> Self;
+    fn rem(&self, rhs: &Self) -> Self;
 }
 
 #[macro_export]
@@ -291,6 +298,59 @@ macro_rules! impl_univariate_polynomial_api {
 
             fn degree(&self) -> i64 {
                 unsafe { degree(self.handle) }
+            }
+
+            fn add(&self, rhs: &Self) -> Self {
+                unsafe {
+                    Self {
+                        handle: add(self.handle, rhs.handle),
+                    }
+                }
+            }
+
+            fn add_assign(&mut self, rhs: &Self) {
+                unsafe { add_inplace(self.handle, rhs.handle) };
+            }
+
+            fn sub(&self, rhs: &Self) -> Self {
+                unsafe {
+                    Self {
+                        handle: subtract(self.handle, rhs.handle),
+                    }
+                }
+            }
+
+            fn mul(&self, rhs: &Self) -> Self {
+                unsafe {
+                    Self {
+                        handle: multiply(self.handle, rhs.handle),
+                    }
+                }
+            }
+
+            //poly * scalar
+            fn mul_by_scalar(&self, rhs: &Self::Field) -> Self {
+                unsafe {
+                    Self {
+                        handle: multiply_by_scalar(self.handle, rhs),
+                    }
+                }
+            }
+
+            fn div(&self, rhs: &Self) -> Self {
+                unsafe {
+                    Self {
+                        handle: quotient(self.handle, rhs.handle),
+                    }
+                }
+            }
+
+            fn rem(&self, rhs: &Self) -> Self {
+                unsafe {
+                    Self {
+                        handle: remainder(self.handle, rhs.handle),
+                    }
+                }
             }
         }
 

--- a/wrappers/rust/icicle-core/src/polynomials/mod.rs
+++ b/wrappers/rust/icicle-core/src/polynomials/mod.rs
@@ -36,8 +36,6 @@ where
     fn sub(&self, rhs: &Self) -> Self;
     fn mul(&self, rhs: &Self) -> Self;
     fn mul_by_scalar(&self, rhs: &Self::Field) -> Self;
-    fn div(&self, rhs: &Self) -> Self;
-    fn rem(&self, rhs: &Self) -> Self;
 }
 
 #[macro_export]
@@ -333,22 +331,6 @@ macro_rules! impl_univariate_polynomial_api {
                 unsafe {
                     Self {
                         handle: multiply_by_scalar(self.handle, rhs),
-                    }
-                }
-            }
-
-            fn div(&self, rhs: &Self) -> Self {
-                unsafe {
-                    Self {
-                        handle: quotient(self.handle, rhs.handle),
-                    }
-                }
-            }
-
-            fn rem(&self, rhs: &Self) -> Self {
-                unsafe {
-                    Self {
-                        handle: remainder(self.handle, rhs.handle),
                     }
                 }
             }


### PR DESCRIPTION
## Describe the changes

This PR adds the following missing functions in the univariate polynomial trait. 

```rust
    fn add(&self, rhs: &Self) -> Self;
    fn add_assign(&mut self, rhs: &Self);
    fn sub(&self, rhs: &Self) -> Self;
    fn mul(&self, rhs: &Self) -> Self;
    fn mul_by_scalar(&self, rhs: &Self::Field) -> Self;
```

Added an example for folding polynomial in examples/rust/polynomials
```rust
fn fold_poly<P: UnivariatePolynomial>(poly: P, beta: P::Field) -> P {
    let o = poly.odd(); // Get the odd terms (in coeff form)
    let e = poly.even(); // Get the even terms (in coeff form)
                         // Perform the fold operation: e + (o * beta)
    let o_beta = o.mul_by_scalar(&beta); // o * beta (polynomial * scalar)
    e.add(&o_beta) // e + (o * beta) (addition of polynomials)
}
```

## Linked Issues

Resolves #

## (optional) CUDA backend branch
# cuda-backend-branch: main # specify the branch here
