### PR TITLE
fix sumcheck transcript-config copy rather than move

### DIFF
--- a/icicle/backend/cpu/include/cpu_sumcheck.h
+++ b/icicle/backend/cpu/include/cpu_sumcheck.h
@@ -22,7 +22,7 @@ namespace icicle {
       const uint64_t mle_polynomial_size,
       const F& claimed_sum,
       const CombineFunction<F>& combine_function,
-      const SumcheckTranscriptConfig<F>&& transcript_config,
+      SumcheckTranscriptConfig<F>&& transcript_config,
       const SumcheckConfig& sumcheck_config,
       SumcheckProof<F>& sumcheck_proof /*out*/) override
     {

--- a/icicle/include/icicle/backend/sumcheck_backend.h
+++ b/icicle/include/icicle/backend/sumcheck_backend.h
@@ -49,7 +49,7 @@ namespace icicle {
       const uint64_t mle_polynomial_size,
       const F& claimed_sum,
       const CombineFunction<F>& combine_function,
-      const SumcheckTranscriptConfig<F>&& transcript_config,
+      SumcheckTranscriptConfig<F>&& transcript_config,
       const SumcheckConfig& sumcheck_config,
       SumcheckProof<F>& sumcheck_proof /*out*/) = 0;
   };

--- a/icicle/include/icicle/sumcheck/sumcheck.h
+++ b/icicle/include/icicle/sumcheck/sumcheck.h
@@ -57,7 +57,7 @@ namespace icicle {
       const uint64_t mle_polynomial_size,
       const F& claimed_sum,
       const CombineFunction<F>& combine_function,
-      const SumcheckTranscriptConfig<F>&& transcript_config,
+      SumcheckTranscriptConfig<F>&& transcript_config,
       const SumcheckConfig& sumcheck_config,
       SumcheckProof<F>& sumcheck_proof /*out*/) const
     {
@@ -77,7 +77,7 @@ namespace icicle {
     eIcicleError verify(
       const SumcheckProof<F>& sumcheck_proof,
       const F& claimed_sum,
-      const SumcheckTranscriptConfig<F>&& transcript_config,
+      SumcheckTranscriptConfig<F>&& transcript_config,
       bool& valid /*out*/)
     {
       valid = false;

--- a/icicle/include/icicle/sumcheck/sumcheck_transcript.h
+++ b/icicle/include/icicle/sumcheck/sumcheck_transcript.h
@@ -10,7 +10,7 @@ public:
     const S& claimed_sum,
     const uint32_t mle_polynomial_size,
     const uint32_t combine_function_poly_degree,
-    const SumcheckTranscriptConfig<S>&& transcript_config)
+    SumcheckTranscriptConfig<S>&& transcript_config)
       : m_claimed_sum(claimed_sum), m_mle_polynomial_size(mle_polynomial_size),
         m_combine_function_poly_degree(combine_function_poly_degree), m_transcript_config(std::move(transcript_config))
   {
@@ -40,7 +40,7 @@ public:
   }
 
 private:
-  const SumcheckTranscriptConfig<S>&& m_transcript_config; // configuration how to build the transcript
+  const SumcheckTranscriptConfig<S> m_transcript_config; // configuration how to build the transcript
   HashConfig m_config;                                     // hash config - default
   uint32_t m_round_idx;                                    //
   std::vector<std::byte> m_entry_0;                        //

--- a/icicle/include/icicle/sumcheck/sumcheck_transcript.h
+++ b/icicle/include/icicle/sumcheck/sumcheck_transcript.h
@@ -41,9 +41,9 @@ public:
 
 private:
   const SumcheckTranscriptConfig<S> m_transcript_config; // configuration how to build the transcript
-  HashConfig m_config;                                     // hash config - default
-  uint32_t m_round_idx;                                    //
-  std::vector<std::byte> m_entry_0;                        //
+  HashConfig m_config;                                   // hash config - default
+  uint32_t m_round_idx;                                  //
+  std::vector<std::byte> m_entry_0;                      //
   uint32_t m_mle_polynomial_size = 0;
   uint32_t m_combine_function_poly_degree = 0;
   const S m_claimed_sum;

--- a/icicle/include/icicle/sumcheck/sumcheck_transcript_config.h
+++ b/icicle/include/icicle/sumcheck/sumcheck_transcript_config.h
@@ -98,12 +98,12 @@ namespace icicle {
     const F& get_seed_rng() const { return m_seed_rng; }
 
   private:
-    Hash m_hasher;                                         ///< Hash function used for randomness generation.
-    const std::vector<std::byte> m_domain_separator_label; ///< Label for the domain separator in the transcript.
-    const std::vector<std::byte> m_round_poly_label;       ///< Label for round polynomials in the transcript.
-    const std::vector<std::byte> m_round_challenge_label;  ///< Label for round challenges in the transcript.
-    const bool m_little_endian = true;                     ///< Encoding endianness (default: little-endian).
-    F m_seed_rng;                                          ///< Seed for initializing the RNG.
+    Hash m_hasher;                                   ///< Hash function used for randomness generation.
+    std::vector<std::byte> m_domain_separator_label; ///< Label for the domain separator in the transcript.
+    std::vector<std::byte> m_round_poly_label;       ///< Label for round polynomials in the transcript.
+    std::vector<std::byte> m_round_challenge_label;  ///< Label for round challenges in the transcript.
+    const bool m_little_endian = true;               ///< Encoding endianness (default: little-endian).
+    F m_seed_rng;                                    ///< Seed for initializing the RNG.
 
     static inline std::vector<std::byte> cstr_to_bytes(const char* str)
     {

--- a/icicle/include/icicle/sumcheck/sumcheck_transcript_config.h
+++ b/icicle/include/icicle/sumcheck/sumcheck_transcript_config.h
@@ -82,7 +82,7 @@ namespace icicle {
 
     // Move Constructor
     SumcheckTranscriptConfig(SumcheckTranscriptConfig&& other) noexcept
-        : m_hasher(other.m_hasher), m_domain_separator_label(std::move(other.m_domain_separator_label)),
+        : m_hasher(std::move(other.m_hasher)), m_domain_separator_label(std::move(other.m_domain_separator_label)),
           m_round_poly_label(std::move(other.m_round_poly_label)),
           m_round_challenge_label(std::move(other.m_round_challenge_label)), m_little_endian(other.m_little_endian),
           m_seed_rng(other.m_seed_rng)

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -262,7 +262,8 @@ TEST_F(FieldTestBase, SumcheckDataOnDevice)
   // create sumcheck
   auto verifier_sumcheck = create_sumcheck<scalar_t>();
   bool verification_pass = false;
-  ICICLE_CHECK(verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
+  ICICLE_CHECK(
+    verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
 
   ASSERT_EQ(true, verification_pass);
 

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -184,11 +184,12 @@ TEST_F(FieldTestBase, Sumcheck)
     END_TIMER(sumcheck, oss.str().c_str(), true);
 
     // ===== Verifier side ======
+    SumcheckTranscriptConfig<scalar_t> verifier_transcript_config; // default configuration
     // create sumcheck
     auto verifier_sumcheck = create_sumcheck<scalar_t>();
     bool verification_pass = false;
     ICICLE_CHECK(
-      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(transcript_config), verification_pass));
+      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
 
     ASSERT_EQ(true, verification_pass);
   };
@@ -257,10 +258,11 @@ TEST_F(FieldTestBase, SumcheckDataOnDevice)
   END_TIMER(sumcheck, oss.str().c_str(), true);
 
   // ===== Verifier side ======
+  SumcheckTranscriptConfig<scalar_t> verifier_transcript_config; // default configuration
   // create sumcheck
   auto verifier_sumcheck = create_sumcheck<scalar_t>();
   bool verification_pass = false;
-  ICICLE_CHECK(verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(transcript_config), verification_pass));
+  ICICLE_CHECK(verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
 
   ASSERT_EQ(true, verification_pass);
 
@@ -327,11 +329,12 @@ TEST_F(FieldTestBase, SumcheckUserDefinedCombine)
     END_TIMER(sumcheck, oss.str().c_str(), true);
 
     // ===== Verifier side ======
+    SumcheckTranscriptConfig<scalar_t> verifier_transcript_config; // default configuration
     // create sumcheck
     auto verifier_sumcheck = create_sumcheck<scalar_t>();
     bool verification_pass = false;
     ICICLE_CHECK(
-      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(transcript_config), verification_pass));
+      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
 
     ASSERT_EQ(true, verification_pass);
   };
@@ -492,11 +495,12 @@ TEST_F(FieldTestBase, SumcheckIdentity)
     END_TIMER(sumcheck, oss.str().c_str(), true);
 
     // ===== Verifier side ======
+    SumcheckTranscriptConfig<scalar_t> verifier_transcript_config; // default configuration
     // create sumcheck
     auto verifier_sumcheck = create_sumcheck<scalar_t>();
     bool verification_pass = false;
     ICICLE_CHECK(
-      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(transcript_config), verification_pass));
+      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
 
     ASSERT_EQ(true, verification_pass);
   };
@@ -557,11 +561,12 @@ TEST_F(FieldTestBase, SumcheckSingleInputProgram)
     END_TIMER(sumcheck, oss.str().c_str(), true);
 
     // ===== Verifier side ======
+    SumcheckTranscriptConfig<scalar_t> verifier_transcript_config; // default configuration
     // create sumcheck
     auto verifier_sumcheck = create_sumcheck<scalar_t>();
     bool verification_pass = false;
     ICICLE_CHECK(
-      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(transcript_config), verification_pass));
+      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
 
     ASSERT_EQ(true, verification_pass);
   };

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -135,6 +135,7 @@ TEST_F(FieldTestBase, polynomialDivision)
 }
 
 #ifdef SUMCHECK
+  #include "icicle/hash/keccak.h"
 TEST_F(FieldTestBase, Sumcheck)
 {
   int log_mle_poly_size = 13;
@@ -165,7 +166,8 @@ TEST_F(FieldTestBase, Sumcheck)
     icicle_set_device(dev);
 
     // create transcript_config
-    SumcheckTranscriptConfig<scalar_t> transcript_config; // default configuration
+    SumcheckTranscriptConfig<scalar_t> transcript_config(
+      create_keccak_256_hash(), "labelA", "labelB", "LabelC", scalar_t::from(12));
 
     std::ostringstream oss;
     oss << dev_type << " " << msg;
@@ -183,8 +185,11 @@ TEST_F(FieldTestBase, Sumcheck)
       sumcheck_proof));
     END_TIMER(sumcheck, oss.str().c_str(), true);
 
+    ASSERT_EQ(transcript_config.get_domain_separator_label().size(), 0); // assert data was moved and not copied
+
     // ===== Verifier side ======
-    SumcheckTranscriptConfig<scalar_t> verifier_transcript_config; // default configuration
+    SumcheckTranscriptConfig<scalar_t> verifier_transcript_config(
+      create_keccak_256_hash(), "labelA", "labelB", "LabelC", scalar_t::from(12));
     // create sumcheck
     auto verifier_sumcheck = create_sumcheck<scalar_t>();
     bool verification_pass = false;

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -165,13 +165,18 @@ TEST_F(FieldTestBase, Sumcheck)
     Device dev = {dev_type, 0};
     icicle_set_device(dev);
 
+    // ===== Prover side ======
+
     // create transcript_config
     SumcheckTranscriptConfig<scalar_t> transcript_config(
       create_keccak_256_hash(), "labelA", "labelB", "LabelC", scalar_t::from(12));
 
+    ASSERT_NE(transcript_config.get_domain_separator_label().size(),
+              0); // assert label exists
+
     std::ostringstream oss;
     oss << dev_type << " " << msg;
-    // ===== Prover side ======
+
     // create sumcheck
     auto prover_sumcheck = create_sumcheck<scalar_t>();
 
@@ -188,6 +193,9 @@ TEST_F(FieldTestBase, Sumcheck)
     ASSERT_EQ(transcript_config.get_domain_separator_label().size(), 0); // assert data was moved and not copied
 
     // ===== Verifier side ======
+    // Note that the verifier is another machine and needs to regenerate the same transcript config.
+    // Also note that even if the same process, the transcript-config is moved since it may be large, so cannot reuse
+    // twice.
     SumcheckTranscriptConfig<scalar_t> verifier_transcript_config(
       create_keccak_256_hash(), "labelA", "labelB", "LabelC", scalar_t::from(12));
     // create sumcheck


### PR DESCRIPTION
This PR addresses a critical issue in the SumcheckTranscript API where move semantics are improperly implemented due to the use of const rvalue references. This misuse leads to unintended copying of objects instead of moving them, which contradicts the original design intentions and can lead to performance degradation, especially since some of the data structures involved (like labels and public data) are potentially large.

Issues Addressed:

1. Const Rvalue Reference Misuse: The API currently accepts and stores configurations as const rvalue references (`const SumcheckTranscriptConfig<S>&&`). This approach mistakenly assumes that objects can be moved efficiently, but due to their constness, they are actually copied. This undermines the efficiency of move semantics.
2. Faulty Move Operations in Tests: The associated tests incorrectly move an object twice. This behavior, under normal circumstances, should lead to undefined behavior but appears to work correctly due to the accidental copying. This masks potential bugs and can lead to false positives during testing.

cuda-backend-branch: yshekel/fix_sumcheck_transcript