### PR TITLE
[DOCS] Fix rendering italics from dollar sign

### DIFF
--- a/docs/docs/grants.md
+++ b/docs/docs/grants.md
@@ -1,10 +1,10 @@
 # Ingonyama Grants Program 2.0
 
-Exactly one year ago, we launched our first-ever grants program, offering 100,000 Dollars to support research involving ICICLE. Today, we’re excited to announce our second grants program — another 100,000 Dollars dedicated to researchers. Details below!
+Exactly one year ago, we launched our first-ever grants program, offering \$100,000 to support research involving ICICLE. Today, we’re excited to announce our second grants program — another \$100,000 dedicated to researchers. Details below!
 
 ### ICICLE ZK-GPU Ecosystem Grant
 
-Ingonyama invites researchers and practitioners to collaborate in advancing ZK acceleration. We are allocating $100,000 for grants to support this initiative.
+Ingonyama invites researchers and practitioners to collaborate in advancing ZK acceleration. We are allocating \$100,000 for grants to support this initiative.
 
 ### Bounties & Grants
 Eligibility for grants includes:

--- a/docs/versioned_docs/version-3.5.0/grants.md
+++ b/docs/versioned_docs/version-3.5.0/grants.md
@@ -1,10 +1,10 @@
 # Ingonyama Grants Program 2.0
 
-Exactly one year ago, we launched our first-ever grants program, offering $100,000 to support research involving ICICLE. Today, we’re excited to announce our second grants program — another $100,000 dedicated to researchers. Details below!
+Exactly one year ago, we launched our first-ever grants program, offering \$100,000 to support research involving ICICLE. Today, we’re excited to announce our second grants program — another \$100,000 dedicated to researchers. Details below!
 
 ### ICICLE ZK-GPU Ecosystem Grant
 
-Ingonyama invites researchers and practitioners to collaborate in advancing ZK acceleration. We are allocating $100,000 for grants to support this initiative.
+Ingonyama invites researchers and practitioners to collaborate in advancing ZK acceleration. We are allocating \$100,000 for grants to support this initiative.
 
 ### Bounties & Grants
 Eligibility for grants includes:

--- a/docs/versioned_docs/version-3.6.0/grants.md
+++ b/docs/versioned_docs/version-3.6.0/grants.md
@@ -1,10 +1,10 @@
 # Ingonyama Grants Program 2.0
 
-Exactly one year ago, we launched our first-ever grants program, offering $100,000 to support research involving ICICLE. Today, we’re excited to announce our second grants program — another $100,000 dedicated to researchers. Details below!
+Exactly one year ago, we launched our first-ever grants program, offering \$100,000 to support research involving ICICLE. Today, we’re excited to announce our second grants program — another \$100,000 dedicated to researchers. Details below!
 
 ### ICICLE ZK-GPU Ecosystem Grant
 
-Ingonyama invites researchers and practitioners to collaborate in advancing ZK acceleration. We are allocating $100,000 for grants to support this initiative.
+Ingonyama invites researchers and practitioners to collaborate in advancing ZK acceleration. We are allocating \$100,000 for grants to support this initiative.
 
 ### Bounties & Grants
 Eligibility for grants includes:


### PR DESCRIPTION
## Describe the changes

This PR fixes the rendering on the grants page where text between non-escaped (\$ - vs escaped \\$) dollar signs are italicized 
