### PR TITLE
docs (README.md): add link to go install-and-use examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This guide will help you get started with ICICLE in C++, Rust, and Go.
 > **Developers**: We highly recommend reading our [documentation](https://dev.ingonyama.com/) for a comprehensive explanation of ICICLE’s capabilities.
 
 > [!TIP]
-> Try out ICICLE by running some [examples] available in C++, Rust, and Go bindings. Check out our install-and-use examples in [C++](https://github.com/ingonyama-zk/icicle/tree/main/examples/c%2B%2B/install-and-use-icicle), [Rust](https://github.com/ingonyama-zk/icicle/tree/main/examples/rust/install-and-use-icicle) and [Go](TODO)
+> Try out ICICLE by running some [examples] available in C++, Rust, and Go bindings. Check out our install-and-use examples in [C++](https://github.com/ingonyama-zk/icicle/tree/main/examples/c%2B%2B/install-and-use-icicle), [Rust](https://github.com/ingonyama-zk/icicle/tree/main/examples/rust/install-and-use-icicle) and [Go](https://github.com/ingonyama-zk/icicle/tree/main/examples/golang/install-and-use-icicle)
 
 ### Prerequisites
 


### PR DESCRIPTION
## Describe the changes

This PR adds link to [go install-and-use examples](https://github.com/ingonyama-zk/icicle/tree/main/examples/golang/install-and-use-icicle)

## Describe the rational

Why is this change necessary?

We need to keep our README.md in updated version. 

Does it increase performance?

## Backend branches

Replace "main" with the branch this PR should work with

cuda-backend-branch: main

metal-backend-branch: main
