### PR TITLE
Formatting in documentation and sidebar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The developer docs for ICICLE is a static website built using [Docusaurus](https
 
 ## Requirements
 
-Docusaurus is written in Typescript and distributed as npm packages. npm is a prerequisite as is node.js
+Docusaurus is written in TypeScript and distributed as npm packages. npm is a prerequisite as is node.js
 
 If node.js or npm aren't installed, its suggested to use [nvm](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) to [install both](https://github.com/nvm-sh/nvm?tab=readme-ov-file#usage) at the same time.
 
@@ -70,7 +70,7 @@ Read more on this [here](https://docusaurus.io/docs/static-assets)
 
 ### Adding a new static directory
 
-To update where Docusaurus looks for static directories, add the directory name to the `statidDirectories` list in the config:
+To update where Docusaurus looks for static directories, add the directory name to the `staticDirectories` list in the config:
 
 ```ts
 const config: Config = {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -179,10 +179,10 @@ const rustBindingsApi = [
     id: "icicle/rust-bindings/merkle",
   },
   {
-    "type": "doc",
-    "label": "Sumcheck",
-    "id": "icicle/rust-bindings/sumcheck"
-  }
+    type: "doc",
+    label: "Sumcheck",
+    id: "icicle/rust-bindings/sumcheck"
+  },
   // {
   //   type: "doc",
   //   label: "Multi GPU Support (TODO)",


### PR DESCRIPTION
1. Standardized object syntax in **sidebars.ts** by removing inconsistent quotation marks.

2. Fixed: `statidDirectories` → `staticDirectories`, `Typescript` → `TypeScript`