### PR TITLE
fix: digit comparison for balanced representation

### DIFF
--- a/scripts/python/balanced_decomposition.py
+++ b/scripts/python/balanced_decomposition.py
@@ -66,7 +66,7 @@ def decompose(num: Labrador, base: int) -> list[int]:
         digit = val % base
         val = val // base
         # balanced decomposition means that the digits are in the range [-base//2, base//2)
-        if digit > base//2:
+        if digit >= base // 2:
             digit = digit - base
             val = val + 1
         print(f"{digit=}, {val=} ")


### PR DESCRIPTION
## Describe the changes

Fixed the issue in the function where the comparison `if digit >= base // 2:` was incorrect.

Now, the value `digit == base // 2` is handled properly, ensuring that the function works as intended for balanced digit representation.