### PR TITLE
Update GitHub Actions checkout action from v3 to v4

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: 'repo'
       - uses: actions/setup-node@v3

--- a/.github/workflows/test-deploy-docs.yml
+++ b/.github/workflows/test-deploy-docs.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test deployment of docs website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: 'repo'
       - uses: actions/setup-node@v3


### PR DESCRIPTION


**Description:**
This PR updates the GitHub Actions checkout action from v3 to v4 in our documentation deployment workflows.

Changes made:
- Updated `actions/checkout@v3` to `actions/checkout@v4` in deploy-docs.yml
- Updated `actions/checkout@v3` to `actions/checkout@v4` in test-deploy-docs.yml

This update ensures we're using the latest version of the checkout action which includes performance improvements and bug fixes.


