### PR TITLE
[FEAT] Download taskflow if not found on system

### DIFF
--- a/icicle/backend/cpu/CMakeLists.txt
+++ b/icicle/backend/cpu/CMakeLists.txt
@@ -1,33 +1,41 @@
 cmake_minimum_required(VERSION 3.18)
 
-message(STATUS "Fetching Taskflow v3.8.0 (CPU backend)")
+# Find Taskflow package
+message(STATUS "Checking for Taskflow v3.8.0")
+find_package(Taskflow 3.8.0 EXACT QUIET)
 
+if(Taskflow_FOUND)
+  message(STATUS "Found Taskflow v${Taskflow_VERSION}, using existing installation.")
+  # Use icicle_device as interface for TaskFlow headers
+  target_include_directories(icicle_device INTERFACE ${Taskflow_INCLUDE_DIRS})
+else()
+  message(STATUS "Taskflow not found locally. Fetching Taskflow v3.8.0 (CPU backend)")
+  include(FetchContent)
+  # Temporarily redefine set message log level to WARNING for fetched content
+  set(ORIG_CMAKE_MESSAGE_LOG_LEVEL "${CMAKE_MESSAGE_LOG_LEVEL}")
+  set(CMAKE_MESSAGE_LOG_LEVEL "WARNING")
 
-include(FetchContent)
-# Temporarily redefine set message log level to WARNING for fetched content
-set(ORIG_CMAKE_MESSAGE_LOG_LEVEL "${CMAKE_MESSAGE_LOG_LEVEL}")
-set(CMAKE_MESSAGE_LOG_LEVEL "WARNING")
+  FetchContent_Declare(
+    Taskflow
+    GIT_REPOSITORY https://github.com/taskflow/taskflow.git
+    GIT_TAG d8c49c64b4ee5015a3f1c0a42748fa7a2bf5529e # v3.8.0
+    GIT_SHALLOW TRUE
+  )
+  # Disable unnecessary components
+  set(TF_BUILD_BENCHMARKS OFF CACHE BOOL "Disable Taskflow benchmarks" FORCE)
+  set(TF_BUILD_PROFILER OFF CACHE BOOL "Disable Taskflow profiler" FORCE)
+  set(TF_BUILD_CUDA OFF CACHE BOOL "Disable Taskflow CUDA support" FORCE)
+  set(TF_BUILD_SYCL OFF CACHE BOOL "Disable Taskflow SYCL support" FORCE)
+  set(TF_BUILD_TESTS OFF CACHE BOOL "Disable Taskflow tests" FORCE)
+  set(TF_BUILD_EXAMPLES OFF CACHE BOOL "Disable Taskflow examples" FORCE)
 
-FetchContent_Declare(
-  Taskflow
-  GIT_REPOSITORY https://github.com/taskflow/taskflow.git
-  GIT_TAG v3.8.0
-  GIT_SHALLOW TRUE
-)
-# Disable unnecessary components
-set(TF_BUILD_BENCHMARKS OFF CACHE BOOL "Disable Taskflow benchmarks" FORCE)
-set(TF_BUILD_PROFILER OFF CACHE BOOL "Disable Taskflow profiler" FORCE)
-set(TF_BUILD_CUDA OFF CACHE BOOL "Disable Taskflow CUDA support" FORCE)
-set(TF_BUILD_SYCL OFF CACHE BOOL "Disable Taskflow SYCL support" FORCE)
-set(TF_BUILD_TESTS OFF CACHE BOOL "Disable Taskflow tests" FORCE)
-set(TF_BUILD_EXAMPLES OFF CACHE BOOL "Disable Taskflow examples" FORCE)
+  FetchContent_MakeAvailable(Taskflow)
+  # Use icicle_device as interface for TaskFlow headers
+  target_include_directories(icicle_device INTERFACE ${Taskflow_SOURCE_DIR})
 
-FetchContent_MakeAvailable(Taskflow)
-# Use icicle_device as interface for TaskFlow headers
-target_include_directories(icicle_device INTERFACE ${Taskflow_SOURCE_DIR})
-
-# Restore the original message log level
-set(CMAKE_MESSAGE_LOG_LEVEL "${ORIG_CMAKE_MESSAGE_LOG_LEVEL}")
+  # Restore the original message log level
+  set(CMAKE_MESSAGE_LOG_LEVEL "${ORIG_CMAKE_MESSAGE_LOG_LEVEL}")
+endif()
 
 # CPU backend is built directly into icicle library
 


### PR DESCRIPTION
## Describe the changes

This PR updates the cmake build process for CPU backend to only fetch Taskflow if it cannot be found on the system already.

## Describe the rational

Why is this change necessary?

This reduces build times for CPU backends considerably, especially in the CI

Does it increase performance?

Build performance
