### PR TITLE
docs: fixed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This guide will help you get started with ICICLE in C++, Rust, and Go.
 > **Developers**: We highly recommend reading our [documentation](https://dev.ingonyama.com/) for a comprehensive explanation of ICICLE’s capabilities.
 
 > [!TIP]
-> Try out ICICLE by running some [examples] available in C++, Rust, and Go bindings. Check out our install-and-use examples in [C++](https://github.com/ingonyama-zk/icicle/tree/main/examples/c%2B%2B/install-and-use-icicle), [Rust](https://github.com/ingonyama-zk/icicle/tree/main/examples/rust/install-and-use-icicle) and [Go](TODO)
+> Try out ICICLE by running some [examples] available in C++, Rust, and Go bindings. Check out our install-and-use examples in [C++](https://github.com/ingonyama-zk/icicle/tree/main/examples/c%2B%2B/install-and-use-icicle), [Rust](https://github.com/ingonyama-zk/icicle/tree/main/examples/rust/install-and-use-icicle) and [Go](https://github.com/ingonyama-zk/icicle/tree/main/examples/golang/install-and-use-icicle)
 
 ### Prerequisites
 

--- a/docs/docs/icicle/arch_overview.md
+++ b/docs/docs/icicle/arch_overview.md
@@ -11,7 +11,7 @@ ICICLE v3 is designed with flexibility and extensibility in mind, offering a rob
 ## CUDA Backend
 
 - **CUDA Backend:** ICICLE also includes a high-performance CUDA backend that is closed-source. This backend is optimized for NVIDIA GPUs and provides significant acceleration for cryptographic operations. 
-- **Installation and Licensing:** The CUDA backend needs to be downloaded and installed. Refer to the [installation guide](./install_gpu_backend) for detailed instructions.
+- **Installation and Licensing:** The CUDA backend needs to be downloaded and installed. Refer to the [installation guide](./install_gpu_backend.md) for detailed instructions.
 
 ## Multi-Device Support
 

--- a/docs/docs/icicle/build_from_source.md
+++ b/docs/docs/icicle/build_from_source.md
@@ -176,4 +176,4 @@ Make sure to install icicle libs when installing a library/application that depe
 ### Go: Build, Test, and Install (TODO)
 
 --- 
-**To install CUDA backend and license click [here](./install_gpu_backend#installation)**
+**To install CUDA backend and license click [here](./install_gpu_backend.md#installation)**

--- a/docs/docs/icicle/getting_started.md
+++ b/docs/docs/icicle/getting_started.md
@@ -8,7 +8,7 @@ This guide will walk you through the entire process of building, testing, and in
 1. **Install ICICLE or build it from source**: This is explained in this guide. For building from source, refer to the [Build from Source page](./build_from_source.md).
 2. **Follow the [Programmer’s Guide](./programmers_guide/general.md)**: Learn how to use ICICLE APIs.  
 3. **Start using ICICLE APIs on your CPU**: Your application will now use ICICLE on the CPU.
-4. **Accelerate your application on a GPU**: [install the GPU backend](./install_gpu_backend),  load it, and select it in your application ([C++](./programmers_guide/cpp.md#loading-a-backend),[Rust](./programmers_guide/rust.md#loading-a-backend), [Go](./programmers_guide/go.md#loading-a-backend)).
+4. **Accelerate your application on a GPU**: [install the GPU backend](./install_gpu_backend.md),  load it, and select it in your application ([C++](./programmers_guide/cpp.md#loading-a-backend),[Rust](./programmers_guide/rust.md#loading-a-backend), [Go](./programmers_guide/go.md#loading-a-backend)).
 5. **Run on the GPU**: Once the GPU backend is selected, all subsequent API calls will execute on the GPU.
 6. **Optimize for multi-GPU environments**: Refer to the [Multi-GPU](./multi-device.md) Guide to fully utilize your system’s capabilities.  
 7. **Review memory management**: Revisit the [Memory Management section](./programmers_guide/general.md#device-abstraction) to allocate memory on the device efficiently and try to keep data on the GPU as long as possible.  

--- a/docs/docs/icicle/golang-bindings/msm.md
+++ b/docs/docs/icicle/golang-bindings/msm.md
@@ -160,7 +160,7 @@ out.Malloc(p.Size(), batchSize)
 
 ## Parameters for optimal performance
 
-Please refer to the [primitive description](../primitives/msm#choosing-optimal-parameters)
+Please refer to the [primitive description](../primitives/msm.md#choosing-optimal-parameters)
 
 ## Support for G2 group
 

--- a/docs/docs/icicle/install_gpu_backend.md
+++ b/docs/docs/icicle/install_gpu_backend.md
@@ -6,7 +6,7 @@ ICICLE v3 supports high-performance GPU backends, including **CUDA** (for NVIDIA
 
 ## Installation
 
-GPU backends are closed-source components that require a valid license. [To install and configure GPU backends in ICICLE, see here](./getting_started#installing-and-using-icicle).
+GPU backends are closed-source components that require a valid license. [To install and configure GPU backends in ICICLE, see here](./getting_started.md#installing-and-using-icicle).
 
 ## Licensing
 

--- a/docs/docs/icicle/libraries.md
+++ b/docs/docs/icicle/libraries.md
@@ -8,13 +8,13 @@ ICICLE is composed of two main logical parts:
 
 The ICICLE device library serves as an abstraction layer for interacting with various hardware devices. It provides a comprehensive interface for tasks such as setting the active device, querying device-specific information like free and total memory, determining the number of available devices, and managing memory allocation. Additionally, it offers functionality for copying data to and from devices, managing task queues (streams) for efficient device utilization, and abstracting the complexities of device management away from the user.
 
-See programmers guide for more details. [C++](./programmers_guide/cpp#device-management), [Rust](./programmers_guide/rust#device-management), [Go](./programmers_guide/go)
+See programmers guide for more details. [C++](./programmers_guide/cpp.md#device-management), [Rust](./programmers_guide/rust.md#device-management), [Go](./programmers_guide/go.md)
 
 ## ICICLE Core
 
 ICICLE Core is a template library written in C++ that implements fundamental cryptographic operations, including field and curve arithmetic, as well as higher-level APIs such as MSM and NTT.
 
-The Core can be [instantiated](./build_from_source) for different fields, curves, and other cryptographic components, allowing you to tailor it to your specific needs. You can link your application to one or more ICICLE libraries, depending on the requirements of your project. For example, you might only need the babybear library or a combination of babybear and a Merkle tree builder.
+The Core can be [instantiated](./build_from_source.md) for different fields, curves, and other cryptographic components, allowing you to tailor it to your specific needs. You can link your application to one or more ICICLE libraries, depending on the requirements of your project. For example, you might only need the babybear library or a combination of babybear and a Merkle tree builder.
 
 
 ### Rust
@@ -26,35 +26,35 @@ Each library has a corresponding crate. See [programmers guide](./programmers_gu
 
 | Operation\Curve                           | [bn254](https://neuromancer.sk/std/bn/bn254) | [bls12-377](https://neuromancer.sk/std/bls/BLS12-377) | [bls12-381](https://neuromancer.sk/std/bls/BLS12-381) | [bw6-761](https://eprint.iacr.org/2020/351) | grumpkin |
 | ----------------------------------------- | :------------------------------------------: | :---------------------------------------------------: | :---------------------------------------------------: | :-----------------------------------------: | :------: |
-| [MSM](./primitives/msm)                   |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
+| [MSM](./primitives/msm.md)                   |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
 | G2 MSM                                    |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ❌     |
-| [NTT](./primitives/ntt)                   |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ❌     |
+| [NTT](./primitives/ntt.md)                   |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ❌     |
 | ECNTT                                     |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ❌     |
-| [Vector operations](./primitives/vec_ops) |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
-| [Polynomials](./polynomials/overview)     |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ❌     |
-| [Poseidon](primitives/hash#poseidon)      |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
-| [Poseidon2](primitives/hash#poseidon2)    |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
+| [Vector operations](./primitives/vec_ops.md) |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
+| [Polynomials](./polynomials/overview.md)     |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ❌     |
+| [Poseidon](primitives/hash.md#poseidon)      |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
+| [Poseidon2](primitives/hash.md#poseidon2)    |                      ✅                       |                           ✅                           |                           ✅                           |                      ✅                      |    ✅     |
 
 #### Supported fields and operations
 
 | Operation\Field                           | [babybear](https://eprint.iacr.org/2023/824.pdf) | [Stark252](https://docs.starknet.io/architecture-and-concepts/cryptography/#stark-field) |  m31  |  Koalabear  |
 | ----------------------------------------- | :----------------------------------------------: | :------------------------------------------------------------------------------------------------: | :---: | :---: |
-| [Vector operations](./primitives/vec_ops) |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
-| [Polynomials](./polynomials/overview)     |                        ✅                         |                                                 ✅                                                  |   ❌     |   ✅   |
-| [NTT](primitives/ntt)                     |                        ✅                         |                                                 ✅                                                  |   ❌     |   ✅   |
+| [Vector operations](./primitives/vec_ops.md) |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
+| [Polynomials](./polynomials/overview.md)     |                        ✅                         |                                                 ✅                                                  |   ❌     |   ✅   |
+| [NTT](primitives/ntt.md)                     |                        ✅                         |                                                 ✅                                                  |   ❌     |   ✅   |
 | Extension Field                           |                        ✅                         |                                                 ❌                                                  |   ✅     |   ✅   |
-| [Poseidon](primitives/hash#poseidon)      |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
-| [Poseidon2](primitives/hash#poseidon2)    |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
+| [Poseidon](primitives/hash.md#poseidon)      |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
+| [Poseidon2](primitives/hash.md#poseidon2)    |                        ✅                         |                                                 ✅                                                  |   ✅     |   ✅   |
 
 ### Misc
 
 | Operation                                 |                 Description                  |
 | ----------------------------------------- | :------------------------------------------: |
-| [Keccak](primitives/hash#keccak-and-sha3) |       supporting 256b and 512b digest        |
-| [SHA3](primitives/hash#keccak-and-sha3)   |       supporting 256b and 512b digest        |
-| [Blake2s](primitives/hash#blake2s)        |                digest is 256b                |
-| [Blake3](primitives/hash#blake3)        |                digest is 256b                |
-| [Merkle-Tree](primitives/merkle)          | works with any combination of hash functions |
+| [Keccak](primitives/hash.md#keccak-and-sha3) |       supporting 256b and 512b digest        |
+| [SHA3](primitives/hash.md#keccak-and-sha3)   |       supporting 256b and 512b digest        |
+| [Blake2s](primitives/hash.md#blake2s)        |                digest is 256b                |
+| [Blake3](primitives/hash.md#blake3)        |                digest is 256b                |
+| [Merkle-Tree](primitives/merkle.md)          | works with any combination of hash functions |
 
 
 
@@ -67,4 +67,4 @@ Each backend may implement
 - One or more ICICLE library. For example implement only bn254 curve.
 - One or more APIs in this library. For example MSM only.
 
-See [CUDA backend](./install_gpu_backend) and [Build Your Own Backend](./build_your_own_backend.md) for more info about implementing a backend.
+See [CUDA backend](./install_gpu_backend.md) and [Build Your Own Backend](./build_your_own_backend.md) for more info about implementing a backend.

--- a/docs/docs/icicle/migrate_from_v2.md
+++ b/docs/docs/icicle/migrate_from_v2.md
@@ -10,7 +10,7 @@ ICICLE v3 introduces a unified interface for high-performance computing across v
 - **Unified API**: The APIs are now standardized across all devices, ensuring consistent usage and reducing the complexity of managing different hardware backends.
 
 :::warning
-When migrating from v2 to v3, it is important to note that, by default, your code now executes on the CPU. This contrasts with V2, which was exclusively a CUDA library. For details on installing and using CUDA or METAL GPUs, refer to the [GPU backend guide](./install_gpu_backend).
+When migrating from v2 to v3, it is important to note that, by default, your code now executes on the CPU. This contrasts with V2, which was exclusively a CUDA library. For details on installing and using CUDA or METAL GPUs, refer to the [GPU backend guide](./install_gpu_backend.md).
 :::
 
 ## Migration Guide for C++

--- a/docs/docs/icicle/primitives/hash.md
+++ b/docs/docs/icicle/primitives/hash.md
@@ -183,5 +183,5 @@ Currently the poseidon sponge mode (sponge function description could be found i
 
 ### Supported Bindings
 
-- [Rust](../rust-bindings/hash)
-- [Go](../golang-bindings/hash)
+- [Rust](../rust-bindings/hash.md)
+- [Go](../golang-bindings/hash.md)

--- a/docs/docs/icicle/primitives/poseidon.md
+++ b/docs/docs/icicle/primitives/poseidon.md
@@ -62,7 +62,7 @@ So for Poseidon of arity 2 and input of size 1024 * 2, we would expect 1024 elem
 
 Poseidon is extremely customizable and using different constants will produce different hashes, security levels and performance results.
 
-We support pre-calculated and optimized constants for each of the [supported curves](../libraries#supported-curves-and-operations).The constants can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/icicle/hash/poseidon_constants/constants) and are labeled clearly per curve `<curve_name>_poseidon.h`.
+We support pre-calculated and optimized constants for each of the [supported curves](../libraries.md#supported-curves-and-operations).The constants can be found [here](https://github.com/ingonyama-zk/icicle/tree/main/icicle/include/icicle/hash/poseidon_constants/constants) and are labeled clearly per curve `<curve_name>_poseidon.h`.
 
 If you wish to generate your own constants you can use our python script which can be found [here](https://github.com/ingonyama-zk/icicle/blob/main/icicle/include/icicle/hash/poseidon_constants/constants/generate_parameters.py).
 

--- a/docs/docs/icicle/rust-bindings/msm.md
+++ b/docs/docs/icicle/rust-bindings/msm.md
@@ -114,4 +114,4 @@ pub fn precompute_bases<C: Curve + MSM<C>>(
 
 ## Parameters for optimal performance
 
-Please refer to the [primitive description](../primitives/msm#choosing-optimal-parameters)
+Please refer to the [primitive description](../primitives/msm.md#choosing-optimal-parameters)


### PR DESCRIPTION
Hi! I found two documentation issues:

1. **Missing File Extensions**:
   - Many internal links lack `.md` extensions, causing broken navigation on GitHub (404 errors)

2. **removed `TODO` Go Example in README.md**