### PR TITLE
Adds a few starter cursor rules

### DIFF
--- a/.cursor/rules/add-feature-go-wrapper.mdc
+++ b/.cursor/rules/add-feature-go-wrapper.mdc
@@ -1,0 +1,74 @@
+---
+description: How to add a new feature to go wrappers
+globs: 
+alwaysApply: false
+---
+# Add New Feature to Go Wrappers
+
+This checklist outlines the steps required to add support for a new ICICLE feature (e.g., Sumcheck, Pairing) to the Go wrappers generator. Replace `<FeatureName>` with the PascalCase name of the feature (e.g., `Sumcheck`) and `<featurename>` with the lowercase version (e.g., `sumcheck`).
+
+**Context Files:**
+
+*   `@wrappers/golang/internal/generator/config/config.go`
+*   `@wrappers/golang/internal/generator/config/fields.go` (or similar config initialization file)
+*   `@wrappers/golang/internal/generator/config/curves.go` (or similar config initialization file)
+*   `@wrappers/golang/internal/generator/main.go`
+*   `@icicle/cmake/features.cmake`
+*   (New) `@wrappers/golang/internal/generator/<featurename>/generate.go`
+*   (New) `@wrappers/golang/internal/generator/<featurename>/templates/<featurename>.go.tmpl`
+*   (New) `@wrappers/golang/internal/generator/<featurename>/templates/<featurename>_test.go.tmpl`
+*   (New) `@wrappers/golang/internal/generator/<featurename>/templates/<featurename>.h.tmpl`
+
+**Checklist:**
+
+*   [ ] **Update Config Structs:**
+    *   In `wrappers/golang/internal/generator/config/config.go`:
+        *   Add `Supports<FeatureName> bool` field to `FieldData` struct.
+        *   Add `Supports<FeatureName> bool` field to `CurveData` struct.
+
+*   [ ] **Update Config Initialization:**
+    *   In the files under `wrappers/golang/internal/generator/config/` where `FieldData` and `CurveData` instances are created (e.g., `fields.go`, `curves.go`):
+        *   Initialize the `Supports<FeatureName>` field for each field/curve based on its capabilities, typically by checking `icicle/cmake/features.cmake`.
+
+*   [ ] **Update Main Generator (`main.go`):**
+    *   In `wrappers/golang/internal/generator/main.go`:
+        *   Update the feature parsing logic (likely reading from `features.cmake`) to recognize the new `<FeatureName>` feature string.
+        *   Set the `Supports<FeatureName>` flag accordingly in the `CurveData` or `FieldData` instances being processed.
+        *   Add the import statement for the new generator package: `_ "github.com/ingonyama-zk/icicle/v3/wrappers/golang/internal/generator/<featurename>"`.
+        *   Within the loops processing curves and fields, add a conditional call to the new feature's generator:
+            ```go
+            if curve.Supports<FeatureName> { // or field.Supports<FeatureName>
+                <featurename>.Generate(outputDir, curve.Curve, ...) // Pass necessary arguments
+            }
+            ```
+
+*   [ ] **Create Feature Generator Directory:**
+    *   Create the directory: `wrappers/golang/internal/generator/<featurename>/`
+
+*   [ ] **Create Generator Logic File:**
+    *   Create the file: `wrappers/golang/internal/generator/<featurename>/generate.go`.
+    *   Define a `Generate` function responsible for executing templates.
+    *   Define a data struct (e.g., `<FeatureName>Data`) to pass information to the templates.
+    *   Define constants for the template file paths (pointing into the `templates` subdirectory).
+    *   Implement the `Generate` function to parse templates and call `generator_utils.GenerateFile` for each template (`.go`, `_test.go`, `.h`).
+
+*   [ ] **Create Templates Directory:**
+    *   Create the subdirectory: `wrappers/golang/internal/generator/<featurename>/templates/`
+
+*   [ ] **Create Go Template File:**
+    *   Create the Go code template: `wrappers/golang/internal/generator/<featurename>/templates/<featurename>.go.tmpl`.
+    *   Implement the Go bindings using CGO, referencing functions defined in the corresponding `.h.tmpl`. Use template variables (e.g., `{{.Field}}`, `{{.PackageName}}`) passed from `generate.go`.
+
+*   [ ] **Create Test Template File:**
+    *   Create the Go test template: `wrappers/golang/internal/generator/<featurename>/templates/<featurename>_test.go.tmpl`.
+    *   Add placeholder test functions (e.g., `Test<FeatureName>Functionality`, `Test<FeatureName>Serialization`) using the `testing` package and ideally `stretchr/testify`. Mark tests as skipped initially.
+
+*   [ ] **Create Header Template File:**
+    *   Create the C header template: `wrappers/golang/internal/generator/<featurename>/templates/<featurename>.h.tmpl`.
+    *   Define the necessary C function signatures, structs (like FFI-safe configs), typedefs, and includes required for the CGO calls in the `.go.tmpl` file. Use template variables as needed.
+
+*   [ ] **Run Generator:**
+    *   Execute `go generate` within the `wrappers/golang/internal/generator/` directory to test the changes and generate the new wrapper files.
+
+*   [ ] **Implement TODOs:**
+    *   Fill in any `// TODO:` comments left in the generated Go code or templates, especially around complex CGO conversions, memory management, and test logic.

--- a/.cursor/rules/cursor-rules.mdc
+++ b/.cursor/rules/cursor-rules.mdc
@@ -1,0 +1,53 @@
+---
+description: How to add or edit Cursor rules in our project
+globs: 
+alwaysApply: false
+---
+# Cursor Rules Location
+
+How to add new cursor rules to the project
+
+1. Always place rule files in PROJECT_ROOT/.cursor/rules/:
+    ```
+    .cursor/rules/
+    ├── your-rule-name.mdc
+    ├── another-rule.mdc
+    └── ...
+    ```
+
+2. Follow the naming convention:
+    - Use kebab-case for filenames
+    - Always use .mdc extension
+    - Make names descriptive of the rule's purpose
+
+3. Directory structure:
+    ```
+    PROJECT_ROOT/
+    ├── .cursor/
+    │   └── rules/
+    │       ├── your-rule-name.mdc
+    │       └── ...
+    └── ...
+    ```
+
+4. Never place rule files:
+    - In the project root
+    - In subdirectories outside .cursor/rules
+    - In any other location
+
+5. Cursor rules have the following structure:
+
+````
+---
+description: Short description of the rule's purpose
+globs: optional/path/pattern/**/*
+alwaysApply: false
+---
+# Rule Title
+
+Main content explaining the rule with markdown formatting.
+
+1. Step-by-step instructions
+2. Code examples
+3. Guidelines
+````

--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -1,0 +1,43 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# ICICLE - Main Rule Index
+
+This document serves as the central index for all active Cursor rules within this repository, organized by category. These rules define processes, structures, and guidelines for development.
+
+In general, ICICLE should be upper case unless being used in code.
+
+When updating this file, do not change when this file is ap
+
+## Core & General
+
+Fundamental project structure, setup, and general development guidelines.
+
+| Rule File                          | Description                                                 |
+| :--------------------------------- | :---------------------------------------------------------- |
+| @cursor-rules.mdc                  | How to add or edit Cursor rules in our project              |
+| @project-structure.mdc             | Project structure and file organization guidelines          |
+
+## Frontend and wrapper languages
+
+Guidelines for building frontend libraries and wrapper languages like Rust and Golang.
+
+| Rule File                          | Description                                                 |
+| :--------------------------------- | :---------------------------------------------------------- |
+| @add-feature-go-wrapper.mdc        | Guidelines for adding new feature in Go wrapper             |
+
+## Backends
+
+Guidelines for implementing backend logic.
+
+| Rule File                          | Description                                                 |
+| :--------------------------------- | :---------------------------------------------------------- |
+
+## Testing and CI
+
+Guidelines for application testing.
+
+| Rule File                          | Description                                                 |
+| :--------------------------------- | :---------------------------------------------------------- |

--- a/.cursor/rules/project-structure.mdc
+++ b/.cursor/rules/project-structure.mdc
@@ -1,0 +1,98 @@
+---
+description: Project structure and file organization guidelines
+globs: 
+alwaysApply: false
+---
+# Project Structure
+
+The ICICLE project is made up of three pieces:
+- The frontend
+- A backend
+- A wrapper language
+
+The frontend is a cpp implementation that includes API definitions, object definitions, interfaces for backends to implement, some core logic for fields and arithmetic, and a dispatcher class that routes API calls to the correct backend implementation.
+
+Each backend, located under `icicle/backend`, implements features according to the frontend's interfaces
+
+Each wrapper language, located under `wrappers/`, implements bindings for that language to the frontend's externed C API which wraps the c++ implementation
+
+## Directory Structure
+
+- Front cpp implementation is in the `icicle` folder
+- Wrapper languages are in the `wrappers` folder
+- Backends are in `icicle/backend` folder
+- Docs are in `docs` folder
+
+```tree
+.
+├── docs                                      # Developer documentation
+│   ├── docs                                  # Developer documentation for the next release
+│   │   └── icicle                            #
+│   │       ├── golang-bindings               # Golang bindings docs
+│   │       ├── primitives                    # Cpp docs
+│   │       ├── programmers_guide             # Guides for using ICICLE
+│   │       └── rust-bindings                 # Rust bindings docs
+│   ├── versioned_docs                        # Previous versions' docs
+│   └── versioned_sidebars                    # Previous versions' nav menu
+├── examples                                  # Examples using ICICLE APIs
+│   ├── c++                                   # Examples using ICICLE c++ API
+│   ├── golang                                # Examples using ICICLE golang API
+│   └── rust                                  # Examples using ICICLE rust API
+├── icicle                                    # Main c++ implementation of ICICLE
+│   ├── backend                               # Backends location
+│   │   ├── cpu                               # CPU Backend
+│   │   └── <other>                           # Potentially other local backends
+│   ├── cmake                                 # Cmake configuration files
+│   ├── include                               # includes directory for ICICLE
+│   │   └── icicle
+│   │       ├── api
+│   │       ├── backend
+│   │       ├── curves
+│   │       ├── fields
+│   │       ├── fri
+│   │       ├── hash
+│   │       ├── math
+│   │       ├── merkle
+│   │       ├── pairing
+│   │       ├── polynomials
+│   │       ├── program
+│   │       ├── rings
+│   │       ├── sumcheck
+│   │       └── utils
+│   ├── src                                   # source directory for ICICLE
+│   │   ├── curves
+│   │   ├── fields
+│   │   ├── fri
+│   │   ├── hash
+│   │   ├── polynomials
+│   │   ├── program
+│   │   ├── rings
+│   │   ├── sumcheck
+│   │   └── symbol
+│   └── tests                                 # Tests directory for ICICLE using gtest
+├── scripts                                   # Scripts directory
+│   ├── hooks                                 # Git hooks scripts
+│   ├── python                                # python scripts
+│   └── release                               # Buidling releases
+└── wrappers                                  # Wrapper languages
+    ├── golang                                # Golang bindings
+    │   ├── core                              # Core package
+    │   ├── curves
+    │   ├── fields
+    │   ├── hash
+    │   ├── internal                          # Code templates and generation
+    │   ├── merkle-tree
+    │   └── runtime                           # Bindings for device and runtime
+    └── rust                                  # Rust bindings
+        ├── icicle-core                       # Core package
+        ├── icicle-curves
+        ├── icicle-fields
+        ├── icicle-hash
+        ├── icicle-rings
+        └── icicle-runtime                    # Bindings for device and runtime
+```
+
+## New Docs
+
+- Create new docs in `docs/docs`
+


### PR DESCRIPTION
## Describe the changes

This PR adds a few starter cursor rules to help cursor understand ICICLE better

## Describe the rational

Why is this change necessary?

It helps standardize the use of Cursor across the team and outside contributors

## Backend branches

cuda-backend-branch: main

metal-backend-branch: main
