### PR TITLE
Grammar and Clarity Improvements in Documentation

### DIFF
--- a/docs/docs/contributor-guide.md
+++ b/docs/docs/contributor-guide.md
@@ -1,6 +1,6 @@
 # Contributor's Guide
 
-We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build a ecosystem.
+We welcome all contributions with open arms. At Ingonyama we take a village approach, believing it takes many hands and minds to build an ecosystem.
 
 ## Contributing to ICICLE
 
@@ -16,7 +16,7 @@ When opening a [pull request](https://github.com/ingonyama-zk/icicle/pulls) plea
 - `Clear Purpose` - The pull request should solve a single issue and be clean of any unrelated changes.
 - `Clear description` - If the pull request is for a new feature describe what you built, why you added it and how its best that we test it. For bug fixes please describe the issue and the solution.
 - `Consistent style` - Rust and Golang code should be linted by the official linters (golang fmt and rust fmt) and maintain a proper style. For CUDA and C++ code we use [`clang-format`](https://github.com/ingonyama-zk/icicle/blob/main/.clang-format), [here](https://github.com/ingonyama-zk/icicle/blob/605c25f9d22135c54ac49683b710fe2ce06e2300/.github/workflows/main-format.yml#L46) you can see how we run it.
-- `Minimal Tests` - please add test which cover basic usage of your changes .
+- `Minimal Tests` - please add tests which cover basic usage of your changes .
 
 ## Questions?
 

--- a/docs/versioned_docs/version-1.10.1/icicle/golang-bindings/multi-gpu.md
+++ b/docs/versioned_docs/version-1.10.1/icicle/golang-bindings/multi-gpu.md
@@ -70,7 +70,7 @@ Runs a given function on a specific GPU device, ensuring that all CUDA calls wit
 
 In Go, most concurrency can be done via Goroutines. However, there is no guarantee that a goroutine stays on a specific host thread. 
 
-`RunOnDevice` was designed to solve this caveat and insure that the goroutine will stay on a specific host thread.
+`RunOnDevice` was designed to solve this caveat and ensure that the goroutine will stay on a specific host thread.
 
 `RunOnDevice` will lock a goroutine into a specific host thread, sets a current GPU device, runs a provided function, and unlocks the goroutine from the host thread after the provided function finishes.
 

--- a/docs/versioned_docs/version-1.10.1/icicle/primitives/ntt.md
+++ b/docs/versioned_docs/version-1.10.1/icicle/primitives/ntt.md
@@ -63,7 +63,7 @@ NTT also supports two different modes `Batch NTT` and `Single NTT`
 
 Batch NTT allows you to run many NTTs with a single API call, Single MSM will launch a single MSM computation.
 
-Deciding weather to use `batch NTT` vs `single NTT` is highly dependent on your application and use case.
+Deciding whether to use `batch NTT` vs `single NTT` is highly dependent on your application and use case.
 
 **Single NTT Mode**
 


### PR DESCRIPTION
In the contributor-guide.md file:

Old: "a ecosystem"
New: "an ecosystem"
Reason: "Ecosystem" starts with a vowel sound, so "an" should be used instead of "a."
In the multi-gpu.md file:

Old: "insure"
New: "ensure"
Reason: "Insure" is related to insurance, whereas "ensure" means to guarantee something, which is the correct term here.
In the ntt.md file:

Old: "weather"
New: "whether"
Reason: "Weather" refers to atmospheric conditions, while "whether" is used to express a choice or condition, which is the correct word in this context.
In the contributor-guide.md file:

Old: "Minimal Tests - please add test which cover basic usage of your changes ."
New: "Minimal Tests - please add tests which cover basic usage of your changes ."
Reason: The plural "tests" is needed here because multiple tests are expected to be added, not just one.
