### PR TITLE
Danny/poseidon2 consolidate kernels

### DIFF
--- a/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
+++ b/icicle/backend/cpu/src/hash/cpu_poseidon2.cpp
@@ -187,7 +187,7 @@ namespace icicle {
       bool is_unsupported_T_for_this_field = m_poseidon2_constants.nof_upper_full_rounds == 0;
       if (is_unsupported_T_for_this_field) {
         ICICLE_LOG_ERROR << "Unsupported poseidon2 width (t=" << t << ") for this field!";
-        return eIcicleError::API_NOT_IMPLEMENTED;
+        return eIcicleError::INVALID_ARGUMENT;
       }
 
       int input_size_in_scalars = size / sizeof(S);

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1102,7 +1102,16 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   config.batch = 1;
 
   auto input = std::make_unique<scalar_t[]>(config.batch * t);
-  scalar_t::rand_host_many(input.get(), t * config.batch);
+  // scalar_t::rand_host_many(input.get(), t * config.batch);
+  // Set the inputs as needed.
+  for (int i = 0; i < config.batch; i++) {
+    for (int j = 0; j < t; j++) {
+      input[i * t + j] = scalar_t::from(j + 4);
+    }
+  }
+  for (int i = 0; i < config.batch * t; i++) {
+    std::cout << "Input = " << input[i] << std::endl;
+  }
 
   auto run = [&](const std::string& dev_type, scalar_t* out, bool measure, const char* msg, int iters) {
     Device dev = {dev_type, 0};
@@ -1135,7 +1144,7 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt)
 {
   const unsigned t = 4;
   auto config = default_hash_config();
-  int nof_hashers = 2;
+  int nof_hashers = 4096;
   int nof_inputs = 1 + nof_hashers * (t - 1);
 
   auto input = std::make_unique<scalar_t[]>(nof_inputs);

--- a/icicle/tests/test_hash_api.cpp
+++ b/icicle/tests/test_hash_api.cpp
@@ -1102,16 +1102,7 @@ TEST_F(HashApiTest, poseidon2_3_single_hasher)
   config.batch = 1;
 
   auto input = std::make_unique<scalar_t[]>(config.batch * t);
-  // scalar_t::rand_host_many(input.get(), t * config.batch);
-  // Set the inputs as needed.
-  for (int i = 0; i < config.batch; i++) {
-    for (int j = 0; j < t; j++) {
-      input[i * t + j] = scalar_t::from(j + 4);
-    }
-  }
-  for (int i = 0; i < config.batch * t; i++) {
-    std::cout << "Input = " << input[i] << std::endl;
-  }
+  scalar_t::rand_host_many(input.get(), t * config.batch);
 
   auto run = [&](const std::string& dev_type, scalar_t* out, bool measure, const char* msg, int iters) {
     Device dev = {dev_type, 0};
@@ -1144,7 +1135,7 @@ TEST_F(HashApiTest, poseidon2_4_sponge_2_hashers_without_dt)
 {
   const unsigned t = 4;
   auto config = default_hash_config();
-  int nof_hashers = 4096;
+  int nof_hashers = 2;
   int nof_inputs = 1 + nof_hashers * (t - 1);
 
   auto input = std::make_unique<scalar_t[]>(nof_inputs);
@@ -1586,7 +1577,7 @@ TEST_F(HashApiTest, poseidon2_invalid_t)
     auto poseidon2 = Poseidon2::create<scalar_t>(t);
     auto err = poseidon2.hash(input.get(), t, config, output.get());
     if (large_field) {
-      EXPECT_EQ(err, eIcicleError::API_NOT_IMPLEMENTED);
+      EXPECT_EQ(err, eIcicleError::INVALID_ARGUMENT);
     } else {
       EXPECT_EQ(err, eIcicleError::SUCCESS);
     }


### PR DESCRIPTION
## Describe the changes

This PR consolidates kernel invocations in non-sponge poseidon2 hash from 6 to 1.
In addition it changes the poseidon2_invalid_t test in test_hash_api and cpu_poseidon2 (eIcicleError changed from API_NOT_IMPLEMENTED to INVALID_ARGUMENT).

## Linked Issues

Resolves #

## (optional) CUDA backend branch
cuda-backend-branch: danny/poseidon2_consolidate_kernels # specify the branch here
