### PR TITLE
chore: remove redundant import of `factorint`

### DIFF
--- a/scripts/python/integer_ring.py
+++ b/scripts/python/integer_ring.py
@@ -4,8 +4,6 @@ import math
 
 # Prime fields - find generator
 
-from sympy import factorint
-
 def is_primitive_root(g, q, phi, factors):
     """Checks if g is a primitive root mod q by verifying its order."""
     for p in factors:


### PR DESCRIPTION
## Describe the changes

I removed the duplicate import of `factorint` from the code.
The import was included twice, and I’ve cleaned it up to make the code more concise and efficient.
