### PR TITLE
[FEAT] Add flattening utilities for polynomial slices into scalar slices

### DIFF
--- a/wrappers/rust/icicle-core/src/jl_projection/mod.rs
+++ b/wrappers/rust/icicle-core/src/jl_projection/mod.rs
@@ -369,6 +369,16 @@ macro_rules! impl_jl_projection_polyring_tests {
                 test_utilities::test_set_ref_device();
                 check_jl_projection_polyring::<$poly_type>();
             }
+
+            #[test]
+            fn test_polynomial_projection() {
+                initialize();
+                test_utilities::test_set_main_device();
+                // TODO uncomment when implemented for CUDA
+                // check_polynomial_projection::<$poly_type>();
+                test_utilities::test_set_ref_device();
+                check_polynomial_projection::<$poly_type>();
+            }
         }
     };
 }

--- a/wrappers/rust/icicle-core/src/polynomial_ring.rs
+++ b/wrappers/rust/icicle-core/src/polynomial_ring.rs
@@ -51,6 +51,34 @@ where
     unsafe { DeviceSlice::from_raw_parts(input.as_ptr() as *const P::Base, total) }
 }
 
+/// Reinterprets a mutable host slice of polynomials as a flat mutable slice of scalar coefficients.
+///
+/// # Safety
+/// Assumes device memory is laid out like `[P::Base; DEGREE]` per polynomial.
+/// Caller must ensure the slice is valid for mutation as `P::Base` elements.
+pub fn flatten_host_polynomials_mut<P>(input: &mut HostSlice<P>) -> &mut HostSlice<P::Base>
+where
+    P: PolynomialRing,
+    P::Base: FieldImpl,
+{
+    let total = input.len() * P::DEGREE;
+    unsafe { HostSlice::from_raw_parts_mut(input.as_mut_ptr() as *mut P::Base, total) }
+}
+
+/// Reinterprets a mutable device slice of polynomials as a flat mutable slice of scalar coefficients.
+///
+/// # Safety
+/// Assumes device memory is laid out like `[P::Base; DEGREE]` per polynomial.
+/// Assumes memory layout is compatible. Caller must ensure it is valid and exclusive.
+pub fn flatten_device_polynomials_mut<P>(input: &mut DeviceSlice<P>) -> &mut DeviceSlice<P::Base>
+where
+    P: PolynomialRing,
+    P::Base: FieldImpl,
+{
+    let total = input.len() * P::DEGREE;
+    unsafe { DeviceSlice::from_raw_parts_mut(input.as_mut_ptr() as *mut P::Base, total) }
+}
+
 #[macro_export]
 macro_rules! impl_polynomial_ring {
     ($polyring:ident, $base:ty, $degree:expr, $modulus_coeff:expr) => {

--- a/wrappers/rust/icicle-core/src/polynomial_ring.rs
+++ b/wrappers/rust/icicle-core/src/polynomial_ring.rs
@@ -158,11 +158,6 @@ macro_rules! test_polynomial_ring {
             }
 
             #[test]
-            fn test_vector_alloc() {
-                check_vector_alloc::<$type>();
-            }
-
-            #[test]
             fn test_flatten_slices() {
                 check_polyring_flatten_host_memory::<$type>();
                 check_polyring_flatten_device_memory::<$type>();

--- a/wrappers/rust/icicle-core/src/tests.rs
+++ b/wrappers/rust/icicle-core/src/tests.rs
@@ -208,12 +208,6 @@ where
     let poly = P::from_slice(&input);
     assert_eq!(poly.values(), input.as_slice());
 }
-
-pub fn check_vector_alloc<P: PolynomialRing>() {
-    let vec = vec![P::zero(); 10];
-    assert_eq!(vec.len(), 10);
-}
-
 /// Verifies that flattening a slice of polynomials yields a correctly sized,
 /// reinterpreted slice of base field elements.
 pub fn check_polyring_flatten_host_memory<P>()

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -250,6 +250,14 @@ impl<T> HostSlice<T> {
         self.0
             .iter_mut()
     }
+
+    pub unsafe fn from_raw_parts<'a>(ptr: *const T, len: usize) -> &'a HostSlice<T> {
+        &*(std::slice::from_raw_parts(ptr, len) as *const [T] as *const HostSlice<T>)
+    }
+
+    pub unsafe fn from_raw_parts_mut<'a>(ptr: *mut T, len: usize) -> &'a mut HostSlice<T> {
+        &mut *(std::slice::from_raw_parts_mut(ptr, len) as *mut [T] as *mut HostSlice<T>)
+    }
 }
 
 impl<T> DeviceSlice<T> {

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -354,6 +354,20 @@ impl<T> DeviceSlice<T> {
             .wrap()
         }
     }
+
+    /// # Safety
+    /// `ptr` must point to `len` contiguous elements in device memory.
+    /// The caller must ensure the memory is valid for the lifetime `'a` and not aliased.
+    pub unsafe fn from_raw_parts<'a>(ptr: *const T, len: usize) -> &'a DeviceSlice<T> {
+        &*(std::slice::from_raw_parts(ptr, len) as *const [T] as *const DeviceSlice<T>)
+    }
+
+    /// # Safety
+    /// `ptr` must point to `len` contiguous elements in device memory and be uniquely owned.
+    /// The caller must ensure the memory is valid for the lifetime `'a` and not aliased.
+    pub unsafe fn from_raw_parts_mut<'a>(ptr: *mut T, len: usize) -> &'a mut DeviceSlice<T> {
+        &mut *(std::slice::from_raw_parts_mut(ptr, len) as *mut [T] as *mut DeviceSlice<T>)
+    }
 }
 
 impl<T> DeviceVec<T> {


### PR DESCRIPTION
Some APIs operate on scalar elements rather than polynomials. To use them with polynomial data, we need to reinterpret polynomial slices as flat slices of their scalar coefficients.

This PR introduces four functions to safely flatten HostSlice and DeviceSlice—both mutable and immutable—into corresponding slices of scalar elements.

cuda-backend-branch: main
metal-backend-branch: main
