### PR TITLE
fix: ensure `s` stays within valid range `[0, p²)`

### DIFF
--- a/scripts/python/param_generation_for_from_func.py
+++ b/scripts/python/param_generation_for_from_func.py
@@ -64,8 +64,7 @@ for i in range(n):
     # num_to_limbs(pi[i], 32, 18)
     s += ai[i] * pi[i]
     # s = s % p**2
-    if s > p**2:
-        s = s-p**2
+    s = s % (p**2)
     # print("mul")
     # num_to_limbs(ai[i] * pi[i], 32, 18)
     # print("add")


### PR DESCRIPTION
## Describe the changes

in certain edge cases, `s` could fall outside the expected range.
this change guarantees that `s` is always within `[0, p²)`, which is the correct behavior across all scenarios.