### PR TITLE
[FIX] Invalid memory access causes hang

### DIFF
--- a/wrappers/golang/runtime/tests/device_test.go
+++ b/wrappers/golang/runtime/tests/device_test.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/ingonyama-zk/icicle/v3/wrappers/golang/internal/test_helpers"
+	icicle_runtime "github.com/ingonyama-zk/icicle/v3/wrappers/golang/runtime"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func testGetDeviceType(suite *suite.Suite) {
+	expectedDeviceName := "test"
+	config := icicle_runtime.CreateDevice(expectedDeviceName, 0)
+	suite.Equal(expectedDeviceName, config.GetDeviceType())
+
+	expectedDeviceNameLong := "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
+	configLargeName := icicle_runtime.CreateDevice(expectedDeviceNameLong, 1)
+	suite.NotEqual(expectedDeviceNameLong, configLargeName.GetDeviceType())
+}
+
+func testRegisteredDevices(suite *suite.Suite) {
+	devices, _ := icicle_runtime.GetRegisteredDevices()
+	suite.Equal([]string{test_helpers.MAIN_DEVICE.GetDeviceType(), "CPU"}, devices)
+}
+
+func testDeviceProperties(suite *suite.Suite) {
+	_, err := icicle_runtime.GetDeviceProperties()
+	suite.Equal(icicle_runtime.Success, err)
+}
+
+func testActiveDevice(suite *suite.Suite) {
+	test_helpers.ActivateMainDevice()
+	activeDevice, err := icicle_runtime.GetActiveDevice()
+	suite.Equal(icicle_runtime.Success, err)
+	suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
+	memory1, err := icicle_runtime.GetAvailableMemory()
+	if err == icicle_runtime.ApiNotImplemented {
+		suite.T().Skipf("GetAvailableMemory() function is not implemented on %s device", test_helpers.MAIN_DEVICE.GetDeviceType())
+	}
+	suite.Equal(icicle_runtime.Success, err)
+	suite.Greater(memory1.Total, uint(0))
+	suite.Greater(memory1.Free, uint(0))
+}
+
+type DeviceTestSuite struct {
+	suite.Suite
+}
+
+func (s *DeviceTestSuite) TestGetDeviceType() {
+	s.Run("TestGetDeviceType", test_helpers.TestWrapper(&s.Suite, testGetDeviceType))
+	s.Run("TestIsDeviceAvailable", test_helpers.TestWrapper(&s.Suite, testIsDeviceAvailable))
+	s.Run("TestSetDefaultDevice", test_helpers.TestWrapper(&s.Suite, testSetDefaultDevice))
+	s.Run("TestRegisteredDevices", test_helpers.TestWrapper(&s.Suite, testRegisteredDevices))
+	s.Run("TestDeviceProperties", test_helpers.TestWrapper(&s.Suite, testDeviceProperties))
+	s.Run("TestActiveDevice", test_helpers.TestWrapper(&s.Suite, testActiveDevice))
+}
+
+func TestSuiteDevice(t *testing.T) {
+	suite.Run(t, new(DeviceTestSuite))
+}

--- a/wrappers/golang/runtime/tests/device_test_darwin.go
+++ b/wrappers/golang/runtime/tests/device_test_darwin.go
@@ -23,16 +23,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func testGetDeviceType(suite *suite.Suite) {
-	expectedDeviceName := "test"
-	config := icicle_runtime.CreateDevice(expectedDeviceName, 0)
-	suite.Equal(expectedDeviceName, config.GetDeviceType())
-
-	expectedDeviceNameLong := "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
-	configLargeName := icicle_runtime.CreateDevice(expectedDeviceNameLong, 1)
-	suite.NotEqual(expectedDeviceNameLong, configLargeName.GetDeviceType())
-}
-
 func testIsDeviceAvailable(suite *suite.Suite) {
 	test_helpers.ActivateMainDevice()
 	res, err := icicle_runtime.GetDeviceCount()
@@ -47,11 +37,11 @@ func testIsDeviceAvailable(suite *suite.Suite) {
 }
 
 func testSetDefaultDevice(suite *suite.Suite) {
-	test_helpers.ActivateMainDevice()
-
-	activeDevice, err := icicle_runtime.GetActiveDevice()
-	suite.Equal(icicle_runtime.Success, err)
-	suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	
+	defaultDevice := &test_helpers.MAIN_DEVICE
+	icicle_runtime.SetDefaultDevice(defaultDevice)
 
 	outerThreadID := C.get_pthread_id()
 	done := make(chan struct{}, 1)
@@ -70,7 +60,7 @@ func testSetDefaultDevice(suite *suite.Suite) {
 
 		activeDevice, err := icicle_runtime.GetActiveDevice()
 		suite.Equal(icicle_runtime.Success, err)
-		suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
+		suite.Equal(defaultDevice, *activeDevice)
 
 		close(done)
 	}()
@@ -78,45 +68,4 @@ func testSetDefaultDevice(suite *suite.Suite) {
 	<-done
 
 	icicle_runtime.SetDefaultDevice(&test_helpers.REFERENCE_DEVICE)
-}
-
-func testRegisteredDevices(suite *suite.Suite) {
-	devices, _ := icicle_runtime.GetRegisteredDevices()
-	suite.Equal([]string{test_helpers.MAIN_DEVICE.GetDeviceType(), "CPU"}, devices)
-}
-
-func testDeviceProperties(suite *suite.Suite) {
-	_, err := icicle_runtime.GetDeviceProperties()
-	suite.Equal(icicle_runtime.Success, err)
-}
-
-func testActiveDevice(suite *suite.Suite) {
-	test_helpers.ActivateMainDevice()
-	activeDevice, err := icicle_runtime.GetActiveDevice()
-	suite.Equal(icicle_runtime.Success, err)
-	suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
-	memory1, err := icicle_runtime.GetAvailableMemory()
-	if err == icicle_runtime.ApiNotImplemented {
-		suite.T().Skipf("GetAvailableMemory() function is not implemented on %s device", test_helpers.MAIN_DEVICE.GetDeviceType())
-	}
-	suite.Equal(icicle_runtime.Success, err)
-	suite.Greater(memory1.Total, uint(0))
-	suite.Greater(memory1.Free, uint(0))
-}
-
-type DeviceTestSuite struct {
-	suite.Suite
-}
-
-func (s *DeviceTestSuite) TestGetDeviceType() {
-	s.Run("TestGetDeviceType", test_helpers.TestWrapper(&s.Suite, testGetDeviceType))
-	s.Run("TestIsDeviceAvailable", test_helpers.TestWrapper(&s.Suite, testIsDeviceAvailable))
-	s.Run("TestSetDefaultDevice", test_helpers.TestWrapper(&s.Suite, testSetDefaultDevice))
-	s.Run("TestRegisteredDevices", test_helpers.TestWrapper(&s.Suite, testRegisteredDevices))
-	s.Run("TestDeviceProperties", test_helpers.TestWrapper(&s.Suite, testDeviceProperties))
-	s.Run("TestActiveDevice", test_helpers.TestWrapper(&s.Suite, testActiveDevice))
-}
-
-func TestSuiteDevice(t *testing.T) {
-	suite.Run(t, new(DeviceTestSuite))
 }

--- a/wrappers/golang/runtime/tests/device_test_darwin.go
+++ b/wrappers/golang/runtime/tests/device_test_darwin.go
@@ -39,7 +39,7 @@ func testIsDeviceAvailable(suite *suite.Suite) {
 func testSetDefaultDevice(suite *suite.Suite) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	
+
 	defaultDevice := &test_helpers.MAIN_DEVICE
 	icicle_runtime.SetDefaultDevice(defaultDevice)
 

--- a/wrappers/golang/runtime/tests/device_test_linux.go
+++ b/wrappers/golang/runtime/tests/device_test_linux.go
@@ -7,23 +7,12 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"testing"
 
 	"github.com/ingonyama-zk/icicle/v3/wrappers/golang/internal/test_helpers"
 	icicle_runtime "github.com/ingonyama-zk/icicle/v3/wrappers/golang/runtime"
 
 	"github.com/stretchr/testify/suite"
 )
-
-func testGetDeviceType(suite *suite.Suite) {
-	expectedDeviceName := "test"
-	config := icicle_runtime.CreateDevice(expectedDeviceName, 0)
-	suite.Equal(expectedDeviceName, config.GetDeviceType())
-
-	expectedDeviceNameLong := "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
-	configLargeName := icicle_runtime.CreateDevice(expectedDeviceNameLong, 1)
-	suite.NotEqual(expectedDeviceNameLong, configLargeName.GetDeviceType())
-}
 
 func testIsDeviceAvailable(suite *suite.Suite) {
 	test_helpers.ActivateMainDevice()
@@ -58,14 +47,11 @@ func testIsDeviceAvailable(suite *suite.Suite) {
 func testSetDefaultDevice(suite *suite.Suite) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	tidOuter := syscall.Gettid()
-
-	icicle_runtime.SetDefaultDevice(&test_helpers.MAIN_DEVICE)
-
-	activeDevice, err := icicle_runtime.GetActiveDevice()
-	suite.Equal(icicle_runtime.Success, err)
-	suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
-
+	
+	defaultDevice := test_helpers.MAIN_DEVICE
+	icicle_runtime.SetDefaultDevice(&defaultDevice)
+	
+	outerThreadID := syscall.Gettid()
 	done := make(chan struct{}, 1)
 	go func() {
 		runtime.LockOSThread()
@@ -73,7 +59,7 @@ func testSetDefaultDevice(suite *suite.Suite) {
 
 		// Ensure we are operating on an OS thread other than the original one
 		tidInner := syscall.Gettid()
-		for tidInner == tidOuter {
+		for tidInner == outerThreadID {
 			fmt.Println("Locked thread is the same as original, getting new locked thread")
 			runtime.UnlockOSThread()
 			runtime.LockOSThread()
@@ -82,7 +68,7 @@ func testSetDefaultDevice(suite *suite.Suite) {
 
 		activeDevice, err := icicle_runtime.GetActiveDevice()
 		suite.Equal(icicle_runtime.Success, err)
-		suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
+		suite.Equal(defaultDevice, *activeDevice)
 
 		close(done)
 	}()
@@ -90,45 +76,4 @@ func testSetDefaultDevice(suite *suite.Suite) {
 	<-done
 
 	icicle_runtime.SetDefaultDevice(&test_helpers.REFERENCE_DEVICE)
-}
-
-func testRegisteredDevices(suite *suite.Suite) {
-	devices, _ := icicle_runtime.GetRegisteredDevices()
-	suite.Equal([]string{test_helpers.MAIN_DEVICE.GetDeviceType(), "CPU"}, devices)
-}
-
-func testDeviceProperties(suite *suite.Suite) {
-	_, err := icicle_runtime.GetDeviceProperties()
-	suite.Equal(icicle_runtime.Success, err)
-}
-
-func testActiveDevice(suite *suite.Suite) {
-	test_helpers.ActivateMainDevice()
-	activeDevice, err := icicle_runtime.GetActiveDevice()
-	suite.Equal(icicle_runtime.Success, err)
-	suite.Equal(test_helpers.MAIN_DEVICE, *activeDevice)
-	memory1, err := icicle_runtime.GetAvailableMemory()
-	if err == icicle_runtime.ApiNotImplemented {
-		suite.T().Skipf("GetAvailableMemory() function is not implemented on %s device", test_helpers.MAIN_DEVICE.GetDeviceType())
-	}
-	suite.Equal(icicle_runtime.Success, err)
-	suite.Greater(memory1.Total, uint(0))
-	suite.Greater(memory1.Free, uint(0))
-}
-
-type DeviceTestSuite struct {
-	suite.Suite
-}
-
-func (s *DeviceTestSuite) TestGetDeviceType() {
-	s.Run("TestGetDeviceType", test_helpers.TestWrapper(&s.Suite, testGetDeviceType))
-	s.Run("TestIsDeviceAvailable", test_helpers.TestWrapper(&s.Suite, testIsDeviceAvailable))
-	s.Run("TestSetDefaultDevice", test_helpers.TestWrapper(&s.Suite, testSetDefaultDevice))
-	s.Run("TestRegisteredDevices", test_helpers.TestWrapper(&s.Suite, testRegisteredDevices))
-	s.Run("TestDeviceProperties", test_helpers.TestWrapper(&s.Suite, testDeviceProperties))
-	s.Run("TestActiveDevice", test_helpers.TestWrapper(&s.Suite, testActiveDevice))
-}
-
-func TestSuiteDevice(t *testing.T) {
-	suite.Run(t, new(DeviceTestSuite))
 }

--- a/wrappers/golang/runtime/tests/device_test_linux.go
+++ b/wrappers/golang/runtime/tests/device_test_linux.go
@@ -47,10 +47,10 @@ func testIsDeviceAvailable(suite *suite.Suite) {
 func testSetDefaultDevice(suite *suite.Suite) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	
+
 	defaultDevice := test_helpers.MAIN_DEVICE
 	icicle_runtime.SetDefaultDevice(&defaultDevice)
-	
+
 	outerThreadID := syscall.Gettid()
 	done := make(chan struct{}, 1)
 	go func() {

--- a/wrappers/golang/runtime/tests/memory_test.go
+++ b/wrappers/golang/runtime/tests/memory_test.go
@@ -11,15 +11,20 @@ import (
 
 func testMalloc(suite *suite.Suite) {
 	test_helpers.ActivateMainDevice()
-	_, err := runtime.Malloc(20)
+	mem, err := runtime.Malloc(20)
 	suite.Equal(runtime.Success, err, "Unable to allocate device memory due to %d", err)
+	runtime.Free(mem)
 }
 
 func testMallocAsync(suite *suite.Suite) {
 	test_helpers.ActivateMainDevice()
 	stream, _ := runtime.CreateStream()
-	_, err := runtime.MallocAsync(20, stream)
+	mem, err := runtime.MallocAsync(20, stream)
 	suite.Equal(runtime.Success, err, "Unable to allocate device memory due to %d", err)
+
+	runtime.FreeAsync(mem, stream)
+	runtime.SynchronizeStream(stream)
+	runtime.DestroyStream(stream)
 }
 
 func testFree(suite *suite.Suite) {
@@ -35,7 +40,7 @@ func testCopyFromToHost(suite *suite.Suite) {
 	test_helpers.ActivateMainDevice()
 	someInts := make([]int32, 1)
 	someInts[0] = 34
-	numBytes := uint(8)
+	numBytes := uint(4)
 	deviceMem, _ := runtime.Malloc(numBytes)
 	deviceMem, err := runtime.CopyToDevice(deviceMem, unsafe.Pointer(&someInts[0]), numBytes)
 	suite.Equal(runtime.Success, err, "Couldn't copy to device due to %v", err)
@@ -44,13 +49,14 @@ func testCopyFromToHost(suite *suite.Suite) {
 	_, err = runtime.CopyFromDevice(unsafe.Pointer(&someInts2[0]), deviceMem, numBytes)
 	suite.Equal(runtime.Success, err, "Couldn't copy to device due to %v", err)
 	suite.Equal(someInts, someInts2, "Elements of host slices do not match. Copying from/to host failed")
+	runtime.Free(deviceMem)
 }
 
 type MemoryTestSuite struct {
 	suite.Suite
 }
 
-func (s *MemoryTestSuite) TestMerkleTree() {
+func (s *MemoryTestSuite) TestMemory() {
 	s.Run("TestMalloc", test_helpers.TestWrapper(&s.Suite, testMalloc))
 	s.Run("TestMallocAsync", test_helpers.TestWrapper(&s.Suite, testMallocAsync))
 	s.Run("TestFree", test_helpers.TestWrapper(&s.Suite, testFree))


### PR DESCRIPTION
## Describe the changes

This PR fixes:
1. a hang in the Go memory tests when copying from device. The test was trying to copy more bytes than the source and destination sizes which caused a hang.
2. Fixes the naming of the Go memory tests
3. Go device tests actually run now.
4. Go device set default device test

