### PR TITLE
docs: Complete Go example for multi-device setup

### DIFF
--- a/docs/docs/start/architecture/multi-device.md
+++ b/docs/docs/start/architecture/multi-device.md
@@ -48,7 +48,25 @@ let device = icicle_runtime::Device::new("CUDA", 0 /* =device_id*/);
 icicle_runtime::set_device(&device).unwrap();
 ```
 
-### Go (TODO)
+### Go
+
+```go
+import "github.com/ingonyama-zk/icicle/v3/wrappers/golang/runtime"
+
+// Set the device to the first CUDA GPU (GPU-0)
+device := runtime.CreateDevice("CUDA", 0)
+err := runtime.SetDevice(&device)
+if err != runtime.Success {
+    panic("Failed to set device")
+}
+
+// Alternatively, set the device to CPU
+cpuDevice := runtime.CreateDevice("CPU", 0)
+err = runtime.SetDevice(&cpuDevice)
+if err != runtime.Success {
+    panic("Failed to set CPU device")
+}
+```
 
 ## Best Practices
 


### PR DESCRIPTION
## Describe the changes

This PR completes the Go section in the multi-device documentation by removing the TODO placeholder and adding a comprehensive code example. The addition includes proper import statements, device creation for both CUDA and CPU, error handling, and follows the same pattern established by C++ and Rust examples.

## Describe the rational

Why is this change necessary?
The TODO in the Go section left Go developers without guidance on how to implement multi-device functionality using ICICLE's Go bindings. This creates documentation gaps and reduces developer experience for Go users.

Does it increase performance?
No, this is a documentation improvement that enables developers to properly utilize existing multi-device performance features in Go applications.

## Backend branches

Replace "main" with the branch this PR should work with

cuda-backend-branch: main

metal-backend-branch: main
