### PR TITLE
Enable Rust cross-compilation to Android

### DIFF
--- a/scripts/cross-compilation/android/Dockerfile
+++ b/scripts/cross-compilation/android/Dockerfile
@@ -1,0 +1,76 @@
+# Use Ubuntu LTS as base
+FROM ubuntu:24.04
+
+# Avoid interactive prompts during build
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    make \
+    clang \
+    wget \
+    unzip \
+    software-properties-common \
+    git \
+    ninja-build \
+    python3.8 \
+    adb \
+    xxd \
+    build-essential \
+    pkg-config 
+
+# Install cmake, the version in apt is too old 
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh \
+-o /tmp/cmake-install.sh \
+&& chmod u+x /tmp/cmake-install.sh \
+&& mkdir /opt/cmake-3.24.1 \
+&& /tmp/cmake-install.sh --skip-license --prefix=/opt/cmake-3.24.1 \
+&& rm /tmp/cmake-install.sh \
+&& ln -s /opt/cmake-3.24.1/bin/* /usr/local/bin
+
+# Install Rust via rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Download and extract Android NDK
+ARG NDK_VERSION=28
+ARG NDK_URL=https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux.zip
+ENV ANDROID_NDK=/opt/android-ndk-r${NDK_VERSION}/
+ENV ANDROID_NDK_HOME=/opt/android-ndk-r${NDK_VERSION}/
+ENV NDK_DIR=/opt/android-ndk-r${NDK_VERSION}/
+ENV CMAKE_ANDROID_NDK=/opt/android-ndk-r${NDK_VERSION}/
+ENV RUSTFLAGS="-C link-arg=-Wl,--allow-shlib-undefined"
+
+RUN wget -q ${NDK_URL} -O android-ndk.zip \
+    && unzip -q android-ndk.zip -d /opt/ \
+    && rm android-ndk.zip
+
+# Add Android targets (ARM64, ARMv7, x86_64)
+RUN rustup target add \
+    aarch64-linux-android \
+    armv7-linux-androideabi \
+    x86_64-linux-android
+
+# Configure Cargo for cross-compilation
+RUN mkdir -p /root/.cargo
+COPY <<EOF /root/.cargo/config.toml
+[target.aarch64-linux-android]
+linker = "${ANDROID_NDK_HOME}toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+ar = "${ANDROID_NDK_HOME}toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+
+[target.armv7-linux-androideabi]
+linker = "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
+ar = "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+
+[target.x86_64-linux-android]
+linker = "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
+ar = "${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+EOF
+
+# Set working directory for builds
+WORKDIR /app
+VOLUME /app
+
+# Use bash shell
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/scripts/cross-compilation/android/README.md
+++ b/scripts/cross-compilation/android/README.md
@@ -1,0 +1,44 @@
+# Cross-compile to Android
+
+At this moment we only support cross-compiling Rust applications
+
+## Cross-compile Rust CLI app to Android using Ubuntu container
+
+### Build a container to setup the required toolchains
+
+We assume you are in the Icicle root directory.
+
+- on Ubuntu (amd86), run
+
+```sh
+docker build -t icicle-cross-android -f ./scripts/cross-compilation/android/Dockerfile ./scripts/cross-compilation/android/
+```
+
+- on Apple Silicon (arm64), ensure the image supports multi-platform builds:
+
+```sh
+docker buildx build --platform linux/amd64 -t icicle-cross-android -f ./scripts/cross-compilation/android/Dockerfile ./scripts/cross-compilation/android/
+```
+
+### Use the container to cross-compile
+
+We assume you are in the root directory of your Rust project:
+
+Edit the exact location of Icicle directory and run the container interactively:
+
+```sh
+docker run --platform linux/amd64 -it \
+  -v $(pwd):/app \
+  -v ~/Projects/ingonyama-zk/icicle:/opt/icicle \
+  icicle-cross-android /bin/bash
+```
+
+Once inside the container:
+
+```sh
+cd /app
+cargo build --target aarch64-linux-android --release
+exit
+```
+
+Once you exit the conatiner your cross-compiled application is in `./target/aarch64-linux-android`

--- a/wrappers/rust/icicle-curves/icicle-bn254/build.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/build.rs
@@ -28,7 +28,11 @@ fn main() {
         .define("FIELD", "bn254")
         .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
-
+    // check if cross-compilation is required
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("android") {
+        config.define("BUILD_FOR_ANDROID", "ON");
+    }
     // build (or pull and build) cuda backend if feature enabled.
     // Note: this requires access to the repo
     if cfg!(feature = "cuda_backend") {

--- a/wrappers/rust/icicle-hash/build.rs
+++ b/wrappers/rust/icicle-hash/build.rs
@@ -25,7 +25,11 @@ fn main() {
     config
         .define("HASH", "ON")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
-
+    // check if cross-compilation is required
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("android") {
+        config.define("BUILD_FOR_ANDROID", "ON");
+    }
     // build (or pull and build) cuda backend if feature enabled.
     // Note: this requires access to the repo
     if cfg!(feature = "cuda_backend") {

--- a/wrappers/rust/icicle-runtime/build.rs
+++ b/wrappers/rust/icicle-runtime/build.rs
@@ -25,7 +25,12 @@ fn main() {
     config
         .define("HASH", "OFF")
         .define("CMAKE_INSTALL_PREFIX", &icicle_install_dir);
-
+    // check if cross-compilation is required
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("android") {
+        config.define("BUILD_FOR_ANDROID", "ON");
+    }
+    config.define("BUILD_FOR_ANDROID", "ON");
     // build (or pull and build) cuda backend if feature enabled.
     // Note: this requires access to the repo
     if cfg!(feature = "cuda_backend") {


### PR DESCRIPTION
## Describe the changes

### Modified build.rs scripts to pass ANDROID flags to cmake.

Reviewer, please voice your opinion if the following approach is OK:

    // check if cross-compilation is required
    let target = std::env::var("TARGET").unwrap();
    if target.contains("android") {
        config.define("BUILD_FOR_ANDROID", "ON");
    }

### added ./scripts/cross-compilation/android directory

The directory has a README.md and a Dockerfile to build the required toolchain
