### PR TITLE
[FEAT] add method to get challenges from sumcheck's Fiat-Shamir

### DIFF
--- a/icicle/backend/cpu/include/cpu_sumcheck.h
+++ b/icicle/backend/cpu/include/cpu_sumcheck.h
@@ -24,6 +24,7 @@ namespace icicle {
       const CombineFunction<F>& combine_function,
       SumcheckTranscriptConfig<F>&& transcript_config,
       const SumcheckConfig& sumcheck_config,
+      F* challenge_vector /*out*/,
       SumcheckProof<F>& sumcheck_proof /*out*/) override
     {
       if (sumcheck_config.use_extension_field) {
@@ -71,6 +72,7 @@ namespace icicle {
         const int nof_tasks_per_worker = (nof_total_iterations + nof_workers - 1) / nof_workers; // round up
         F alpha =
           round_idx ? sumcheck_transcript.get_alpha(sumcheck_proof.get_round_polynomial(round_idx - 1)) : F::zero();
+        challenge_vector[round_idx] = alpha;
         for (int worker_idx = 0; worker_idx < nof_workers; ++worker_idx) {
           m_taskflow.emplace([&, worker_idx]() {
             const int start_element_idx = worker_idx * nof_tasks_per_worker;

--- a/icicle/include/icicle/backend/sumcheck_backend.h
+++ b/icicle/include/icicle/backend/sumcheck_backend.h
@@ -51,6 +51,7 @@ namespace icicle {
       const CombineFunction<F>& combine_function,
       SumcheckTranscriptConfig<F>&& transcript_config,
       const SumcheckConfig& sumcheck_config,
+      F* challenge_vector /*out*/,
       SumcheckProof<F>& sumcheck_proof /*out*/) = 0;
   };
 

--- a/icicle/include/icicle/sumcheck/sumcheck.h
+++ b/icicle/include/icicle/sumcheck/sumcheck.h
@@ -110,7 +110,7 @@ namespace icicle {
         mle_polynomials, mle_polynomial_size, claimed_sum, combine_function, std::move(transcript_config),
         sumcheck_config, const_cast<F*>(m_challenge_vector.data()), sumcheck_proof);
     }
-    F get_challenge_vector(int round_idx) { return m_challenge_vector[round_idx]; }
+    std::vector<F> get_challenge_vector() { return m_challenge_vector; }
 
     /**
      * @brief Verify an element against the Sumcheck round polynomial.

--- a/icicle/include/icicle/sumcheck/sumcheck.h
+++ b/icicle/include/icicle/sumcheck/sumcheck.h
@@ -102,10 +102,15 @@ namespace icicle {
                          << ", but " << total_nof_vars << " were given";
         return eIcicleError::INVALID_ARGUMENT;
       }
+
+      // Initialize challenge vector with the correct size based on MLE polynomial size
+      m_challenge_vector.resize(std::log2(mle_polynomial_size));
+
       return m_backend->get_proof(
         mle_polynomials, mle_polynomial_size, claimed_sum, combine_function, std::move(transcript_config),
-        sumcheck_config, sumcheck_proof);
+        sumcheck_config, const_cast<F*>(m_challenge_vector.data()), sumcheck_proof);
     }
+    F get_challenge_vector(int round_idx) { return m_challenge_vector[round_idx]; }
 
     /**
      * @brief Verify an element against the Sumcheck round polynomial.
@@ -158,6 +163,7 @@ namespace icicle {
   private:
     std::shared_ptr<SumcheckBackend<F>>
       m_backend; ///< Shared pointer to the backend responsible for Sumcheck operations.
+    mutable std::vector<F> m_challenge_vector;
 
     // Receive the polynomial in evaluation on x=0,1,2...
     // return the evaluation of the polynomial at x

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -951,11 +951,11 @@ TYPED_TEST(FieldTest, SumcheckGetChallengeVector)
 
     ASSERT_EQ(true, verification_pass);
 
-    ASSERT_EQ(prover_sumcheck.get_challenge_vector(0), TypeParam::zero());
+    std::vector<TypeParam> challenge_vector = prover_sumcheck.get_challenge_vector();
+    ASSERT_EQ(challenge_vector[0], TypeParam::zero());
 
     for (int i = 0; i < std::log2(mle_poly_size); i++) {
-      TypeParam challenge = prover_sumcheck.get_challenge_vector(i);
-      ICICLE_LOG_INFO << "challenge_vector[" << i << "] = " << challenge;
+      ICICLE_LOG_INFO << "challenge_vector[" << i << "] = " << challenge_vector[i];
     }
   };
   for (const auto& device : IcicleTestBase::s_registered_devices)

--- a/icicle/tests/test_field_api.cpp
+++ b/icicle/tests/test_field_api.cpp
@@ -881,6 +881,91 @@ TYPED_TEST(FieldTest, SumcheckSingleInputProgram)
   }
 }
 
+TYPED_TEST(FieldTest, SumcheckGetChallengeVector)
+{
+  int log_mle_poly_size = 13;
+  int mle_poly_size = 1 << log_mle_poly_size;
+  int nof_mle_poly = 4;
+
+  // generate inputs
+  std::vector<TypeParam*> mle_polynomials(nof_mle_poly);
+  for (int poly_i = 0; poly_i < nof_mle_poly; poly_i++) {
+    mle_polynomials[poly_i] = new TypeParam[mle_poly_size];
+    TypeParam::rand_host_many(mle_polynomials[poly_i], mle_poly_size);
+  }
+
+  // calculate the claimed sum
+  TypeParam claimed_sum = TypeParam::zero();
+  for (int element_i = 0; element_i < mle_poly_size; element_i++) {
+    const TypeParam a = mle_polynomials[0][element_i];
+    const TypeParam b = mle_polynomials[1][element_i];
+    const TypeParam c = mle_polynomials[2][element_i];
+    const TypeParam eq = mle_polynomials[3][element_i];
+    claimed_sum = claimed_sum + (a * b - c) * eq;
+  }
+
+  auto run = [&](
+               const std::string& dev_type, std::vector<TypeParam*>& mle_polynomials, const int mle_poly_size,
+               const TypeParam claimed_sum, const char* msg) {
+    Device dev = {dev_type, 0};
+    icicle_set_device(dev);
+
+    // ===== Prover side ======
+
+    // create transcript_config
+    SumcheckTranscriptConfig<TypeParam> transcript_config(
+      create_keccak_256_hash(), "labelA", "labelB", "LabelC", TypeParam::from(12));
+
+    ASSERT_NE(transcript_config.get_domain_separator_label().size(),
+              0); // assert label exists
+
+    std::ostringstream oss;
+    oss << dev_type << " " << msg;
+
+    // create sumcheck
+    auto prover_sumcheck = create_sumcheck<TypeParam>();
+
+    CombineFunction<TypeParam> combine_func(EQ_X_AB_MINUS_C);
+    SumcheckConfig sumcheck_config;
+    SumcheckProof<TypeParam> sumcheck_proof;
+
+    START_TIMER(sumcheck);
+    ICICLE_CHECK(prover_sumcheck.get_proof(
+      mle_polynomials, mle_poly_size, claimed_sum, combine_func, std::move(transcript_config), sumcheck_config,
+      sumcheck_proof));
+    END_TIMER(sumcheck, oss.str().c_str(), true);
+
+    ASSERT_EQ(transcript_config.get_domain_separator_label().size(), 0); // assert data was moved and not copied
+
+    // ===== Verifier side ======
+    // Note that the verifier is another machine and needs to regenerate the same transcript config.
+    // Also note that even if the same process, the transcript-config is moved since it may be large, so cannot reuse
+    // twice.
+    SumcheckTranscriptConfig<TypeParam> verifier_transcript_config(
+      create_keccak_256_hash(), "labelA", "labelB", "LabelC", TypeParam::from(12));
+    // create sumcheck
+    auto verifier_sumcheck = create_sumcheck<TypeParam>();
+    bool verification_pass = false;
+    ICICLE_CHECK(
+      verifier_sumcheck.verify(sumcheck_proof, claimed_sum, std::move(verifier_transcript_config), verification_pass));
+
+    ASSERT_EQ(true, verification_pass);
+
+    ASSERT_EQ(prover_sumcheck.get_challenge_vector(0), TypeParam::zero());
+
+    for (int i = 0; i < std::log2(mle_poly_size); i++) {
+      TypeParam challenge = prover_sumcheck.get_challenge_vector(i);
+      ICICLE_LOG_INFO << "challenge_vector[" << i << "] = " << challenge;
+    }
+  };
+  for (const auto& device : IcicleTestBase::s_registered_devices)
+    run(device, mle_polynomials, mle_poly_size, claimed_sum, "Sumcheck");
+
+  for (auto& mle_poly_ptr : mle_polynomials) {
+    delete[] mle_poly_ptr;
+  }
+}
+
 #endif // SUMCHECK
 
 #ifdef FRI


### PR DESCRIPTION
In sumcheck - add get_challenge_vector method to let users get the challenges generated by the transcript

cuda-backend-branch: get_sumchecks_challanges

metal-backend-branch: main
