### PR TITLE
Fix Broken Reference to ntt.cu

### DIFF
--- a/docs/docs/icicle/primitives/ntt.md
+++ b/docs/docs/icicle/primitives/ntt.md
@@ -288,7 +288,7 @@ Mixed radix on the other hand works better for larger NTTs with larger input siz
 
 Performance really depends on logn size, batch size, ordering, inverse, coset, coeff-field and which GPU you are using.
 
-For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt/ntt.cu#L573) which should choose the most efficient algorithm in most cases.
+For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt.cpp) which should choose the most efficient algorithm in most cases.
 
 We still recommend you benchmark for your specific use case if you think a different configuration would yield better results.
 

--- a/docs/versioned_docs/version-2.8.0/icicle/primitives/ntt.md
+++ b/docs/versioned_docs/version-2.8.0/icicle/primitives/ntt.md
@@ -154,6 +154,6 @@ Mixed radix on the other hand works better for larger NTTs with larger input siz
 
 Performance really depends on logn size, batch size, ordering, inverse, coset, coeff-field and which GPU you are using.
 
-For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt/ntt.cu#L573) which should choose the most efficient algorithm in most cases.
+For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt.cpp) which should choose the most efficient algorithm in most cases.
 
 We still recommend you benchmark for your specific use case if you think a different configuration would yield better results.

--- a/docs/versioned_docs/version-3.0.0/icicle/primitives/ntt.md
+++ b/docs/versioned_docs/version-3.0.0/icicle/primitives/ntt.md
@@ -288,7 +288,7 @@ Mixed radix on the other hand works better for larger NTTs with larger input siz
 
 Performance really depends on logn size, batch size, ordering, inverse, coset, coeff-field and which GPU you are using.
 
-For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt/ntt.cu#L573) which should choose the most efficient algorithm in most cases.
+For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt.cpp) which should choose the most efficient algorithm in most cases.
 
 We still recommend you benchmark for your specific use case if you think a different configuration would yield better results.
 

--- a/docs/versioned_docs/version-3.1.0/icicle/primitives/ntt.md
+++ b/docs/versioned_docs/version-3.1.0/icicle/primitives/ntt.md
@@ -288,7 +288,7 @@ Mixed radix on the other hand works better for larger NTTs with larger input siz
 
 Performance really depends on logn size, batch size, ordering, inverse, coset, coeff-field and which GPU you are using.
 
-For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt/ntt.cu#L573) which should choose the most efficient algorithm in most cases.
+For this reason we implemented our [heuristic auto-selection](https://github.com/ingonyama-zk/icicle/blob/main/icicle/src/ntt.cpp) which should choose the most efficient algorithm in most cases.
 
 We still recommend you benchmark for your specific use case if you think a different configuration would yield better results.
 


### PR DESCRIPTION
This PR updates references to the old ntt.cu file, replacing them with ntt.cpp across multiple documentation files. The new file (ntt.cpp) contains relevant NTT computation logic and serves as an appropriate replacement.

I recommend using ntt.cpp since it contains similar information. However, if there is a better alternative, please let me know, and I will update the reference accordingly.