### PR TITLE
update fri links and sidebars for consistency

### DIFF
--- a/docs/docs/icicle/rust-bindings/fri.md
+++ b/docs/docs/icicle/rust-bindings/fri.md
@@ -106,4 +106,4 @@ assert!(valid);
 
 ## **Links**
 
-For more information on FRI concepts, see [FRI Primitives](../../primitives/fri.md).
+For more information on FRI concepts, see [FRI Primitives](../primitives/fri).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -202,6 +202,11 @@ const rustBindingsApi = [
     "type": "doc",
     "label": "Sumcheck",
     "id": "icicle/rust-bindings/sumcheck"
+  },
+  {
+    "type": "doc",
+    "label": "FRI",
+    "id": "icicle/rust-bindings/fri"
   }
   // {
   //   type: "doc",

--- a/docs/versioned_docs/version-3.8.0/icicle/rust-bindings/fri.md
+++ b/docs/versioned_docs/version-3.8.0/icicle/rust-bindings/fri.md
@@ -106,4 +106,4 @@ assert!(valid);
 
 ## **Links**
 
-For more information on FRI concepts, see [FRI Primitives](../../primitives/fri.md).
+For more information on FRI concepts, see [FRI Primitives](../primitives/fri).

--- a/docs/versioned_sidebars/version-3.8.0-sidebars.json
+++ b/docs/versioned_sidebars/version-3.8.0-sidebars.json
@@ -256,6 +256,11 @@
                   "type": "doc",
                   "label": "Sumcheck",
                   "id": "icicle/rust-bindings/sumcheck"
+                },
+                {
+                  "type": "doc",
+                  "label": "FRI",
+                  "id": "icicle/rust-bindings/fri"
                 }
               ]
             }


### PR DESCRIPTION
## Describe the changes

This PR fixes a broken link in fri rust documentation

## Describe the rational

Why is this change necessary?

Does it increase performance?

## Backend branches

Replace "main" with the branch this PR should work with

cuda-backend-branch: main

metal-backend-branch: main
