### PR TITLE
fix: stream type consistency with `IcicleStreamHandle` alias

### DIFF
--- a/wrappers/rust/icicle-runtime/src/runtime.rs
+++ b/wrappers/rust/icicle-runtime/src/runtime.rs
@@ -50,7 +50,7 @@ extern "C" {
     fn icicle_get_device_properties(properties: *mut DeviceProperties) -> eIcicleError;
     fn icicle_get_registered_devices(output: *mut c_char, output_size: usize) -> eIcicleError;
     fn icicle_memset(ptr: *mut c_void, value: i32, size: usize) -> eIcicleError;
-    fn icicle_memset_async(ptr: *mut c_void, value: i32, size: usize, stream: *mut c_void) -> eIcicleError;
+    fn icicle_memset_async(ptr: *mut c_void, value: i32, size: usize, stream: IcicleStreamHandle) -> eIcicleError;
 }
 
 pub fn load_backend_from_env_or_default() -> Result<(), eIcicleError> {


### PR DESCRIPTION
## Describe the changes

corrected the stream type to be of type `IcicleStreamHandle` (i.e., `*mut c_void`) for consistency across the interface.

p.s. previously, it was using `IcicleStreamHandle` as an alias, which caused some inconsistency with other functions like `icicle_malloc_async`.

now the types align properly.
