### PR TITLE
chore: remove redundant import of `factorint` from `sympy`

### DIFF
--- a/scripts/python/integer_ring.py
+++ b/scripts/python/integer_ring.py
@@ -4,8 +4,6 @@ import math
 
 # Prime fields - find generator
 
-from sympy import factorint
-
 def is_primitive_root(g, q, phi, factors):
     """Checks if g is a primitive root mod q by verifying its order."""
     for p in factors:


### PR DESCRIPTION
## Describe the changes

I noticed that `factorint` from `sympy` was imported twice in the same file.
The second import is unnecessary and has been removed to clean up the code.