### PR TITLE
[Feat] Rust curves and fields to build with HASH

### DIFF
--- a/wrappers/rust/icicle-curves/icicle-bls12-377/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/build.rs
@@ -26,7 +26,7 @@ fn main() {
     config
         .define("CURVE", "bls12_377")
         .define("FIELD", "bls12_377")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/build.rs
@@ -26,7 +26,7 @@ fn main() {
     config
         .define("CURVE", "bls12_381")
         .define("FIELD", "bls12_381")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-curves/icicle-bn254/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/build.rs
@@ -25,7 +25,8 @@ fn main() {
     };
     config
         .define("CURVE", "bn254")
-        .define("HASH", "OFF")
+        .define("FIELD", "bn254")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/build.rs
@@ -25,7 +25,7 @@ fn main() {
     };
     config
         .define("CURVE", "bw6_761")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/build.rs
@@ -25,7 +25,7 @@ fn main() {
     };
     config
         .define("CURVE", "grumpkin")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-fields/icicle-babybear/build.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/build.rs
@@ -25,7 +25,7 @@ fn main() {
     };
     config
         .define("FIELD", "babybear")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-fields/icicle-koalabear/build.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/build.rs
@@ -25,7 +25,7 @@ fn main() {
     };
     config
         .define("FIELD", "koalabear")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     // build (or pull and build) cuda backend if feature enabled.

--- a/wrappers/rust/icicle-fields/icicle-m31/build.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/build.rs
@@ -26,7 +26,7 @@ fn main() {
     config
         .define("FIELD", "m31")
         .define("EXT_FIELD", "ON")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     if cfg!(feature = "cuda_backend") {

--- a/wrappers/rust/icicle-fields/icicle-stark252/build.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/build.rs
@@ -25,7 +25,7 @@ fn main() {
     };
     config
         .define("FIELD", "stark252")
-        .define("HASH", "OFF")
+        .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
 
     if cfg!(feature = "cuda_backend") {


### PR DESCRIPTION
## Describe the changes

This PR sets HASH to ON by default for all curves and fields in the Rust wrapper


## (optional) CUDA backend branch
# cuda-backend-branch: main # specify the branch here
