### PR TITLE
Fixed devdocs link licensing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ For help and support talk to our devs in our discord channel [#ICICLE](https://d
 
 ## License
 
-ICICLE frontend is distributed under the terms of the MIT License. If you want to learn more, check out our [developer documentation.](https://dev.ingonyama.com/start/architecture/install_gpu_backend#licensing)
+ICICLE frontend is distributed under the terms of the MIT License. If you want to learn more, check out our [developer documentation.](https://github.com/ingonyama-zk/icicle/blob/main/README.md?plain=1#L322-L323)
 
 > [!NOTE]
 > ICICLE backends, excluding the CPU backend, are distributed under a special license and are not covered by the MIT license.

--- a/README.md
+++ b/README.md
@@ -317,12 +317,12 @@ For help and support talk to our devs in our discord channel [#ICICLE](https://d
 
 ## License
 
-ICICLE frontend is distributed under the terms of the MIT License. If you want to learn more, check out our [developer documentation.](https://github.com/ingonyama-zk/icicle/blob/main/README.md?plain=1#L322-L323)
-
-> [!NOTE]
-> ICICLE backends, excluding the CPU backend, are distributed under a special license and are not covered by the MIT license.
+ICICLE frontend is distributed under the terms of the MIT License. 
 
 See [LICENSE-MIT][LMIT] for details.
+
+> [!NOTE]
+> ICICLE backends, excluding the CPU backend, are distributed under a special license and are not covered by the MIT license. If you want to learn more, check out our [developer documentation.](https://dev.ingonyama.com/start/architecture/install_gpu_backend#licensing)
 
 <!-- Begin Links -->
 [BLS12-381]: ./icicle/curves/


### PR DESCRIPTION
## Describe the changes

This PR (fixes, updates, adds, etc).....

## Describe the rational

Why is this change necessary?

Does it increase performance?

## Backend branches

Replace "main" with the branch this PR should work with

cuda-backend-branch: main

metal-backend-branch: main
