### PR TITLE
HostDevice memory API tweaks

### DIFF
--- a/docs/docs/icicle/migrate_from_v2.md
+++ b/docs/docs/icicle/migrate_from_v2.md
@@ -80,7 +80,7 @@ stream.synchronize().unwrap();
 use icicle_runtime::{IcicleStream, DeviceVec, HostSlice};
 
 let mut stream = IcicleStream::create().unwrap();
-let mut device_memory = DeviceVec::device_malloc(1024).unwrap();
+let mut device_memory = DeviceVec::malloc(1024);
 // Perform operations using IcicleStream and related APIs
 stream.synchronize().unwrap();
 ```

--- a/docs/docs/icicle/programmers_guide/rust.md
+++ b/docs/docs/icicle/programmers_guide/rust.md
@@ -88,7 +88,7 @@ Memory can be allocated on the active device using the `DeviceVec` API. This mem
 use icicle_runtime::memory::DeviceVec;
 
 // Allocate 1024 elements on the device
-let mut device_memory: DeviceVec<u8> = DeviceVec::<u8>::device_malloc(1024).unwrap();
+let mut device_memory: DeviceVec<u8> = DeviceVec::<u8>::malloc(1024);
 ```
 
 The memory is released when the `DeviceVec` object is dropped.
@@ -143,7 +143,7 @@ use icicle_runtime::memory::{DeviceVec, HostSlice};
 
 // Copy data from host to device
 let input = vec![1, 2, 3, 4];
-let mut d_mem = DeviceVec::<u32>::device_malloc(input.len()).unwrap();
+let mut d_mem = DeviceVec::<u32>::malloc(input.len()).unwrap();
 d_mem.copy_from_host(HostSlice::from_slice(&input)).unwrap();
 // OR
 d_mem.copy_from_host_async(HostSlice::from_slice(&input, &stream)).unwrap();

--- a/docs/docs/icicle/programmers_guide/rust.md
+++ b/docs/docs/icicle/programmers_guide/rust.md
@@ -251,10 +251,10 @@ fn main() {
 
     let mut msm_results = vec![G1Projective::zero(); 1];
     msm::msm(
-        HostSlice::from_slice(&scalars),
-        HostSlice::from_slice(&points),
+        scalars.into_slice(),
+        points.into_slice(),
         &MSMConfig::default(),
-        HostSlice::from_mut_slice(&mut msm_results[..]),
+        msm_results.into_slice_mut(),
     )
     .unwrap();
     println!("MSM result = {:?}", msm_results);

--- a/docs/docs/icicle/rust-bindings/msm.md
+++ b/docs/docs/icicle/rust-bindings/msm.md
@@ -73,10 +73,10 @@ fn main() {
 
     let mut msm_results = vec![G1Projective::zero(); 1];
     msm::msm(
-        HostSlice::from_slice(&scalars),
-        HostSlice::from_slice(&points),
+        scalars.into_slice(),
+        points.into_slice(),
         &MSMConfig::default(),
-        HostSlice::from_mut_slice(&mut msm_results[..]),
+        msm_results.into_slice_mut(),
     )
     .unwrap();
     println!("MSM result = {:?}", msm_results);

--- a/docs/docs/icicle/rust-bindings/ntt.md
+++ b/docs/docs/icicle/rust-bindings/ntt.md
@@ -67,7 +67,7 @@ The `NTTConfig` struct is a configuration object used to specify parameters for 
 // Setting Bn254 points and scalars
 println!("Generating random inputs on host for bn254...");
 let scalars = Bn254ScalarCfg::generate_random(size);
-let mut ntt_results = DeviceVec::<Bn254ScalarField>::device_malloc(size).unwrap();
+let mut ntt_results = DeviceVec::<Bn254ScalarField>::malloc(size);
 
 // constructing NTT domain
 initialize_domain(

--- a/docs/docs/icicle/rust-bindings/ntt.md
+++ b/docs/docs/icicle/rust-bindings/ntt.md
@@ -84,10 +84,10 @@ let cfg = ntt::NTTConfig::<Bn254ScalarField>::default();
 
 // Computing NTT
 ntt::ntt(
-    HostSlice::from_slice(&scalars),
+    scalars.into_slice(),
     ntt::NTTDir::kForward,
     &cfg,
-    &mut ntt_results[..],
+    ntt_results.into_slice_mut(),
 )
 .unwrap();
 ```

--- a/docs/docs/icicle/rust-bindings/polynomials.md
+++ b/docs/docs/icicle/rust-bindings/polynomials.md
@@ -130,7 +130,7 @@ Functions within the DensePolynomial API that deal with polynomial coefficients 
 
 ```rust
 // Assume `coeffs` could either be in host memory or CUDA device memory
-let coeffs: DeviceSlice<F> = DeviceVec::<F>::device_malloc(coeffs_len).unwrap();
+let coeffs: DeviceSlice<F> = DeviceVec::<F>::malloc(coeffs_len);
 let p_from_coeffs = PolynomialBabyBear::from_coeffs(&coeffs, coeffs.len());
 
 // Similarly for evaluations from roots of unity
@@ -231,7 +231,7 @@ f.eval_on_domain(HostSlice::from_slice(&domain), HostSlice::from_mut_slice(&mut 
 
 // Evaluate on roots-of-unity-domain
 let domain_log_size = 4;
-let mut device_evals = DeviceVec::<ScalarField>::device_malloc(1 << domain_log_size).unwrap();
+let mut device_evals = DeviceVec::<ScalarField>::malloc(1 << domain_log_size);
 f.eval_on_rou_domain(domain_log_size, &mut device_evals[..]);
 ```
 
@@ -243,7 +243,7 @@ Read or copy polynomial coefficients for further processing:
 let x_squared_coeff = f.get_coeff(2);  // Coefficient of x^2
 
 // Copy coefficients to a device-specific memory space
-let mut device_mem = DeviceVec::<Field>::device_malloc(coeffs.len()).unwrap();
+let mut device_mem = DeviceVec::<Field>::malloc(coeffs.len());
 f.copy_coeffs(0, &mut device_mem[..]);
 ```
 

--- a/docs/docs/icicle/rust-bindings/polynomials.md
+++ b/docs/docs/icicle/rust-bindings/polynomials.md
@@ -232,7 +232,7 @@ f.eval_on_domain(HostSlice::from_slice(&domain), HostSlice::from_mut_slice(&mut 
 // Evaluate on roots-of-unity-domain
 let domain_log_size = 4;
 let mut device_evals = DeviceVec::<ScalarField>::malloc(1 << domain_log_size);
-f.eval_on_rou_domain(domain_log_size, &mut device_evals[..]);
+f.eval_on_rou_domain(domain_log_size, device_evals.into_slice_mut());
 ```
 
 ### Read coefficients
@@ -244,7 +244,7 @@ let x_squared_coeff = f.get_coeff(2);  // Coefficient of x^2
 
 // Copy coefficients to a device-specific memory space
 let mut device_mem = DeviceVec::<Field>::malloc(coeffs.len());
-f.copy_coeffs(0, &mut device_mem[..]);
+f.copy_coeffs(0, device_mem.into_slice_mut());
 ```
 
 ### Polynomial Degree

--- a/docs/versioned_docs/version-2.8.0/icicle/rust-bindings/keccak.md
+++ b/docs/versioned_docs/version-2.8.0/icicle/rust-bindings/keccak.md
@@ -15,7 +15,7 @@ fn main() {
     let mut output = DeviceVec::<u8>::cuda_malloc(32).unwrap();
 
     let mut config = HashConfig::default();
-    keccak256(input, initial_data.len() as i32, 1, &mut output[..], &mut config).expect("Failed to execute keccak256 hashing");
+    keccak256(input, initial_data.len() as i32, 1, output.into_slice(), &mut config).expect("Failed to execute keccak256 hashing");
 
     let mut output_host = vec![0_u8; 32];
     output.copy_to_host(HostSlice::from_mut_slice(&mut output_host[..])).unwrap();

--- a/examples/rust/arkworks-icicle-conversions/src/main.rs
+++ b/examples/rust/arkworks-icicle-conversions/src/main.rs
@@ -311,10 +311,7 @@ fn main() {
     }
 
     // transfer points to device
-    let mut d_icicle_affine_points = DeviceVec::<IcicleAffine>::malloc(icicle_affine_points.len());
-    d_icicle_affine_points
-        .copy_from_host(icicle_affine_points.into_slice())
-        .unwrap();
+    let d_icicle_affine_points = DeviceVec::<IcicleAffine>::from_host_slice(&icicle_affine_points);
 
     let start = Instant::now();
     msm(

--- a/examples/rust/arkworks-icicle-conversions/src/main.rs
+++ b/examples/rust/arkworks-icicle-conversions/src/main.rs
@@ -13,7 +13,7 @@ use icicle_core::{
     traits::MontgomeryConvertible,
 };
 use icicle_runtime::{
-    memory::{DeviceVec, HostSlice},
+    memory::{DeviceVec, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut},
     stream::IcicleStream,
 };
 use rayon::prelude::*;
@@ -105,7 +105,7 @@ where
     // SAFETY: Reinterpreting Arkworks field elements as Icicle-specific scalars
     let icicle_scalars = unsafe { &mut *(ark_scalars as *mut _ as *mut [I]) };
 
-    let icicle_host_slice = HostSlice::from_mut_slice(&mut icicle_scalars[..]);
+    let icicle_host_slice = icicle_scalars.into_slice_mut();
 
     // Convert from Montgomery representation using the Icicle type's conversion method
     I::from_mont(icicle_host_slice, &IcicleStream::default());
@@ -122,7 +122,7 @@ where
     let icicle_scalars = unsafe { &*(ark_scalars as *const _ as *const [I]) };
 
     // Create a HostSlice from the mutable slice
-    let icicle_host_slice = HostSlice::from_slice(&icicle_scalars[..]);
+    let icicle_host_slice = icicle_scalars.into_slice();
 
     let mut icicle_scalars = DeviceVec::<I>::device_malloc_async(ark_scalars.len(), &stream).unwrap();
     icicle_scalars
@@ -281,9 +281,9 @@ fn main() {
     let start = Instant::now();
     msm(
         &icicle_scalars_dev,
-        HostSlice::from_slice(&icicle_affine_points),
+        icicle_affine_points.into_slice(),
         &MSMConfig::default(),
-        HostSlice::from_mut_slice(&mut icicle_msm_result),
+        icicle_msm_result.into_slice_mut(),
     )
     .unwrap();
     let duration = start.elapsed();
@@ -311,9 +311,9 @@ fn main() {
     }
 
     // transfer points to device
-    let mut d_icicle_affine_points = DeviceVec::<IcicleAffine>::device_malloc(icicle_affine_points.len()).unwrap();
+    let mut d_icicle_affine_points = DeviceVec::<IcicleAffine>::malloc(icicle_affine_points.len());
     d_icicle_affine_points
-        .copy_from_host(HostSlice::from_slice(&icicle_affine_points[..]))
+        .copy_from_host(icicle_affine_points.into_slice())
         .unwrap();
 
     let start = Instant::now();
@@ -321,7 +321,7 @@ fn main() {
         &icicle_scalars_dev,
         &d_icicle_affine_points,
         &MSMConfig::default(),
-        HostSlice::from_mut_slice(&mut icicle_msm_result),
+        icicle_msm_result.into_slice_mut(),
     )
     .unwrap();
     let duration = start.elapsed();

--- a/examples/rust/hash-and-merkle/src/main.rs
+++ b/examples/rust/hash-and-merkle/src/main.rs
@@ -7,7 +7,7 @@ use icicle_core::{
     traits::GenerateRandom,
 };
 use icicle_hash::{blake2s::Blake2s, keccak::Keccak256};
-use icicle_runtime::memory::HostSlice;
+use icicle_runtime::memory::{HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
 use std::time::Instant;
 
 /// Command-line argument parser
@@ -43,9 +43,9 @@ fn keccak_hash_example() {
 
     keccak_hasher
         .hash(
-            HostSlice::from_slice(input_str.as_bytes()),
+            input_str.as_bytes().into_slice(),
             &HashConfig::default(),
-            HostSlice::from_mut_slice(&mut output),
+            output.into_slice_mut(),
         )
         .unwrap();
 
@@ -60,9 +60,9 @@ fn keccak_hash_example() {
 
     keccak_hasher
         .hash(
-            HostSlice::from_slice(&input_field_elements),
+            input_field_elements.into_slice(),
             &HashConfig::default(),
-            HostSlice::from_mut_slice(&mut output),
+            output.into_slice_mut(),
         )
         .unwrap();
 
@@ -82,9 +82,9 @@ fn keccak_hash_example() {
     let start = Instant::now(); // Start timer for performance measurement
     keccak_hasher
         .hash(
-            HostSlice::from_slice(&input_field_elements_batch),
+            input_field_elements_batch.into_slice(),
             &HashConfig::default(),
-            HostSlice::from_mut_slice(&mut output),
+            output.into_slice_mut(),
         )
         .unwrap();
 
@@ -141,7 +141,7 @@ fn merkle_tree_example() {
     // Build the tree with the input data.
     let input = input_string.as_bytes();
     merkle_tree
-        .build(HostSlice::from_slice(&input), &config)
+        .build(input.into_slice(), &config)
         .unwrap();
 
     // Retrieve the root commitment (Merkle root).
@@ -154,7 +154,7 @@ fn merkle_tree_example() {
     // A Merkle proof contains sibling hashes that help verify a specific leaf's inclusion in the tree.
     let merkle_proof = merkle_tree
         .get_proof(
-            HostSlice::from_slice(&input),
+            input.into_slice(),
             3,    /* leaf index */
             true, /* pruned */
             &config,

--- a/examples/rust/install-and-use-icicle/src/main.rs
+++ b/examples/rust/install-and-use-icicle/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
     // Part 2 (cont.): Compute on GPU (from/to GPU memory)
     println!("Part 2: compute on GPU (from/to GPU memory): ");
     let mut output_gpu = DeviceVec::<ScalarField>::malloc(ntt_size);
-    let input_gpu = DeviceVec::<ScalarField>::from_host_vec(&input_cpu);
+    let input_gpu = DeviceVec::<ScalarField>::from_host_slice(&input_cpu);
     ntt(
         input_gpu.into_slice(),
         ntt::NTTDir::kForward,

--- a/examples/rust/install-and-use-icicle/src/main.rs
+++ b/examples/rust/install-and-use-icicle/src/main.rs
@@ -4,7 +4,7 @@ use icicle_core::{
     traits::GenerateRandom,
     field::PrimeField
 };
-use icicle_runtime::memory::{DeviceVec, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
+use icicle_runtime::memory::{DeviceVec, IntoIcicleSlice, IntoIcicleSliceMut};
 use icicle_runtime::{self, Device};
 
 fn main() {
@@ -61,11 +61,8 @@ fn main() {
 
     // Part 2 (cont.): Compute on GPU (from/to GPU memory)
     println!("Part 2: compute on GPU (from/to GPU memory): ");
-    let mut input_gpu = DeviceVec::<ScalarField>::malloc(ntt_size);
     let mut output_gpu = DeviceVec::<ScalarField>::malloc(ntt_size);
-    input_gpu
-        .copy_from_host(input_cpu.into_slice())
-        .expect("Failed to copy data to GPU");
+    let input_gpu = DeviceVec::<ScalarField>::from_host_vec(&input_cpu);
     ntt(
         input_gpu.into_slice(),
         ntt::NTTDir::kForward,
@@ -73,9 +70,8 @@ fn main() {
         output_gpu.into_slice_mut(),
     )
     .expect("NTT computation failed on GPU memory");
-    output_gpu
-        .copy_to_host(output_cpu.into_slice_mut())
-        .expect("Failed to copy data back to CPU");
+    let output_cpu = output_gpu.to_host_vec();
+
     println!("{:?}", output_cpu);
 
     // Part 3: Using both CPU and GPU to compute NTT (GPU) and inverse INTT (CPU)

--- a/examples/rust/msm/src/main.rs
+++ b/examples/rust/msm/src/main.rs
@@ -1,5 +1,5 @@
 use icicle_runtime::{
-    memory::{DeviceVec, HostSlice},
+    memory::{DeviceVec, IntoIcicleSlice, IntoIcicleSliceMut},
     stream::IcicleStream,
 };
 
@@ -66,17 +66,17 @@ fn main() {
         );
 
         // Setting Bn254 points and scalars
-        let points = HostSlice::from_slice(&upper_points[..size]);
-        let g2_points = HostSlice::from_slice(&g2_upper_points[..size]);
-        let scalars = HostSlice::from_slice(&upper_scalars[..size]);
+        let points = upper_points[..size].into_slice();
+        let g2_points = g2_upper_points[..size].into_slice();
+        let scalars = upper_scalars[..size].into_slice();
 
         // Setting bls12377 points and scalars
-        let points_bls12377 = HostSlice::from_slice(&upper_points_bls12377[..size]);
-        let scalars_bls12377 = HostSlice::from_slice(&upper_scalars_bls12377[..size]);
+        let points_bls12377 = upper_points_bls12377[..size].into_slice();
+        let scalars_bls12377 = upper_scalars_bls12377[..size].into_slice();
 
         println!("Configuring bn254 MSM...");
-        let mut msm_results = DeviceVec::<G1Projective>::device_malloc(1).unwrap();
-        let mut g2_msm_results = DeviceVec::<G2Projective>::device_malloc(1).unwrap();
+        let mut msm_results = DeviceVec::<G1Projective>::malloc(1);
+        let mut g2_msm_results = DeviceVec::<G2Projective>::malloc(1);
         let mut stream = IcicleStream::create().unwrap();
         let mut g2_stream = IcicleStream::create().unwrap();
         let mut cfg = msm::MSMConfig::default();
@@ -87,52 +87,36 @@ fn main() {
         g2_cfg.is_async = true;
 
         println!("Configuring bls12377 MSM...");
-        let mut msm_results_bls12377 = DeviceVec::<BLS12377G1Projective>::device_malloc(1).unwrap();
+        let mut msm_results_bls12377 = DeviceVec::<BLS12377G1Projective>::malloc(1);
         let mut stream_bls12377 = IcicleStream::create().unwrap();
         let mut cfg_bls12377 = msm::MSMConfig::default();
         cfg_bls12377.stream_handle = *stream_bls12377;
         cfg_bls12377.is_async = true;
 
         println!("Executing bn254 MSM on device...");
-        msm::msm(scalars, points, &cfg, &mut msm_results[..]).unwrap();
-        msm::msm(scalars, g2_points, &g2_cfg, &mut g2_msm_results[..]).unwrap();
+        msm::msm(scalars, points, &cfg, msm_results.into_slice_mut()).unwrap();
+        msm::msm(scalars, g2_points, &g2_cfg, g2_msm_results.into_slice_mut()).unwrap();
 
         println!("Executing bls12377 MSM on device...");
-        msm::msm(
-            scalars_bls12377,
-            points_bls12377,
-            &cfg_bls12377,
-            &mut msm_results_bls12377[..],
-        )
-        .unwrap();
+        msm::msm(scalars_bls12377, points_bls12377, &cfg_bls12377, msm_results_bls12377.into_slice_mut()).unwrap();
 
         println!("Moving results to host...");
-        let mut msm_host_result = vec![G1Projective::zero(); 1];
-        let mut g2_msm_host_result = vec![G2Projective::zero(); 1];
-        let mut msm_host_result_bls12377 = vec![BLS12377G1Projective::zero(); 1];
-
         stream
             .synchronize()
             .unwrap();
-        msm_results
-            .copy_to_host(HostSlice::from_mut_slice(&mut msm_host_result[..]))
-            .unwrap();
+        let msm_host_result = msm_results.to_host_vec();
         println!("bn254 result: {:#?}", msm_host_result);
 
         g2_stream
             .synchronize()
             .unwrap();
-        g2_msm_results
-            .copy_to_host(HostSlice::from_mut_slice(&mut g2_msm_host_result[..]))
-            .unwrap();
+        let g2_msm_host_result = g2_msm_results.to_host_vec();
         println!("G2 bn254 result: {:#?}", g2_msm_host_result);
 
         stream_bls12377
             .synchronize()
             .unwrap();
-        msm_results_bls12377
-            .copy_to_host(HostSlice::from_mut_slice(&mut msm_host_result_bls12377[..]))
-            .unwrap();
+        let msm_host_result_bls12377 = msm_results_bls12377.to_host_vec();
         println!("bls12377 result: {:#?}", msm_host_result_bls12377);
 
         println!("Cleaning up bn254...");

--- a/examples/rust/ntt/Cargo.toml
+++ b/examples/rust/ntt/Cargo.toml
@@ -8,6 +8,10 @@ icicle-runtime = { path = "../../../wrappers/rust/icicle-runtime" }
 icicle-core = { path = "../../../wrappers/rust/icicle-core" }
 icicle-bn254 = { path = "../../../wrappers/rust/icicle-curves/icicle-bn254" }
 icicle-bls12-377 = { path = "../../../wrappers/rust/icicle-curves/icicle-bls12-377" }
+ark-bn254 = "0.4.0"
+ark-bls12-377 = "0.4.0"
+ark-ff = "0.4.0"
+ark-poly = "0.4.0"
 
 clap = { version = "<=4.4.12", features = ["derive"] }
 

--- a/examples/rust/ntt/README.md
+++ b/examples/rust/ntt/README.md
@@ -24,7 +24,7 @@ In this example we use the `BN254` and `BLS12377` fields.
 3. Set up the domain.
 4. Configure NTT
 5. Execute NTT on-device
-6. Move the result on host
+6. Move the result to host
 7. Compare results with arkworks
 
 Running the example:

--- a/examples/rust/ntt/src/main.rs
+++ b/examples/rust/ntt/src/main.rs
@@ -94,10 +94,10 @@ fn main() {
     println!("Executing bn254 NTT on device...");
     let start = Instant::now();
     ntt::ntt(
-        scalars.into_icicle_slice(),
+        scalars.into_slice(),
         ntt::NTTDir::kForward,
         &cfg,
-        ntt_results.into_icicle_slice_mut(),
+        ntt_results.into_slice_mut(),
     )
     .unwrap();
     println!(
@@ -112,7 +112,7 @@ fn main() {
     assert_ne!(host_bn254_results, scalars); // check that the results are not the same as the inputs
 
     ntt::ntt_inplace(
-        scalars.into_icicle_slice_mut(),
+        scalars.into_slice_mut(),
         ntt::NTTDir::kForward,
         &cfg,
     )
@@ -124,10 +124,10 @@ fn main() {
     println!("Executing bls12377 NTT on device...");
     let start = Instant::now();
     ntt::ntt(
-        scalars_bls12377.into_icicle_slice(),
+        scalars_bls12377.into_slice(),
         ntt::NTTDir::kForward,
         &cfg_bls12377,
-        ntt_results_bls12377.into_icicle_slice_mut(),
+        ntt_results_bls12377.into_slice_mut(),
     )
     .unwrap();
     println!(
@@ -141,7 +141,7 @@ fn main() {
     assert_ne!(host_bls12377_results, scalars_bls12377); // check that the results are not the same as the inputs
 
     ntt::ntt_inplace(
-        scalars_bls12377.into_icicle_slice_mut(),
+        scalars_bls12377.into_slice_mut(),
         ntt::NTTDir::kForward,
         &cfg_bls12377,
     )

--- a/examples/rust/ntt/src/main.rs
+++ b/examples/rust/ntt/src/main.rs
@@ -1,7 +1,7 @@
 use icicle_bls12_377::curve::ScalarField as BLS12377ScalarField;
 use icicle_bn254::curve::ScalarField;
 use icicle_core::field::PrimeField;
-use icicle_runtime::memory::{DeviceVec, HostSlice};
+use icicle_runtime::memory::{DeviceVec, HostOrDeviceSlice, HostSlice};
 
 use clap::Parser;
 use icicle_core::{
@@ -10,6 +10,13 @@ use icicle_core::{
 };
 use std::convert::TryInto;
 use std::time::Instant;
+
+// Add Arkworks imports for comparison
+use ark_bn254::Fr as ArkBn254Fr;
+use ark_bls12_377::Fr as ArkBls12377Fr;
+use ark_ff::{BigInteger, PrimeField as ArkPrimeField};
+use ark_poly::domain::Radix2EvaluationDomain;
+use ark_poly::EvaluationDomain;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -32,6 +39,23 @@ fn try_load_and_set_backend_device(args: &Args) {
     icicle_runtime::set_device(&device).unwrap();
 }
 
+// Add a small extension trait that exposes a convenient one-liner for moving data back to the host.
+trait DeviceVecExt<T: PrimeField + Copy> {
+    /// Convenience helper that copies the `DeviceVec` contents back to the host and returns them
+    /// as a `Vec`.
+    fn to_host_vec(&self) -> Vec<T>;
+}
+
+impl<T: PrimeField + Copy> DeviceVecExt<T> for DeviceVec<T> {
+    fn to_host_vec(&self) -> Vec<T> {
+        let mut host_vec = vec![T::zero(); self.len()];
+        self
+            .copy_to_host(HostSlice::from_mut_slice(&mut host_vec[..]))
+            .unwrap();
+        host_vec
+    }
+}
+
 fn main() {
     let args = Args::parse();
     println!("{:?}", args);
@@ -48,12 +72,14 @@ fn main() {
 
     // Setting Bn254 points and scalars
     println!("Generating random inputs on host for bn254...");
-    let scalars = ScalarField::generate_random(size);
+    let mut scalars = ScalarField::generate_random(size);
+    let scalars_orig = scalars.clone();
     let mut ntt_results = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
 
     // Setting bls12377 points and scalars
     println!("Generating random inputs on host for bls12377...");
-    let scalars_bls12377 = BLS12377ScalarField::generate_random(size);
+    let mut scalars_bls12377 = BLS12377ScalarField::generate_random(size);
+    let scalars_bls12377_orig = scalars_bls12377.clone();
     let mut ntt_results_bls12377 = DeviceVec::<BLS12377ScalarField>::device_malloc(size).unwrap();
 
     println!("Setting up bn254 Domain...");
@@ -98,6 +124,20 @@ fn main() {
             .as_micros()
     );
 
+    println!("Moving results to host...");
+    let host_bn254_results = ntt_results.to_host_vec();
+    assert_ne!(host_bn254_results, scalars); // check that the results are not the same as the inputs
+
+    ntt::ntt_inplace(
+        HostSlice::from_mut_slice(&mut scalars),
+        ntt::NTTDir::kForward,
+        &cfg,
+    )
+    .unwrap();
+
+    assert_eq!(host_bn254_results, scalars); // check that the results are the same as the inputs after inplace
+
+    //==================== BLS12-377 ====================
     println!("Executing bls12377 NTT on device...");
     let start = Instant::now();
     ntt::ntt(
@@ -114,14 +154,59 @@ fn main() {
             .as_micros()
     );
 
-    println!("Moving results to host...");
-    let mut host_bn254_results = vec![ScalarField::zero(); size];
-    ntt_results
-        .copy_to_host(HostSlice::from_mut_slice(&mut host_bn254_results[..]))
-        .unwrap();
+    let host_bls12377_results = ntt_results_bls12377.to_host_vec();
+    assert_ne!(host_bls12377_results, scalars_bls12377); // check that the results are not the same as the inputs
 
-    let mut host_bls12377_results = vec![BLS12377ScalarField::zero(); size];
-    ntt_results_bls12377
-        .copy_to_host(HostSlice::from_mut_slice(&mut host_bls12377_results[..]))
-        .unwrap();
+    ntt::ntt_inplace(
+        HostSlice::from_mut_slice(&mut scalars_bls12377),
+        ntt::NTTDir::kForward,
+        &cfg_bls12377,
+    )
+    .unwrap();
+
+    assert_eq!(host_bls12377_results, scalars_bls12377);
+
+    //==================== Arkworks comparison ====================
+    println!("Comparing results with Arkworks...");
+    // BN254
+    let mut ark_bn_data: Vec<ArkBn254Fr> = scalars_orig
+        .iter()
+        .map(|x| {
+            let bytes = x.to_bytes_le();
+            ArkBn254Fr::from_le_bytes_mod_order(bytes.as_slice())
+        })
+        .collect();
+    let domain_bn = Radix2EvaluationDomain::<ArkBn254Fr>::new(size).unwrap();
+    domain_bn.fft_in_place(&mut ark_bn_data);
+    let ark_bn_as_icicle: Vec<ScalarField> = ark_bn_data
+        .iter()
+        .map(|x| {
+            let bytes = x.into_bigint().to_bytes_le();
+            ScalarField::from_bytes_le(bytes.as_slice())
+        })
+        .collect();
+    assert_eq!(ark_bn_as_icicle, host_bn254_results);
+
+    // BLS12-377
+    let mut ark_bls_data: Vec<ArkBls12377Fr> = scalars_bls12377_orig
+        .iter()
+        .map(|x| {
+            let bytes = x.to_bytes_le();
+            ArkBls12377Fr::from_le_bytes_mod_order(bytes.as_slice())
+        })
+        .collect();
+    let domain_bls = Radix2EvaluationDomain::<ArkBls12377Fr>::new(size).unwrap();
+    domain_bls.fft_in_place(&mut ark_bls_data);
+    let ark_bls_as_icicle: Vec<BLS12377ScalarField> = ark_bls_data
+        .iter()
+        .map(|x| {
+            let bytes = x.into_bigint().to_bytes_le();
+            BLS12377ScalarField::from_bytes_le(bytes.as_slice())
+        })
+        .collect();
+    assert_eq!(ark_bls_as_icicle, host_bls12377_results);
+
+    println!("All comparisons with Arkworks passed ✅");
+
+    println!("Done!");
 }

--- a/examples/rust/polynomials/src/main.rs
+++ b/examples/rust/polynomials/src/main.rs
@@ -3,7 +3,7 @@ use icicle_babybear::polynomials::DensePolynomial as PolynomialBabyBear;
 use icicle_bn254::curve::ScalarField as Bn254ScalarField;
 use icicle_bn254::polynomials::DensePolynomial as PolynomialBn254;
 
-use icicle_runtime::memory::{DeviceVec, HostSlice};
+use icicle_runtime::memory::{DeviceVec, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
 
 use icicle_core::field::PrimeField;
 use icicle_core::{
@@ -59,9 +59,9 @@ where
     println!("Randomizing polynomial of size {} (from_coeffs: {})", size, from_coeffs);
     let coeffs_or_evals = P::Field::generate_random(size);
     let p = if from_coeffs {
-        P::from_coeffs(HostSlice::from_slice(&coeffs_or_evals), size)
+        P::from_coeffs(coeffs_or_evals.into_slice(), size)
     } else {
-        P::from_rou_evals(HostSlice::from_slice(&coeffs_or_evals), size)
+        P::from_rou_evals(coeffs_or_evals.into_slice(), size)
     };
     p
 }
@@ -116,9 +116,9 @@ fn main() {
 
     // Evaluate on domain
     let host_domain = [five, Bn254ScalarField::from_u32(30)];
-    let mut device_image = DeviceVec::<Bn254ScalarField>::device_malloc(host_domain.len()).unwrap();
+    let mut device_image = DeviceVec::<Bn254ScalarField>::malloc(host_domain.len());
     println!("Evaluating t1(x) on domain {:?}", host_domain);
-    t1.eval_on_domain(HostSlice::from_slice(&host_domain), &mut device_image[..]); // for NTT use eval_on_rou_domain()
+    t1.eval_on_domain(host_domain.into_slice(), device_image.into_slice_mut()); // for NTT use eval_on_rou_domain()
 
     // Slicing
     println!("Performing slicing operations on h");

--- a/examples/rust/poseidon2/src/main.rs
+++ b/examples/rust/poseidon2/src/main.rs
@@ -6,7 +6,7 @@ use icicle_core::{
     poseidon2::Poseidon2,
 };
 use icicle_m31::field::ScalarField as M31Field;
-use icicle_runtime::memory::HostSlice;
+use icicle_runtime::memory::{HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
 use rand::{random, Rng};
 use std::convert::TryInto;
 
@@ -34,10 +34,10 @@ fn try_load_and_set_backend_device(args: &Args) {
 }
 
 pub fn hash_test<F: PrimeField>(test_vec: Vec<F>, config: HashConfig, hash: Hasher) {
-    let input_slice = HostSlice::from_slice(&test_vec);
+    let input_slice = test_vec.into_slice();
     let out_init: F = F::zero();
     let mut binding = [out_init];
-    let out_init_slice = HostSlice::from_mut_slice(&mut binding);
+    let out_init_slice = binding.into_slice_mut();
     hash.hash(input_slice, &config, out_init_slice)
         .unwrap();
     println!(
@@ -64,7 +64,7 @@ pub fn compute_binary_tree<F: PrimeField>(
         .chain(std::iter::repeat(&compress).take(tree_height - 1))
         .collect();
     //binary tree
-    let vec_slice: &mut HostSlice<F> = HostSlice::from_mut_slice(&mut test_vec[..]);
+    let vec_slice = test_vec.into_slice_mut();
     let merkle_tree: MerkleTree = MerkleTree::new(&layer_hashes, leaf_size, 0).unwrap();
 
     let start = Instant::now();
@@ -209,7 +209,7 @@ pub fn main() {
     println!("Generated random vector of size {:?}", nof_elements);
     //to use later for merkle proof
     let mut binding = test_vec.clone();
-    let test_vec_slice = HostSlice::from_mut_slice(&mut binding);
+    let test_vec_slice = binding.into_slice_mut();
     //define hash and compression functions (both t-->1 arity)
     let hasher: Hasher = Poseidon2::new::<M31Field>(
         poseidon_state_size // t-->1

--- a/wrappers/rust/icicle-core/src/balanced_decomposition/tests.rs
+++ b/wrappers/rust/icicle-core/src/balanced_decomposition/tests.rs
@@ -19,7 +19,7 @@ where
 
     for base in bases {
         let digits_per_element = balanced_decomposition::count_digits::<F>(base);
-        let mut decomposed = DeviceVec::<F>::device_malloc((total_size * digits_per_element) as usize).unwrap();
+        let mut decomposed = DeviceVec::<F>::malloc((total_size * digits_per_element) as usize);
 
         balanced_decomposition::decompose::<F>(HostSlice::from_slice(&input), &mut decomposed[..], base, &cfg).unwrap();
         // In C++ tests we also check here that the digits are in the correct range. Skipping this check here.

--- a/wrappers/rust/icicle-core/src/balanced_decomposition/tests.rs
+++ b/wrappers/rust/icicle-core/src/balanced_decomposition/tests.rs
@@ -23,7 +23,8 @@ where
 
         balanced_decomposition::decompose::<F>(input.into_slice(), decomposed.into_slice_mut(), base, &cfg).unwrap();
         // In C++ tests we also check here that the digits are in the correct range. Skipping this check here.
-        balanced_decomposition::recompose::<F>(decomposed.into_slice(), recomposed.into_slice_mut(), base, &cfg).unwrap();
+        balanced_decomposition::recompose::<F>(decomposed.into_slice(), recomposed.into_slice_mut(), base, &cfg)
+            .unwrap();
         assert_eq!(input, recomposed);
     }
 }

--- a/wrappers/rust/icicle-core/src/balanced_decomposition/tests.rs
+++ b/wrappers/rust/icicle-core/src/balanced_decomposition/tests.rs
@@ -1,6 +1,6 @@
 use crate::{balanced_decomposition, field::PrimeField, traits::GenerateRandom, vec_ops::VecOpsConfig};
 
-use icicle_runtime::memory::{DeviceVec, HostSlice};
+use icicle_runtime::memory::{DeviceVec, IntoIcicleSlice, IntoIcicleSliceMut};
 
 pub fn check_balanced_decomposition<F>()
 where
@@ -21,10 +21,9 @@ where
         let digits_per_element = balanced_decomposition::count_digits::<F>(base);
         let mut decomposed = DeviceVec::<F>::malloc((total_size * digits_per_element) as usize);
 
-        balanced_decomposition::decompose::<F>(HostSlice::from_slice(&input), &mut decomposed[..], base, &cfg).unwrap();
+        balanced_decomposition::decompose::<F>(input.into_slice(), decomposed.into_slice_mut(), base, &cfg).unwrap();
         // In C++ tests we also check here that the digits are in the correct range. Skipping this check here.
-        balanced_decomposition::recompose::<F>(&decomposed[..], HostSlice::from_mut_slice(&mut recomposed), base, &cfg)
-            .unwrap();
+        balanced_decomposition::recompose::<F>(decomposed.into_slice(), recomposed.into_slice_mut(), base, &cfg).unwrap();
         assert_eq!(input, recomposed);
     }
 }

--- a/wrappers/rust/icicle-core/src/curve.rs
+++ b/wrappers/rust/icicle-core/src/curve.rs
@@ -4,7 +4,7 @@ use icicle_runtime::{errors::eIcicleError, memory::HostOrDeviceSlice, stream::Ic
 use std::fmt::Debug;
 use std::ops::{Add, Mul, Sub};
 
-pub trait Curve: Debug + PartialEq + Copy + Clone {
+pub trait Curve: Debug + PartialEq + Copy + Clone + Default {
     type BaseField: PrimeField;
     type ScalarField: PrimeField + MontgomeryConvertible + GenerateRandom;
 
@@ -43,7 +43,7 @@ pub trait Curve: Debug + PartialEq + Copy + Clone {
 }
 
 /// A [projective](https://hyperelliptic.org/EFD/g1p/auto-shortw-projective.html) elliptic curve point.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 #[repr(C)]
 pub struct Projective<C: Curve> {
     pub x: C::BaseField,
@@ -52,7 +52,7 @@ pub struct Projective<C: Curve> {
 }
 
 /// An [affine](https://hyperelliptic.org/EFD/g1p/auto-shortw.html) elliptic curve point.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 #[repr(C)]
 pub struct Affine<C: Curve> {
     pub x: C::BaseField,
@@ -211,7 +211,7 @@ macro_rules! impl_curve {
         $affine_type:ident,
         $projective_type:ident
     ) => {
-        #[derive(Debug, PartialEq, Copy, Clone)]
+        #[derive(Debug, PartialEq, Copy, Clone, Default)]
         pub struct $curve {}
 
         pub type $affine_type = Affine<$curve>;

--- a/wrappers/rust/icicle-core/src/curve.rs
+++ b/wrappers/rust/icicle-core/src/curve.rs
@@ -328,7 +328,7 @@ macro_rules! impl_curve {
                 let mut res = vec![$projective_type::zero(); size];
                 unsafe {
                     $curve_prefix_ident::generate_projective_points(
-                        &mut res[..] as *mut _ as *mut $projective_type,
+                        res.into_slice_mut() as *mut _ as *mut $projective_type,
                         size,
                     )
                 };

--- a/wrappers/rust/icicle-core/src/curve.rs
+++ b/wrappers/rust/icicle-core/src/curve.rs
@@ -338,7 +338,10 @@ macro_rules! impl_curve {
             fn generate_random_affine_points(size: usize) -> Vec<$affine_type> {
                 let mut res = vec![$affine_type::zero(); size];
                 unsafe {
-                    $curve_prefix_ident::generate_affine_points(res.into_slice_mut() as *mut _ as *mut $affine_type, size)
+                    $curve_prefix_ident::generate_affine_points(
+                        res.into_slice_mut() as *mut _ as *mut $affine_type,
+                        size,
+                    )
                 };
                 res
             }

--- a/wrappers/rust/icicle-core/src/curve.rs
+++ b/wrappers/rust/icicle-core/src/curve.rs
@@ -338,7 +338,7 @@ macro_rules! impl_curve {
             fn generate_random_affine_points(size: usize) -> Vec<$affine_type> {
                 let mut res = vec![$affine_type::zero(); size];
                 unsafe {
-                    $curve_prefix_ident::generate_affine_points(&mut res[..] as *mut _ as *mut $affine_type, size)
+                    $curve_prefix_ident::generate_affine_points(res.into_slice_mut() as *mut _ as *mut $affine_type, size)
                 };
                 res
             }

--- a/wrappers/rust/icicle-core/src/ecntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ecntt/mod.rs
@@ -171,7 +171,7 @@ macro_rules! impl_ecntt_bench {
         use icicle_runtime::{
             device::Device,
             get_active_device, is_device_available,
-            memory::{HostOrDeviceSlice, HostSlice},
+            memory::{HostOrDeviceSlice, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut},
             runtime::load_backend_from_env_or_default,
             set_device,
         };
@@ -237,9 +237,9 @@ macro_rules! impl_ecntt_bench {
                     }
 
                     let points = C::generate_random_projective_points(test_size);
-                    let points = HostSlice::from_slice(&points);
+                    let points = points.into_slice();
                     let mut batch_ntt_result = vec![Projective::<C>::zero(); full_size];
-                    let batch_ntt_result = HostSlice::from_mut_slice(&mut batch_ntt_result);
+                    let batch_ntt_result = batch_ntt_result.into_slice_mut();
                     let mut config = NTTConfig::default();
                     config.ordering = Ordering::kNN;
                     config.batch_size = batch_size as i32;

--- a/wrappers/rust/icicle-core/src/field.rs
+++ b/wrappers/rust/icicle-core/src/field.rs
@@ -357,7 +357,7 @@ macro_rules! impl_generate_random {
                 }
 
                 let mut res = vec![$field::zero(); size];
-                unsafe { $generate_random_function_name(&mut res[..] as *mut _ as *mut $field, size) };
+                unsafe { $generate_random_function_name(res.into_slice_mut() as *mut _ as *mut $field, size) };
                 res
             }
         }

--- a/wrappers/rust/icicle-core/src/field.rs
+++ b/wrappers/rust/icicle-core/src/field.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display};
 
 pub trait PrimeField:
-    Display + Debug + PartialEq + Copy + Clone + Into<Self::Limbs> + From<Self::Limbs> + Send + Sync
+    Display + Debug + PartialEq + Copy + Clone + Into<Self::Limbs> + From<Self::Limbs> + Send + Sync + Default
 {
     const LIMBS_SIZE: usize;
     type Limbs: AsRef<[u32]> + AsMut<[u32]>;
@@ -82,7 +82,7 @@ macro_rules! impl_field {
         $num_limbs:ident,
         $use_ffi:expr
     ) => {
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, Default)]
         #[repr(C)]
         pub struct $field {
             limbs: [u32; $num_limbs],

--- a/wrappers/rust/icicle-core/src/field.rs
+++ b/wrappers/rust/icicle-core/src/field.rs
@@ -174,9 +174,11 @@ macro_rules! impl_field {
         }
 
         impl Default for $field {
-            fn default() -> Self { 
-                Self{limbs:[0u32; $num_limbs]}
-             }
+            fn default() -> Self {
+                Self {
+                    limbs: [0u32; $num_limbs],
+                }
+            }
         }
     };
 }

--- a/wrappers/rust/icicle-core/src/field.rs
+++ b/wrappers/rust/icicle-core/src/field.rs
@@ -82,7 +82,7 @@ macro_rules! impl_field {
         $num_limbs:ident,
         $use_ffi:expr
     ) => {
-        #[derive(Copy, Clone, Default)]
+        #[derive(Copy, Clone)]
         #[repr(C)]
         pub struct $field {
             limbs: [u32; $num_limbs],
@@ -171,6 +171,12 @@ macro_rules! impl_field {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 <Self as PrimeField>::debug_fmt(self, f)
             }
+        }
+
+        impl Default for $field {
+            fn default() -> Self { 
+                Self{limbs:[0u32; $num_limbs]}
+             }
         }
     };
 }

--- a/wrappers/rust/icicle-core/src/fri/tests.rs
+++ b/wrappers/rust/icicle-core/src/fri/tests.rs
@@ -138,7 +138,7 @@ pub fn check_fri_proof_serialization<F, S, D, T>(
 
     let merkle_tree_min_layer_to_store = 0;
 
-    let mut scalars_d: DeviceVec<_> = DeviceVec::<F>::device_malloc(SIZE as usize).unwrap();
+    let mut scalars_d: DeviceVec<_> = DeviceVec::<F>::malloc(SIZE as usize);
     scalars_d
         .copy_from_host(HostSlice::from_slice(&scalars))
         .unwrap();

--- a/wrappers/rust/icicle-core/src/fri/tests.rs
+++ b/wrappers/rust/icicle-core/src/fri/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     traits::GenerateRandom,
 };
 use icicle_runtime::{memory::DeviceVec, stream::IcicleStream};
-use icicle_runtime::{memory::HostSlice, test_utilities};
+use icicle_runtime::{memory::IntoIcicleSlice, test_utilities};
 
 pub fn check_fri<F: FriMerkleTree + GenerateRandom>(
     merkle_tree_leaves_hash: &Hasher,
@@ -27,7 +27,7 @@ pub fn check_fri<F: FriMerkleTree + GenerateRandom>(
         let fri_proof = F::fri_merkle_tree_prove(
             &fri_config,
             &transcript_config,
-            HostSlice::from_slice(&scalars),
+            scalars.into_slice(),
             &merkle_tree_leaves_hash,
             &merkle_tree_compress_hash,
             merkle_tree_min_layer_to_store,
@@ -80,13 +80,13 @@ pub fn check_fri_on_device<F: FriMerkleTree + GenerateRandom>(
 
         let mut scalars_d: DeviceVec<_> = DeviceVec::<F>::device_malloc_async(SIZE as usize, &stream).unwrap();
         scalars_d
-            .copy_from_host_async(HostSlice::from_slice(&scalars), &stream)
+            .copy_from_host_async(scalars.into_slice(), &stream)
             .unwrap();
 
         let fri_proof = fri_merkle_tree_prove::<F>(
             &fri_config,
             &transcript_config,
-            HostSlice::from_slice(&scalars),
+            scalars.into_slice(),
             &merkle_tree_leaves_hash,
             &merkle_tree_compress_hash,
             merkle_tree_min_layer_to_store,
@@ -140,13 +140,13 @@ pub fn check_fri_proof_serialization<F, S, D, T>(
 
     let mut scalars_d: DeviceVec<_> = DeviceVec::<F>::malloc(SIZE as usize);
     scalars_d
-        .copy_from_host(HostSlice::from_slice(&scalars))
+        .copy_from_host(scalars.into_slice())
         .unwrap();
 
     let fri_proof = fri_merkle_tree_prove::<F>(
         &fri_config,
         &transcript_config,
-        HostSlice::from_slice(&scalars),
+        scalars.into_slice(),
         &merkle_tree_leaves_hash,
         &merkle_tree_compress_hash,
         merkle_tree_min_layer_to_store,

--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -422,7 +422,14 @@ macro_rules! impl_msm_bench {
                         );
 
                         group.bench_function(&bench_descr, |b| {
-                            b.iter(|| msm(scalars_h, precomputed_points_d.into_slice(), &cfg, msm_results.into_slice_mut())) // TODO: use into_slice_mut
+                            b.iter(|| {
+                                msm(
+                                    scalars_h,
+                                    precomputed_points_d.into_slice(),
+                                    &cfg,
+                                    msm_results.into_slice_mut(),
+                                )
+                            }) // TODO: use into_slice_mut
                         });
 
                         stream

--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -397,7 +397,7 @@ macro_rules! impl_msm_bench {
 
                 let points = generate_random_affine_points_with_zeroes(test_size, 10);
                 for precompute_factor in [1, 4, 8] {
-                    let mut precomputed_points_d = DeviceVec::device_malloc(precompute_factor * test_size).unwrap();
+                    let mut precomputed_points_d = DeviceVec::malloc(precompute_factor * test_size);
                     cfg.precompute_factor = precompute_factor as i32;
                     precompute_bases(HostSlice::from_slice(&points), &cfg, &mut precomputed_points_d).unwrap();
                     for batch_size_log2 in [0, 4, 7] {
@@ -414,7 +414,7 @@ macro_rules! impl_msm_bench {
 
                         let scalars_h = HostSlice::from_slice(&scalars);
 
-                        let mut msm_results = DeviceVec::<Projective<C>>::device_malloc(batch_size).unwrap();
+                        let mut msm_results = DeviceVec::<Projective<C>>::malloc(batch_size);
 
                         let bench_descr = format!(
                             " {} x {} with precomp = {:?}",

--- a/wrappers/rust/icicle-core/src/msm/mod.rs
+++ b/wrappers/rust/icicle-core/src/msm/mod.rs
@@ -325,7 +325,7 @@ macro_rules! impl_msm_bench {
         use icicle_runtime::{
             device::Device,
             get_active_device, is_device_available,
-            memory::{DeviceVec, HostOrDeviceSlice, HostSlice},
+            memory::{DeviceVec, HostOrDeviceSlice, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut},
             runtime::{load_backend_from_env_or_default, warmup},
             set_device,
             stream::IcicleStream,
@@ -422,7 +422,7 @@ macro_rules! impl_msm_bench {
                         );
 
                         group.bench_function(&bench_descr, |b| {
-                            b.iter(|| msm(scalars_h, &precomputed_points_d[..], &cfg, &mut msm_results[..]))
+                            b.iter(|| msm(scalars_h, precomputed_points_d.into_slice(), &cfg, msm_results.into_slice_mut())) // TODO: use into_slice_mut
                         });
 
                         stream

--- a/wrappers/rust/icicle-core/src/msm/tests.rs
+++ b/wrappers/rust/icicle-core/src/msm/tests.rs
@@ -112,7 +112,8 @@ pub fn check_msm_batch_shared<C: Curve + MSM<C>>() {
         let mut precomputed_points_d = DeviceVec::<Affine<C>>::malloc(cfg.precompute_factor as usize * test_size);
         precompute_bases(points.into_slice(), &cfg, precomputed_points_d.into_slice_mut()).unwrap();
         for batch_size in batch_sizes {
-            let scalars_h = C::ScalarField::generate_random(test_size);
+            let scalars_h = C::ScalarField::generate_random(test_size * batch_size);
+            let scalars_h = scalars_h.into_slice();
 
             let mut msm_results_1 = DeviceVec::<Projective<C>>::malloc(batch_size);
             let mut msm_results_2 = DeviceVec::<Projective<C>>::malloc(batch_size);
@@ -123,7 +124,7 @@ pub fn check_msm_batch_shared<C: Curve + MSM<C>>() {
 
             cfg.precompute_factor = precompute_factor;
             msm(
-                scalars_h.into_slice(),
+                scalars_h,
                 precomputed_points_d.into_slice(),
                 &cfg,
                 msm_results_1.into_slice_mut(),
@@ -131,7 +132,7 @@ pub fn check_msm_batch_shared<C: Curve + MSM<C>>() {
             .unwrap();
             cfg.precompute_factor = 1;
             msm(
-                scalars_h.into_slice(),
+                scalars_h,
                 points_d.into_slice(),
                 &cfg,
                 msm_results_2.into_slice_mut(),
@@ -157,7 +158,7 @@ pub fn check_msm_batch_shared<C: Curve + MSM<C>>() {
             let mut ref_msm_config = MSMConfig::default();
             ref_msm_config.c = 4;
             msm(
-                scalars_h.into_slice(),
+                scalars_h,
                 points.into_slice(),
                 &MSMConfig::default(),
                 msm_ref_result.into_slice_mut(),

--- a/wrappers/rust/icicle-core/src/msm/tests.rs
+++ b/wrappers/rust/icicle-core/src/msm/tests.rs
@@ -112,15 +112,15 @@ pub fn check_msm_batch_shared<C: Curve + MSM<C>>() {
         cfg.precompute_factor = precompute_factor;
         let points = generate_random_affine_points_with_zeroes::<C>(test_size, 10);
         let mut precomputed_points_d =
-            DeviceVec::<Affine<C>>::device_malloc(cfg.precompute_factor as usize * test_size).unwrap();
+            DeviceVec::<Affine<C>>::malloc(cfg.precompute_factor as usize * test_size);
         precompute_bases(HostSlice::from_slice(&points), &cfg, &mut precomputed_points_d).unwrap();
         for batch_size in batch_sizes {
             let scalars = C::ScalarField::generate_random(test_size * batch_size);
             let scalars_h = HostSlice::from_slice(&scalars);
 
-            let mut msm_results_1 = DeviceVec::<Projective<C>>::device_malloc(batch_size).unwrap();
-            let mut msm_results_2 = DeviceVec::<Projective<C>>::device_malloc(batch_size).unwrap();
-            let mut points_d = DeviceVec::<Affine<C>>::device_malloc(test_size).unwrap();
+            let mut msm_results_1 = DeviceVec::<Projective<C>>::malloc(batch_size);
+            let mut msm_results_2 = DeviceVec::<Projective<C>>::malloc(batch_size);
+            let mut points_d = DeviceVec::<Affine<C>>::malloc(test_size);
             points_d
                 .copy_from_host_async(HostSlice::from_slice(&points), &stream)
                 .unwrap();
@@ -190,15 +190,15 @@ pub fn check_msm_batch_not_shared<C: Curve + MSM<C>>() {
             let points = generate_random_affine_points_with_zeroes::<C>(test_size * batch_size, 10);
             println!("points len: {}", points.len());
             let mut precomputed_points_d =
-                DeviceVec::<Affine<C>>::device_malloc(cfg.precompute_factor as usize * test_size * batch_size).unwrap();
+                DeviceVec::<Affine<C>>::malloc(cfg.precompute_factor as usize * test_size * batch_size);
             cfg.batch_size = batch_size as i32;
             cfg.are_points_shared_in_batch = false;
             precompute_bases(HostSlice::from_slice(&points), &cfg, &mut precomputed_points_d).unwrap();
             println!("precomputed points len: {}", (precomputed_points_d).len());
 
-            let mut msm_results_1 = DeviceVec::<Projective<C>>::device_malloc(batch_size).unwrap();
-            let mut msm_results_2 = DeviceVec::<Projective<C>>::device_malloc(batch_size).unwrap();
-            let mut points_d = DeviceVec::<Affine<C>>::device_malloc(test_size * batch_size).unwrap();
+            let mut msm_results_1 = DeviceVec::<Projective<C>>::malloc(batch_size);
+            let mut msm_results_2 = DeviceVec::<Projective<C>>::malloc(batch_size);
+            let mut points_d = DeviceVec::<Affine<C>>::malloc(test_size * batch_size);
             points_d
                 .copy_from_host_async(HostSlice::from_slice(&points), &stream)
                 .unwrap();

--- a/wrappers/rust/icicle-core/src/msm/tests.rs
+++ b/wrappers/rust/icicle-core/src/msm/tests.rs
@@ -65,7 +65,7 @@ pub fn check_msm<C: Curve + MSM<C>>() {
                 .unwrap();
 
                 let msm_host_result = msm_results.to_host_vec();
-                
+
                 stream
                     .synchronize()
                     .unwrap();

--- a/wrappers/rust/icicle-core/src/msm/tests.rs
+++ b/wrappers/rust/icicle-core/src/msm/tests.rs
@@ -64,10 +64,8 @@ pub fn check_msm<C: Curve + MSM<C>>() {
                 )
                 .unwrap();
 
-                let mut msm_host_result = vec![Projective::<C>::zero(); 1];
-                msm_results
-                    .copy_to_host(msm_host_result.into_slice_mut())
-                    .unwrap();
+                let msm_host_result = msm_results.to_host_vec();
+                
                 stream
                     .synchronize()
                     .unwrap();
@@ -140,14 +138,8 @@ pub fn check_msm_batch_shared<C: Curve + MSM<C>>() {
             )
             .unwrap();
 
-            let mut msm_host_result_1 = vec![Projective::<C>::zero(); batch_size];
-            let mut msm_host_result_2 = vec![Projective::<C>::zero(); batch_size];
-            msm_results_1
-                .copy_to_host_async(msm_host_result_1.into_slice_mut(), &stream)
-                .unwrap();
-            msm_results_2
-                .copy_to_host_async(msm_host_result_2.into_slice_mut(), &stream)
-                .unwrap();
+            let msm_host_result_1 = msm_results_1.to_host_vec();
+            let msm_host_result_2 = msm_results_2.to_host_vec();
             stream
                 .synchronize()
                 .unwrap();
@@ -225,14 +217,8 @@ pub fn check_msm_batch_not_shared<C: Curve + MSM<C>>() {
             cfg.precompute_factor = 1;
             msm(scalars_h, points_d.into_slice(), &cfg, msm_results_2.into_slice_mut()).unwrap();
 
-            let mut msm_host_result_1 = vec![Projective::<C>::zero(); batch_size];
-            let mut msm_host_result_2 = vec![Projective::<C>::zero(); batch_size];
-            msm_results_1
-                .copy_to_host_async(msm_host_result_1.into_slice_mut(), &stream)
-                .unwrap();
-            msm_results_2
-                .copy_to_host_async(msm_host_result_2.into_slice_mut(), &stream)
-                .unwrap();
+            let msm_host_result_1 = msm_results_1.to_host_vec();
+            let msm_host_result_2 = msm_results_2.to_host_vec();
             stream
                 .synchronize()
                 .unwrap();

--- a/wrappers/rust/icicle-core/src/msm/tests.rs
+++ b/wrappers/rust/icicle-core/src/msm/tests.rs
@@ -3,7 +3,7 @@ use crate::field::PrimeField;
 use crate::msm::{msm, precompute_bases, MSMConfig, CUDA_MSM_LARGE_BUCKET_FACTOR, MSM};
 use crate::traits::{GenerateRandom, MontgomeryConvertible};
 use icicle_runtime::{
-    memory::{DeviceVec, HostSlice, HostOrDeviceSlice, IntoIcicleSlice, IntoIcicleSliceMut},
+    memory::{DeviceVec, HostOrDeviceSlice, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut},
     runtime,
     stream::IcicleStream,
     test_utilities,

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -1,5 +1,8 @@
 use icicle_runtime::{
-    config::ConfigExtension, errors::eIcicleError, memory::HostOrDeviceSlice, stream::IcicleStreamHandle,
+    config::ConfigExtension,
+    errors::eIcicleError,
+    memory::HostOrDeviceSlice,
+    stream::IcicleStreamHandle,
 };
 
 use crate::field::PrimeField;
@@ -453,7 +456,7 @@ macro_rules! impl_ntt_bench {
     ) => {
         use std::{env, sync::OnceLock};
         use criterion::{black_box, criterion_group, criterion_main, Criterion};
-        use icicle_runtime::{memory::{HostSlice,HostOrDeviceSlice},device::Device,is_device_available,  get_active_device, set_device, runtime::load_backend_from_env_or_default};
+        use icicle_runtime::{memory::{HostOrDeviceSlice, IntoIcicleSlice, IntoIcicleSliceMut}, device::Device, is_device_available, get_active_device, set_device, runtime::load_backend_from_env_or_default};
         use icicle_core::{
             ntt::{NTTConfig, NTTInitDomainConfig, NTTDir, NttAlgorithm, Ordering, NTTDomain, ntt, NTT},
             traits::GenerateRandom,
@@ -524,10 +527,10 @@ macro_rules! impl_ntt_bench {
                     }
 
                     let scalars = F::generate_random(full_size);
-                    let input = HostSlice::from_slice(&scalars);
+                    let input = scalars.into_slice();
 
                     let mut batch_ntt_result = vec![F::zero(); batch_size * test_size];
-                    let batch_ntt_result = HostSlice::from_mut_slice(&mut batch_ntt_result);
+                    let batch_ntt_result = batch_ntt_result.into_slice_mut();
                     let mut config = NTTConfig::<F>::default();
                     for dir in [NTTDir::kForward, NTTDir::kInverse ] {
                         for ordering in [

--- a/wrappers/rust/icicle-core/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-core/src/ntt/mod.rs
@@ -1,8 +1,5 @@
 use icicle_runtime::{
-    config::ConfigExtension,
-    errors::eIcicleError,
-    memory::HostOrDeviceSlice,
-    stream::IcicleStreamHandle,
+    config::ConfigExtension, errors::eIcicleError, memory::HostOrDeviceSlice, stream::IcicleStreamHandle,
 };
 
 use crate::field::PrimeField;

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -395,7 +395,7 @@ where
 
                 for batch_size in batch_sizes {
                     let scalars: Vec<F> = F::generate_random(test_size * batch_size);
-                    let mut scalars_d = DeviceVec::<F>::device_malloc(test_size * batch_size).unwrap();
+                    let mut scalars_d = DeviceVec::<F>::malloc(test_size * batch_size);
                     scalars_d
                         .copy_from_host(HostSlice::from_slice(&scalars))
                         .unwrap();

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -1,6 +1,6 @@
 use crate::ntt::{NttAlgorithm, Ordering, CUDA_NTT_ALGORITHM, CUDA_NTT_FAST_TWIDDLES_MODE};
 use crate::vec_ops::{transpose_matrix, VecOps, VecOpsConfig};
-use icicle_runtime::memory::{HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
+use icicle_runtime::memory::{IntoIcicleSlice, IntoIcicleSliceMut};
 use icicle_runtime::{memory::DeviceVec, runtime, stream::IcicleStream, test_utilities};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
@@ -108,7 +108,8 @@ where
             let ntt_result_half = ntt_result_half.into_slice_mut();
             let mut ntt_result_coset = vec![F::zero(); small_size];
             let ntt_result_coset = ntt_result_coset.into_slice_mut();
-            let scalars_h = HostSlice::from_slice(&scalars[..small_size]);
+            let scalars_h = &scalars[..small_size];
+            let scalars_h = scalars_h.into_slice();
 
             ntt(scalars_h, NTTDir::kForward, &config, ntt_result_half).unwrap();
             assert_ne!(*ntt_result_half.as_slice(), scalars);

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -1,6 +1,6 @@
 use crate::ntt::{NttAlgorithm, Ordering, CUDA_NTT_ALGORITHM, CUDA_NTT_FAST_TWIDDLES_MODE};
 use crate::vec_ops::{transpose_matrix, VecOps, VecOpsConfig};
-use icicle_runtime::memory::{IntoIcicleSlice, IntoIcicleSliceMut};
+use icicle_runtime::memory::{HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
 use icicle_runtime::{memory::DeviceVec, runtime, stream::IcicleStream, test_utilities};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
@@ -108,7 +108,7 @@ where
             let ntt_result_half = ntt_result_half.into_slice_mut();
             let mut ntt_result_coset = vec![F::zero(); small_size];
             let ntt_result_coset = ntt_result_coset.into_slice_mut();
-            let scalars_h = scalars.into_slice();
+            let scalars_h = HostSlice::from_slice(&scalars[..small_size]);
 
             ntt(scalars_h, NTTDir::kForward, &config, ntt_result_half).unwrap();
             assert_ne!(*ntt_result_half.as_slice(), scalars);

--- a/wrappers/rust/icicle-core/src/polynomials/mod.rs
+++ b/wrappers/rust/icicle-core/src/polynomials/mod.rs
@@ -672,7 +672,7 @@ macro_rules! impl_polynomial_tests {
             assert_eq!(host_mem_large[..coeffs.len()], coeffs);
 
             // read coeffs to device memory
-            let mut device_mem = DeviceVec::<$field>::device_malloc(coeffs.len()).unwrap();
+            let mut device_mem = DeviceVec::<$field>::malloc(coeffs.len());
             f.copy_coeffs(0, &mut device_mem[..]);
             let mut host_coeffs_from_dev = vec![$field::zero(); coeffs.len() as usize];
             device_mem
@@ -755,7 +755,7 @@ macro_rules! impl_polynomial_tests {
             assert_eq!(f.eval(&three), host_evals[2]);
 
             // evaluate to device memory
-            let mut device_evals = DeviceVec::<$field>::device_malloc(domain.len()).unwrap();
+            let mut device_evals = DeviceVec::<$field>::malloc(domain.len());
             f.eval_on_domain(HostSlice::from_slice(&domain), &mut device_evals[..]);
             let mut host_evals_from_device = vec![$field::zero(); domain.len()];
             device_evals
@@ -782,7 +782,7 @@ macro_rules! impl_polynomial_tests {
             let f = randomize_poly(1 << poly_log_size);
 
             // evaluate f on rou domain of size 4n
-            let mut device_evals = DeviceVec::<$field>::device_malloc(1 << domain_log_size).unwrap();
+            let mut device_evals = DeviceVec::<$field>::malloc(1 << domain_log_size);
             f.eval_on_rou_domain(domain_log_size, &mut device_evals[..]);
 
             // construct g from f's evals and assert they are equal

--- a/wrappers/rust/icicle-core/src/polynomials/mod.rs
+++ b/wrappers/rust/icicle-core/src/polynomials/mod.rs
@@ -496,13 +496,7 @@ macro_rules! impl_polynomial_tests {
             let mut result = [$field::zero()];
 
             let cfg = VecOpsConfig::default();
-            add_scalars(
-                HostSlice::from_slice(&a),
-                HostSlice::from_slice(&b),
-                HostSlice::from_mut_slice(&mut result),
-                &cfg,
-            )
-            .unwrap();
+            add_scalars(a.into_slice(), b.into_slice(), result.into_slice_mut(), &cfg).unwrap();
             result[0]
         }
 
@@ -512,13 +506,7 @@ macro_rules! impl_polynomial_tests {
             let mut result = [$field::zero()];
 
             let cfg = VecOpsConfig::default();
-            sub_scalars(
-                HostSlice::from_slice(&a),
-                HostSlice::from_slice(&b),
-                HostSlice::from_mut_slice(&mut result),
-                &cfg,
-            )
-            .unwrap();
+            sub_scalars(a.into_slice(), b.into_slice(), result.into_slice_mut(), &cfg).unwrap();
             result[0]
         }
 
@@ -528,19 +516,13 @@ macro_rules! impl_polynomial_tests {
             let mut result = [$field::zero()];
 
             let cfg = VecOpsConfig::default();
-            mul_scalars(
-                HostSlice::from_slice(&a),
-                HostSlice::from_slice(&b),
-                HostSlice::from_mut_slice(&mut result),
-                &cfg,
-            )
-            .unwrap();
+            mul_scalars(a.into_slice(), b.into_slice(), result.into_slice_mut(), &cfg).unwrap();
             result[0]
         }
 
         fn randomize_poly(size: usize) -> Poly {
             let coeffs = randomize_coeffs::<$field>(size);
-            Poly::from_coeffs(HostSlice::from_slice(&coeffs), size)
+            Poly::from_coeffs(coeffs.into_slice(), size)
         }
 
         static INIT: Once = Once::new();
@@ -564,7 +546,7 @@ macro_rules! impl_polynomial_tests {
 
             // testing correct evaluation of f(8) for f(x)=4x^2+2x+5
             let coeffs = [$field::from_u32(5), $field::from_u32(2), $field::from_u32(4)];
-            let f = Poly::from_coeffs(HostSlice::from_slice(&coeffs), coeffs.len());
+            let f = Poly::from_coeffs(coeffs.into_slice(), coeffs.len());
             let x = $field::from_u32(8);
             let f_x = f.eval(&x);
             assert_eq!(f_x, $field::from_u32(277));
@@ -635,7 +617,7 @@ macro_rules! impl_polynomial_tests {
 
             // f(x) = 1+2x^2
             let coeffs = [one, zero, two];
-            let mut f = Poly::from_coeffs(HostSlice::from_slice(&coeffs), coeffs.len());
+            let mut f = Poly::from_coeffs(coeffs.into_slice(), coeffs.len());
             let x = rand();
             let fx = f.eval(&x);
 
@@ -659,16 +641,16 @@ macro_rules! impl_polynomial_tests {
             let four = $field::from_u32(4);
 
             let coeffs = [one, two, three, four];
-            let mut f = Poly::from_coeffs(HostSlice::from_slice(&coeffs), coeffs.len());
+            let mut f = Poly::from_coeffs(coeffs.into_slice(), coeffs.len());
 
             // read coeffs to host memory
             let mut host_mem = vec![$field::zero(); coeffs.len()];
-            f.copy_coeffs(0, HostSlice::from_mut_slice(&mut host_mem));
+            f.copy_coeffs(0, host_mem.into_slice_mut());
             assert_eq!(host_mem, coeffs);
 
             // read into larger buffer
             let mut host_mem_large = vec![$field::zero(); coeffs.len() + 10];
-            f.copy_coeffs(0, HostSlice::from_mut_slice(&mut host_mem_large));
+            f.copy_coeffs(0, host_mem_large.into_slice_mut());
             assert_eq!(host_mem_large[..coeffs.len()], coeffs);
 
             // read coeffs to device memory
@@ -714,7 +696,7 @@ macro_rules! impl_polynomial_tests {
 
             let f = randomize_poly(1 << 12);
             let v_coeffs = [minus_one, zero, zero, zero, one]; // x^4-1
-            let v = Poly::from_coeffs(HostSlice::from_slice(&v_coeffs), v_coeffs.len());
+            let v = Poly::from_coeffs(v_coeffs.into_slice(), v_coeffs.len());
 
             let fv = &f * &v;
             let deg_f = f.degree();
@@ -741,10 +723,7 @@ macro_rules! impl_polynomial_tests {
 
             // evaluate to host memory
             let mut host_evals = vec![$field::zero(); domain.len()];
-            f.eval_on_domain(
-                HostSlice::from_slice(&domain),
-                HostSlice::from_mut_slice(&mut host_evals),
-            );
+            f.eval_on_domain(domain.into_slice(), host_evals.into_slice_mut());
 
             // check eval on domain agrees with eval() method
             assert_eq!(f.eval(&one), host_evals[0]);

--- a/wrappers/rust/icicle-core/src/polynomials/mod.rs
+++ b/wrappers/rust/icicle-core/src/polynomials/mod.rs
@@ -674,10 +674,7 @@ macro_rules! impl_polynomial_tests {
             // read coeffs to device memory
             let mut device_mem = DeviceVec::<$field>::malloc(coeffs.len());
             f.copy_coeffs(0, device_mem.into_slice_mut());
-            let mut host_coeffs_from_dev = vec![$field::zero(); coeffs.len() as usize];
-            device_mem
-                .copy_to_host(HostSlice::from_mut_slice(&mut host_coeffs_from_dev))
-                .unwrap();
+            let host_coeffs_from_dev = device_mem.to_host_vec();
 
             assert_eq!(host_mem, host_coeffs_from_dev);
 
@@ -841,10 +838,7 @@ macro_rules! impl_polynomial_tests {
             // let g = &f + &f; // cannot borrow here since s is a mutable slice of f
 
             // copy to host and check equality
-            let mut coeffs_copied_from_slice = vec![$field::zero(); coeffs_slice_dev.len()];
-            coeffs_slice_dev
-                .copy_to_host(coeffs_copied_from_slice.into_slice_mut())
-                .unwrap();
+            let coeffs_copied_from_slice = coeffs_slice_dev.to_host_vec();
             assert_eq!(coeffs_copied_from_slice, coeffs);
 
             // or can use the memory directly
@@ -854,7 +848,7 @@ macro_rules! impl_polynomial_tests {
                 coeffs_slice_dev,
                 NTTDir::kForward,
                 &config,
-                HostSlice::from_mut_slice(&mut ntt_result),
+                ntt_result.into_slice_mut(),
             )
             .unwrap();
             // ntt[0] is f(one) because it's the sum of coeffs

--- a/wrappers/rust/icicle-core/src/poseidon2/tests.rs
+++ b/wrappers/rust/icicle-core/src/poseidon2/tests.rs
@@ -156,7 +156,7 @@ where
     let t = 4;
     let nof_layers = 4;
     let num_elements = 4_u32.pow(nof_layers);
-    let mut leaves: Vec<F> = (0..num_elements)
+    let leaves: Vec<F> = (0..num_elements)
         .map(|i| F::from_u32(i))
         .collect();
 
@@ -164,15 +164,15 @@ where
     let layer_hashes: Vec<&Hasher> = (0..nof_layers)
         .map(|_| &hasher)
         .collect();
-    let merkle_tree = MerkleTree::new(&layer_hashes[..], mem::size_of::<F>() as u64, 0).unwrap();
+    let merkle_tree = MerkleTree::new(layer_hashes.as_slice(), mem::size_of::<F>() as u64, 0).unwrap();
     merkle_tree
-        .build((&mut leaves).into_slice(), &MerkleTreeConfig::default())
+        .build(leaves.into_slice(), &MerkleTreeConfig::default())
         .unwrap();
 
     let leaf_idx_to_open = num_elements >> 1;
     let merkle_proof: MerkleProof = merkle_tree
         .get_proof(
-            (&leaves).into_slice(),
+            leaves.into_slice(),
             leaf_idx_to_open as u64,
             true, /*=pruned */
             &MerkleTreeConfig::default(),

--- a/wrappers/rust/icicle-core/src/poseidon2/tests.rs
+++ b/wrappers/rust/icicle-core/src/poseidon2/tests.rs
@@ -5,7 +5,10 @@ use crate::{
     poseidon2::{Poseidon2, Poseidon2Hasher},
     traits::GenerateRandom,
 };
-use icicle_runtime::{memory::HostSlice, test_utilities};
+use icicle_runtime::{
+    memory::{IntoIcicleSlice, IntoIcicleSliceMut},
+    test_utilities,
+};
 use std::mem;
 
 pub fn check_poseidon2_hash<F: PrimeField>()
@@ -34,9 +37,9 @@ where
 
             poseidon_hasher_main
                 .hash(
-                    HostSlice::from_slice(&inputs),
+                    inputs.into_slice(),
                     &HashConfig::default(),
-                    HostSlice::from_mut_slice(&mut outputs_main),
+                    outputs_main.into_slice_mut(),
                 )
                 .unwrap();
 
@@ -45,9 +48,9 @@ where
 
             poseidon_hasher_ref
                 .hash(
-                    HostSlice::from_slice(&inputs),
+                    inputs.into_slice(),
                     &HashConfig::default(),
-                    HostSlice::from_mut_slice(&mut outputs_ref),
+                    outputs_ref.into_slice_mut(),
                 )
                 .unwrap();
 
@@ -76,9 +79,9 @@ where
 
         let main_device_err = poseidon_hasher_main
             .hash(
-                HostSlice::from_slice(&inputs),
+                inputs.into_slice(),
                 &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut outputs_main),
+                outputs_main.into_slice_mut(),
             )
             .unwrap();
 
@@ -87,9 +90,9 @@ where
 
         let ref_device_err = poseidon_hasher_ref
             .hash(
-                HostSlice::from_slice(&inputs),
+                inputs.into_slice(),
                 &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut outputs_ref),
+                outputs_ref.into_slice_mut(),
             )
             .unwrap();
 
@@ -112,9 +115,9 @@ where
 
     poseidon_hasher_ref
         .hash(
-            HostSlice::from_slice(&inputs),
+            inputs.into_slice(),
             &HashConfig::default(),
-            HostSlice::from_mut_slice(&mut outputs_ref),
+            outputs_ref.into_slice_mut(),
         )
         .unwrap();
 
@@ -127,9 +130,9 @@ where
     // test device 1
     poseidon_hasher_main_dev_1
         .hash(
-            HostSlice::from_slice(&inputs),
+            inputs.into_slice(),
             &HashConfig::default(),
-            HostSlice::from_mut_slice(&mut outputs_main_1),
+            outputs_main_1.into_slice_mut(),
         )
         .unwrap();
     assert_eq!(outputs_ref, outputs_main_1);
@@ -138,9 +141,9 @@ where
     test_utilities::test_set_main_device_with_id(0);
     poseidon_hasher_main_dev_0
         .hash(
-            HostSlice::from_slice(&inputs),
+            inputs.into_slice(),
             &HashConfig::default(),
-            HostSlice::from_mut_slice(&mut outputs_main_0),
+            outputs_main_0.into_slice_mut(),
         )
         .unwrap();
     assert_eq!(outputs_ref, outputs_main_0);
@@ -163,13 +166,13 @@ where
         .collect();
     let merkle_tree = MerkleTree::new(&layer_hashes[..], mem::size_of::<F>() as u64, 0).unwrap();
     merkle_tree
-        .build(HostSlice::from_slice(&mut leaves), &MerkleTreeConfig::default())
+        .build((&mut leaves).into_slice(), &MerkleTreeConfig::default())
         .unwrap();
 
     let leaf_idx_to_open = num_elements >> 1;
     let merkle_proof: MerkleProof = merkle_tree
         .get_proof(
-            HostSlice::from_slice(&leaves),
+            (&leaves).into_slice(),
             leaf_idx_to_open as u64,
             true, /*=pruned */
             &MerkleTreeConfig::default(),

--- a/wrappers/rust/icicle-core/src/rns/tests.rs
+++ b/wrappers/rust/icicle-core/src/rns/tests.rs
@@ -37,7 +37,7 @@ where
 
     // Convert Zq -> ZqRns on main device
     test_utilities::test_set_main_device();
-    let mut output_rns_main_d = DeviceVec::<ZqRns>::device_malloc(total_size).unwrap();
+    let mut output_rns_main_d = DeviceVec::<ZqRns>::malloc(total_size);
     let mut output_rns_main_h = vec![ZqRns::zero(); total_size];
     to_rns(HostSlice::from_slice(&input_direct), &mut output_rns_main_d[..], &cfg).unwrap();
 

--- a/wrappers/rust/icicle-core/src/rns/tests.rs
+++ b/wrappers/rust/icicle-core/src/rns/tests.rs
@@ -33,13 +33,10 @@ where
     // Convert Zq -> ZqRns on main device
     test_utilities::test_set_main_device();
     let mut output_rns_main_d = DeviceVec::<ZqRns>::malloc(total_size);
-    let mut output_rns_main_h = vec![ZqRns::zero(); total_size];
     to_rns(input_direct.into_slice(), output_rns_main_d.into_slice_mut(), &cfg).unwrap();
 
     // Ensure reference and main device implementations produce identical results
-    output_rns_main_d
-        .copy_to_host(output_rns_main_h.into_slice_mut())
-        .unwrap();
+    let output_rns_main_h = output_rns_main_d.to_host_vec();
 
     assert_eq!(output_rns_ref, output_rns_main_h);
 

--- a/wrappers/rust/icicle-core/src/sumcheck/tests.rs
+++ b/wrappers/rust/icicle-core/src/sumcheck/tests.rs
@@ -3,7 +3,7 @@ use crate::hash::Hasher;
 use crate::program::{PreDefinedProgram, ReturningValueProgram};
 use crate::sumcheck::{Sumcheck, SumcheckConfig, SumcheckProofOps, SumcheckTranscriptConfig};
 use crate::traits::GenerateRandom;
-use icicle_runtime::memory::{DeviceSlice, DeviceVec, HostSlice};
+use icicle_runtime::memory::{DeviceSlice, DeviceVec, HostSlice, IntoIcicleSlice};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -176,7 +176,7 @@ where
 
     let mle_polys_device: Vec<&DeviceSlice<<SW as Sumcheck>::Field>> = device_mle_polys
         .iter()
-        .map(|s| &s[..])
+        .map(|s| s.into_slice())
         .collect();
     let device_mle_polys_slice = mle_polys_device.as_slice();
 
@@ -340,7 +340,7 @@ where
     /****** Begin CPU Proof ******/
     let mle_poly_hosts = mle_polys
         .iter()
-        .map(|poly| HostSlice::from_slice(poly))
+        .map(|poly| poly.into_slice())
         .collect::<Vec<&HostSlice<<SW as Sumcheck>::Field>>>();
 
     let sumcheck = SW::new().unwrap();

--- a/wrappers/rust/icicle-core/src/sumcheck/tests.rs
+++ b/wrappers/rust/icicle-core/src/sumcheck/tests.rs
@@ -167,7 +167,7 @@ where
 
     let mut device_mle_polys = Vec::with_capacity(nof_mle_poly);
     for i in 0..nof_mle_poly {
-        let mut device_slice = DeviceVec::device_malloc(mle_poly_size).unwrap();
+        let mut device_slice = DeviceVec::malloc(mle_poly_size);
         device_slice
             .copy_from_host(mle_poly_hosts[i])
             .unwrap();

--- a/wrappers/rust/icicle-core/src/sumcheck/tests.rs
+++ b/wrappers/rust/icicle-core/src/sumcheck/tests.rs
@@ -91,7 +91,7 @@ where
     /****** Begin CPU Proof ******/
     let mle_poly_hosts = mle_polys
         .iter()
-        .map(|poly| HostSlice::from_slice(poly))
+        .map(|poly| poly.into_slice())
         .collect::<Vec<&HostSlice<<SW as Sumcheck>::Field>>>();
 
     let sumcheck = SW::new().unwrap();
@@ -162,7 +162,7 @@ where
 
     let mle_poly_hosts = mle_polys
         .iter()
-        .map(|poly| HostSlice::from_slice(poly))
+        .map(|poly| poly.into_slice())
         .collect::<Vec<&HostSlice<<SW as Sumcheck>::Field>>>();
 
     let mut device_mle_polys = Vec::with_capacity(nof_mle_poly);
@@ -257,7 +257,7 @@ where
     /****** Begin CPU Proof ******/
     let mle_poly_hosts = mle_polys
         .iter()
-        .map(|poly| HostSlice::from_slice(poly))
+        .map(|poly| poly.into_slice())
         .collect::<Vec<&HostSlice<<SW as Sumcheck>::Field>>>();
 
     let sumcheck = SW::new().unwrap();

--- a/wrappers/rust/icicle-core/src/tests.rs
+++ b/wrappers/rust/icicle-core/src/tests.rs
@@ -138,10 +138,7 @@ where
         .wrap()
         .unwrap();
 
-    let mut affine_copy = vec![Affine::<C>::zero(); size];
-    d_affine
-        .copy_to_host(HostSlice::from_mut_slice(&mut affine_copy))
-        .unwrap();
+    let affine_copy = d_affine.to_host_vec();
 
     assert_eq!(affine_points, affine_copy);
 
@@ -158,10 +155,7 @@ where
         .wrap()
         .unwrap();
 
-    let mut projective_copy = vec![Projective::<C>::zero(); size];
-    d_proj
-        .copy_to_host(HostSlice::from_mut_slice(&mut projective_copy))
-        .unwrap();
+    let projective_copy = d_proj.to_host_vec();
 
     assert_eq!(proj_points, projective_copy);
 }

--- a/wrappers/rust/icicle-core/src/tests.rs
+++ b/wrappers/rust/icicle-core/src/tests.rs
@@ -96,7 +96,7 @@ where
     let size = 1 << 10;
     let scalars = F::generate_random(size);
 
-    let mut d_scalars = DeviceVec::device_malloc(size).unwrap();
+    let mut d_scalars = DeviceVec::<F>::malloc(size);
     d_scalars
         .copy_from_host(HostSlice::from_slice(&scalars))
         .unwrap();
@@ -126,7 +126,7 @@ where
     let size = 1 << 10;
 
     let affine_points = C::generate_random_affine_points(size);
-    let mut d_affine = DeviceVec::device_malloc(size).unwrap();
+    let mut d_affine = DeviceVec::<Affine<C>>::malloc(size);
     d_affine
         .copy_from_host(HostSlice::from_slice(&affine_points))
         .unwrap();
@@ -146,7 +146,7 @@ where
     assert_eq!(affine_points, affine_copy);
 
     let proj_points = C::generate_random_projective_points(size);
-    let mut d_proj = DeviceVec::device_malloc(size).unwrap();
+    let mut d_proj = DeviceVec::<Projective<C>>::malloc(size);
     d_proj
         .copy_from_host(HostSlice::from_slice(&proj_points))
         .unwrap();

--- a/wrappers/rust/icicle-core/src/tests.rs
+++ b/wrappers/rust/icicle-core/src/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     traits::{Arithmetic, GenerateRandom, MontgomeryConvertible},
 };
 use icicle_runtime::{
-    memory::{DeviceVec, HostSlice},
+    memory::{DeviceVec, IntoIcicleSlice, IntoIcicleSliceMut},
     stream::IcicleStream,
 };
 
@@ -98,7 +98,7 @@ where
 
     let mut d_scalars = DeviceVec::<F>::malloc(size);
     d_scalars
-        .copy_from_host(HostSlice::from_slice(&scalars))
+        .copy_from_host(scalars.into_slice())
         .unwrap();
 
     F::to_mont(&mut d_scalars, &stream);
@@ -106,7 +106,7 @@ where
 
     let mut scalars_copy = vec![F::zero(); size];
     d_scalars
-        .copy_to_host_async(HostSlice::from_mut_slice(&mut scalars_copy), &stream)
+        .copy_to_host_async(scalars_copy.into_slice_mut(), &stream)
         .unwrap();
     stream
         .synchronize()
@@ -128,7 +128,7 @@ where
     let affine_points = C::generate_random_affine_points(size);
     let mut d_affine = DeviceVec::<Affine<C>>::malloc(size);
     d_affine
-        .copy_from_host(HostSlice::from_slice(&affine_points))
+        .copy_from_host(affine_points.into_slice())
         .unwrap();
 
     Affine::<C>::to_mont(&mut d_affine, &IcicleStream::default())
@@ -145,7 +145,7 @@ where
     let proj_points = C::generate_random_projective_points(size);
     let mut d_proj = DeviceVec::<Projective<C>>::malloc(size);
     d_proj
-        .copy_from_host(HostSlice::from_slice(&proj_points))
+        .copy_from_host(proj_points.into_slice())
         .unwrap();
 
     Projective::<C>::to_mont(&mut d_proj, &IcicleStream::default())

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -422,12 +422,9 @@ where
     let input = input_vec.into_slice();
     let mut intermediate = DeviceVec::<F>::malloc(TEST_SIZE);
     let cfg = VecOpsConfig::default();
-    bit_reverse(input, &cfg, &mut intermediate[..]).unwrap();
+    bit_reverse(input, &cfg, intermediate.into_slice_mut()).unwrap();
 
-    let mut intermediate_host = vec![F::one(); TEST_SIZE];
-    intermediate
-        .copy_to_host(intermediate_host.into_slice_mut())
-        .unwrap();
+    let intermediate_host = intermediate.to_host_vec();
     let index_reverser = |i: usize| i.reverse_bits() >> (usize::BITS - LOG_SIZE);
     intermediate_host
         .iter()

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -9,7 +9,7 @@ use crate::vec_ops::{
     sum_scalars, transpose_matrix, MixedVecOps, VecOps, VecOpsConfig,
 };
 use icicle_runtime::device::Device;
-use icicle_runtime::memory::{DeviceVec, HostOrDeviceSlice, HostSlice};
+use icicle_runtime::memory::{DeviceVec, HostOrDeviceSlice, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
 use icicle_runtime::{runtime, stream::IcicleStream, test_utilities};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
@@ -73,10 +73,10 @@ where
     let mut result_main = vec![F::zero(); test_size];
     let mut result_ref = vec![F::zero(); test_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     let cfg = VecOpsConfig::default();
 
@@ -98,10 +98,10 @@ where
     let mut result_main = vec![F::zero(); test_size];
     let mut result_ref = vec![F::zero(); test_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     let cfg = VecOpsConfig::default();
 
@@ -123,10 +123,10 @@ where
     let mut result_main = vec![F::zero(); test_size];
     let mut result_ref = vec![F::zero(); test_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     let cfg = VecOpsConfig::default();
 
@@ -148,10 +148,10 @@ where
     let mut result_main = vec![F::zero(); test_size];
     let mut result_ref = vec![F::zero(); test_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     let cfg = VecOpsConfig::default();
 
@@ -176,11 +176,11 @@ where
     let mut result_ref = vec![F::one(); test_size];
     let mut result = vec![F::one(); test_size];
 
-    let a = HostSlice::from_slice(&a);
-    let inv = HostSlice::from_mut_slice(&mut inv);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
-    let result = HostSlice::from_mut_slice(&mut result);
+    let a = a.into_slice();
+    let inv = inv.into_slice_mut();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
+    let result = result.into_slice_mut();
 
     test_utilities::test_set_main_device();
     inv_scalars(a, inv, &cfg).unwrap();
@@ -205,9 +205,9 @@ where
     let mut result_main = vec![F::zero(); batch_size];
     let mut result_ref = vec![F::zero(); batch_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     test_utilities::test_set_main_device();
     sum_scalars(a_main, result_main, &cfg).unwrap();
@@ -229,9 +229,9 @@ where
     let mut result_main = vec![F::zero(); batch_size];
     let mut result_ref = vec![F::zero(); batch_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     test_utilities::test_set_main_device();
     product_scalars(a_main, result_main, &cfg).unwrap();
@@ -254,10 +254,10 @@ where
     let mut result_main = vec![F::zero(); test_size * batch_size as usize];
     let mut result_ref = vec![F::zero(); test_size * batch_size as usize];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     test_utilities::test_set_main_device();
     scalar_add(a_main, b, result_main, &cfg).unwrap();
@@ -280,10 +280,10 @@ where
     let mut result_main = vec![F::zero(); test_size * batch_size];
     let mut result_ref = vec![F::zero(); test_size * batch_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     test_utilities::test_set_main_device();
     scalar_sub(a_main, b, result_main, &cfg).unwrap();
@@ -306,10 +306,10 @@ where
     let mut result_main = vec![F::zero(); test_size * batch_size];
     let mut result_ref = vec![F::zero(); test_size * batch_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     test_utilities::test_set_main_device();
     scalar_mul(a_main, b, result_main, &cfg).unwrap();
@@ -329,9 +329,9 @@ where
 
     let mut a_clone = a_main.clone();
 
-    let a_main_slice = HostSlice::from_mut_slice(&mut a_main);
-    let b_slice = HostSlice::from_slice(&b);
-    let a_clone_slice = HostSlice::from_mut_slice(&mut a_clone);
+    let a_main_slice = a_main.into_slice_mut();
+    let b_slice = b.into_slice();
+    let a_clone_slice = a_clone.into_slice_mut();
 
     let cfg = VecOpsConfig::default();
 
@@ -359,24 +359,10 @@ where
     let mut result_ref = vec![F::zero(); test_size];
 
     test_utilities::test_set_main_device();
-    transpose_matrix(
-        HostSlice::from_slice(&input_matrix),
-        r,
-        c,
-        HostSlice::from_mut_slice(&mut result_main),
-        &cfg,
-    )
-    .unwrap();
+    transpose_matrix(input_matrix.into_slice(), r, c, result_main.into_slice_mut(), &cfg).unwrap();
 
     test_utilities::test_set_ref_device();
-    transpose_matrix(
-        HostSlice::from_slice(&input_matrix),
-        r,
-        c,
-        HostSlice::from_mut_slice(&mut result_ref),
-        &cfg,
-    )
-    .unwrap();
+    transpose_matrix(input_matrix.into_slice(), r, c, result_ref.into_slice_mut(), &cfg).unwrap();
 
     assert_eq!(result_main, result_ref);
 }
@@ -399,25 +385,25 @@ where
 
     test_utilities::test_set_main_device();
     slice(
-        HostSlice::from_slice(&input_matrix),
+        input_matrix.into_slice(),
         offset,
         stride,
         size_in,
         size_out,
         &cfg,
-        HostSlice::from_mut_slice(&mut result_main),
+        result_main.into_slice_mut(),
     )
     .unwrap();
 
     test_utilities::test_set_ref_device();
     slice(
-        HostSlice::from_slice(&input_matrix),
+        input_matrix.into_slice(),
         offset,
         stride,
         size_in,
         size_out,
         &cfg,
-        HostSlice::from_mut_slice(&mut result_ref),
+        result_ref.into_slice_mut(),
     )
     .unwrap();
 
@@ -433,14 +419,14 @@ where
     const LOG_SIZE: u32 = 20;
     const TEST_SIZE: usize = 1 << LOG_SIZE;
     let input_vec = F::generate_random(TEST_SIZE);
-    let input = HostSlice::from_slice(&input_vec);
+    let input = input_vec.into_slice();
     let mut intermediate = DeviceVec::<F>::malloc(TEST_SIZE);
     let cfg = VecOpsConfig::default();
     bit_reverse(input, &cfg, &mut intermediate[..]).unwrap();
 
     let mut intermediate_host = vec![F::one(); TEST_SIZE];
     intermediate
-        .copy_to_host(HostSlice::from_mut_slice(&mut intermediate_host[..]))
+        .copy_to_host(intermediate_host.into_slice_mut())
         .unwrap();
     let index_reverser = |i: usize| i.reverse_bits() >> (usize::BITS - LOG_SIZE);
     intermediate_host
@@ -449,9 +435,9 @@ where
         .for_each(|(i, val)| assert_eq!(val, &input_vec[index_reverser(i)]));
 
     let mut result = vec![F::one(); TEST_SIZE];
-    let result = HostSlice::from_mut_slice(&mut result);
+    let result = result.into_slice_mut();
     let cfg = VecOpsConfig::default();
-    bit_reverse(&intermediate[..], &cfg, result).unwrap();
+    bit_reverse(intermediate.into_slice(), &cfg, result).unwrap();
     assert_eq!(input.as_slice(), result.as_slice());
 }
 
@@ -464,17 +450,17 @@ where
     const LOG_SIZE: u32 = 20;
     const TEST_SIZE: usize = 1 << LOG_SIZE;
     let input_vec = F::generate_random(TEST_SIZE);
-    let input = HostSlice::from_slice(&input_vec);
+    let input = input_vec.into_slice();
     let mut intermediate = DeviceVec::<F>::malloc(TEST_SIZE);
     intermediate
-        .copy_from_host(&input)
+        .copy_from_host(input)
         .unwrap();
     let cfg = VecOpsConfig::default();
-    bit_reverse_inplace(&mut intermediate[..], &cfg).unwrap();
+    bit_reverse_inplace(intermediate.into_slice_mut(), &cfg).unwrap();
 
     let mut intermediate_host = vec![F::one(); TEST_SIZE];
     intermediate
-        .copy_to_host(HostSlice::from_mut_slice(&mut intermediate_host[..]))
+        .copy_to_host(intermediate_host.into_slice_mut())
         .unwrap();
     let index_reverser = |i: usize| i.reverse_bits() >> (usize::BITS - LOG_SIZE);
     intermediate_host
@@ -482,10 +468,10 @@ where
         .enumerate()
         .for_each(|(i, val)| assert_eq!(val, &input_vec[index_reverser(i)]));
 
-    bit_reverse_inplace(&mut intermediate[..], &cfg).unwrap();
+    bit_reverse_inplace(intermediate.into_slice_mut(), &cfg).unwrap();
     let mut result_host = vec![F::one(); TEST_SIZE];
     intermediate
-        .copy_to_host(HostSlice::from_mut_slice(&mut result_host[..]))
+        .copy_to_host(result_host.into_slice_mut())
         .unwrap();
     assert_eq!(input.as_slice(), result_host.as_slice());
 }
@@ -515,13 +501,13 @@ where
     let var4 = vec![F::zero(); TEST_SIZE];
     let var5 = vec![F::zero(); TEST_SIZE];
     let var6 = vec![F::zero(); TEST_SIZE];
-    let a_slice = HostSlice::from_slice(&a);
-    let b_slice = HostSlice::from_slice(&b);
-    let c_slice = HostSlice::from_slice(&c);
-    let eq_slice = HostSlice::from_slice(&eq);
-    let var4_slice = HostSlice::from_slice(&var4);
-    let var5_slice = HostSlice::from_slice(&var5);
-    let var6_slice = HostSlice::from_slice(&var6);
+    let a_slice = a.into_slice();
+    let b_slice = b.into_slice();
+    let c_slice = c.into_slice();
+    let eq_slice = eq.into_slice();
+    let var4_slice = var4.into_slice();
+    let var5_slice = var5.into_slice();
+    let var6_slice = var6.into_slice();
     let mut parameters = vec![a_slice, b_slice, c_slice, eq_slice, var4_slice, var5_slice, var6_slice];
 
     let program = Prog::new(example_lambda, 7).unwrap();
@@ -556,11 +542,11 @@ where
     let c = F::generate_random(TEST_SIZE);
     let eq = F::generate_random(TEST_SIZE);
     let var4 = vec![F::zero(); TEST_SIZE];
-    let a_slice = HostSlice::from_slice(&a);
-    let b_slice = HostSlice::from_slice(&b);
-    let c_slice = HostSlice::from_slice(&c);
-    let eq_slice = HostSlice::from_slice(&eq);
-    let var4_slice = HostSlice::from_slice(&var4);
+    let a_slice = a.into_slice();
+    let b_slice = b.into_slice();
+    let c_slice = c.into_slice();
+    let eq_slice = eq.into_slice();
+    let var4_slice = var4.into_slice();
     let mut parameters = vec![a_slice, b_slice, c_slice, eq_slice, var4_slice];
 
     let program = Prog::new_predefined(PreDefinedProgram::EQtimesABminusC).unwrap();
@@ -588,10 +574,10 @@ where
     let mut result_main = vec![F::zero(); test_size];
     let mut result_ref = vec![F::zero(); test_size];
 
-    let a_main = HostSlice::from_slice(&a_main);
-    let b = HostSlice::from_slice(&b);
-    let result_main = HostSlice::from_mut_slice(&mut result_main);
-    let result_ref = HostSlice::from_mut_slice(&mut result_ref);
+    let a_main = a_main.into_slice();
+    let b = b.into_slice();
+    let result_main = result_main.into_slice_mut();
+    let result_ref = result_ref.into_slice_mut();
 
     let cfg = VecOpsConfig::default();
 

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -455,10 +455,7 @@ where
     let cfg = VecOpsConfig::default();
     bit_reverse_inplace(intermediate.into_slice_mut(), &cfg).unwrap();
 
-    let mut intermediate_host = vec![F::one(); TEST_SIZE];
-    intermediate
-        .copy_to_host(intermediate_host.into_slice_mut())
-        .unwrap();
+    let intermediate_host = intermediate.to_host_vec();
     let index_reverser = |i: usize| i.reverse_bits() >> (usize::BITS - LOG_SIZE);
     intermediate_host
         .iter()
@@ -466,10 +463,7 @@ where
         .for_each(|(i, val)| assert_eq!(val, &input_vec[index_reverser(i)]));
 
     bit_reverse_inplace(intermediate.into_slice_mut(), &cfg).unwrap();
-    let mut result_host = vec![F::one(); TEST_SIZE];
-    intermediate
-        .copy_to_host(result_host.into_slice_mut())
-        .unwrap();
+    let result_host = intermediate.to_host_vec();
     assert_eq!(input.as_slice(), result_host.as_slice());
 }
 

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -434,7 +434,7 @@ where
     const TEST_SIZE: usize = 1 << LOG_SIZE;
     let input_vec = F::generate_random(TEST_SIZE);
     let input = HostSlice::from_slice(&input_vec);
-    let mut intermediate = DeviceVec::<F>::device_malloc(TEST_SIZE).unwrap();
+    let mut intermediate = DeviceVec::<F>::malloc(TEST_SIZE);
     let cfg = VecOpsConfig::default();
     bit_reverse(input, &cfg, &mut intermediate[..]).unwrap();
 
@@ -465,7 +465,7 @@ where
     const TEST_SIZE: usize = 1 << LOG_SIZE;
     let input_vec = F::generate_random(TEST_SIZE);
     let input = HostSlice::from_slice(&input_vec);
-    let mut intermediate = DeviceVec::<F>::device_malloc(TEST_SIZE).unwrap();
+    let mut intermediate = DeviceVec::<F>::malloc(TEST_SIZE);
     intermediate
         .copy_from_host(&input)
         .unwrap();

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/curve.rs
@@ -5,7 +5,11 @@ use icicle_core::{
     impl_curve, impl_field, impl_field_arithmetic, impl_generate_random, impl_montgomery_convertible,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
+use icicle_runtime::{
+    eIcicleError,
+    memory::{HostOrDeviceSlice, IntoIcicleSliceMut},
+    stream::IcicleStream,
+};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/curve.rs
@@ -5,7 +5,7 @@ use icicle_core::{
     impl_curve, impl_field, impl_field_arithmetic, impl_generate_random, impl_montgomery_convertible,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::HostOrDeviceSlice, stream::IcicleStream};
+use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
@@ -6,7 +6,7 @@ use icicle_core::{
     traits::GenerateRandom,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::HostOrDeviceSlice, stream::IcicleStream};
+use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
@@ -6,7 +6,11 @@ use icicle_core::{
     traits::GenerateRandom,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
+use icicle_runtime::{
+    eIcicleError,
+    memory::{HostOrDeviceSlice, IntoIcicleSliceMut},
+    stream::IcicleStream,
+};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/curve.rs
@@ -5,7 +5,11 @@ use icicle_core::{
     impl_curve, impl_field, impl_field_arithmetic, impl_generate_random, impl_montgomery_convertible,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
+use icicle_runtime::{
+    eIcicleError,
+    memory::{HostOrDeviceSlice, IntoIcicleSliceMut},
+    stream::IcicleStream,
+};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/curve.rs
@@ -5,7 +5,7 @@ use icicle_core::{
     impl_curve, impl_field, impl_field_arithmetic, impl_generate_random, impl_montgomery_convertible,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::HostOrDeviceSlice, stream::IcicleStream};
+use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/src/curve.rs
@@ -5,7 +5,7 @@ use icicle_core::{
     impl_curve, impl_field, impl_field_arithmetic, impl_generate_random, impl_montgomery_convertible,
     vec_ops::VecOpsConfig,
 };
-use icicle_runtime::{eIcicleError, memory::HostOrDeviceSlice, stream::IcicleStream};
+use icicle_runtime::{eIcicleError, memory::{HostOrDeviceSlice, IntoIcicleSliceMut}, stream::IcicleStream};
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/field.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/field.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 
 use icicle_runtime::errors::eIcicleError;
-use icicle_runtime::memory::HostOrDeviceSlice;
+use icicle_runtime::memory::{HostOrDeviceSlice, IntoIcicleSliceMut};
 use icicle_runtime::stream::IcicleStream;
 
 pub(crate) const SCALAR_LIMBS: usize = 1;

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/ntt/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod tests {
         ntt::{initialize_domain, ntt_inplace, release_domain, NTTConfig, NTTDir, NTTInitDomainConfig},
         traits::GenerateRandom,
     };
-    use icicle_runtime::memory::HostSlice;
+    use icicle_runtime::memory::IntoIcicleSliceMut;
     use risc0_core::field::{
         baby_bear::{Elem, ExtElem},
         Elem as FieldElem, RootsOfUnity,
@@ -50,8 +50,8 @@ pub(crate) mod tests {
             let ntt_cfg: NTTConfig<ScalarField> = NTTConfig::default();
             ntt_inplace(scalars.into_slice_mut(), NTTDir::kForward, &ntt_cfg).unwrap();
 
-            risc0_zkp::core::ntt::bit_reverse(scalars_risc0.into_slice_mut());
-            risc0_zkp::core::ntt::evaluate_ntt::<Elem, Elem>(scalars_risc0.into_slice(), ntt_size);
+            risc0_zkp::core::ntt::bit_reverse(scalars_risc0.as_mut_slice());
+            risc0_zkp::core::ntt::evaluate_ntt::<Elem, Elem>(scalars_risc0.as_mut_slice(), ntt_size);
 
             for (s1, s2) in scalars
                 .iter()
@@ -73,8 +73,8 @@ pub(crate) mod tests {
             )
             .unwrap();
 
-            risc0_zkp::core::ntt::bit_reverse(ext_scalars_risc0.into_slice_mut());
-            risc0_zkp::core::ntt::evaluate_ntt::<Elem, ExtElem>(ext_scalars_risc0.into_slice(), ntt_size);
+            risc0_zkp::core::ntt::bit_reverse(ext_scalars_risc0.as_mut_slice());
+            risc0_zkp::core::ntt::evaluate_ntt::<Elem, ExtElem>(ext_scalars_risc0.as_mut_slice(), ntt_size);
 
             for (s1, s2) in ext_scalars
                 .iter()

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/ntt/mod.rs
@@ -48,10 +48,10 @@ pub(crate) mod tests {
                 .collect();
 
             let ntt_cfg: NTTConfig<ScalarField> = NTTConfig::default();
-            ntt_inplace(HostSlice::from_mut_slice(&mut scalars[..]), NTTDir::kForward, &ntt_cfg).unwrap();
+            ntt_inplace(scalars.into_slice_mut(), NTTDir::kForward, &ntt_cfg).unwrap();
 
-            risc0_zkp::core::ntt::bit_reverse(&mut scalars_risc0[..]);
-            risc0_zkp::core::ntt::evaluate_ntt::<Elem, Elem>(&mut scalars_risc0[..], ntt_size);
+            risc0_zkp::core::ntt::bit_reverse(scalars_risc0.into_slice_mut());
+            risc0_zkp::core::ntt::evaluate_ntt::<Elem, Elem>(scalars_risc0.into_slice(), ntt_size);
 
             for (s1, s2) in scalars
                 .iter()
@@ -67,14 +67,14 @@ pub(crate) mod tests {
                 .collect();
 
             ntt_inplace(
-                HostSlice::from_mut_slice(&mut ext_scalars[..]),
+                ext_scalars.into_slice_mut(),
                 NTTDir::kForward,
                 &ntt_cfg,
             )
             .unwrap();
 
-            risc0_zkp::core::ntt::bit_reverse(&mut ext_scalars_risc0[..]);
-            risc0_zkp::core::ntt::evaluate_ntt::<Elem, ExtElem>(&mut ext_scalars_risc0[..], ntt_size);
+            risc0_zkp::core::ntt::bit_reverse(ext_scalars_risc0.into_slice_mut());
+            risc0_zkp::core::ntt::evaluate_ntt::<Elem, ExtElem>(ext_scalars_risc0.into_slice(), ntt_size);
 
             for (s1, s2) in ext_scalars
                 .iter()

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/field.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/field.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 
 use icicle_runtime::errors::eIcicleError;
-use icicle_runtime::memory::HostOrDeviceSlice;
+use icicle_runtime::memory::{HostOrDeviceSlice, IntoIcicleSliceMut};
 use icicle_runtime::stream::IcicleStream;
 
 pub(crate) const SCALAR_LIMBS: usize = 1;

--- a/wrappers/rust/icicle-fields/icicle-m31/src/field.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/field.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 
 use icicle_runtime::errors::eIcicleError;
-use icicle_runtime::memory::HostOrDeviceSlice;
+use icicle_runtime::memory::{HostOrDeviceSlice, IntoIcicleSliceMut};
 use icicle_runtime::stream::IcicleStream;
 
 pub(crate) const SCALAR_LIMBS: usize = 1;

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/field.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/field.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 
 use icicle_runtime::errors::eIcicleError;
-use icicle_runtime::memory::HostOrDeviceSlice;
+use icicle_runtime::memory::{HostOrDeviceSlice, IntoIcicleSliceMut};
 use icicle_runtime::stream::IcicleStream;
 
 pub(crate) const SCALAR_LIMBS: usize = 8;

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/ntt/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod tests {
         field::PrimeField,
         ntt::{initialize_domain, ntt_inplace, release_domain, NTTConfig, NTTDir, NTTInitDomainConfig},
     };
-    use icicle_runtime::memory::HostSlice;
+    use icicle_runtime::memory::IntoIcicleSliceMut;
     use lambdaworks_math::{
         field::{
             element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField, traits::IsFFTField,
@@ -58,7 +58,7 @@ pub(crate) mod tests {
             let ntt_cfg: NTTConfig<ScalarField> = NTTConfig::default();
             ntt_inplace(scalars.into_slice_mut(), NTTDir::kForward, &ntt_cfg).unwrap();
 
-            let poly = Polynomial::new(scalars_lw.into_slice());
+            let poly = Polynomial::new(scalars_lw.as_slice());
             let evaluations = Polynomial::evaluate_fft::<Stark252PrimeField>(&poly, 1, None).unwrap();
 
             for (s1, s2) in scalars

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/ntt/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/ntt/mod.rs
@@ -56,9 +56,9 @@ pub(crate) mod tests {
                 .collect();
 
             let ntt_cfg: NTTConfig<ScalarField> = NTTConfig::default();
-            ntt_inplace(HostSlice::from_mut_slice(&mut scalars[..]), NTTDir::kForward, &ntt_cfg).unwrap();
+            ntt_inplace(scalars.into_slice_mut(), NTTDir::kForward, &ntt_cfg).unwrap();
 
-            let poly = Polynomial::new(&scalars_lw[..]);
+            let poly = Polynomial::new(scalars_lw.into_slice());
             let evaluations = Polynomial::evaluate_fft::<Stark252PrimeField>(&poly, 1, None).unwrap();
 
             for (s1, s2) in scalars

--- a/wrappers/rust/icicle-hash/src/tests.rs
+++ b/wrappers/rust/icicle-hash/src/tests.rs
@@ -35,7 +35,7 @@ mod tests {
         let batch = 3;
 
         let mut input = vec![0 as u8; single_hash_input_size * batch];
-        rand::thread_rng().fill(&mut input[..]);
+        rand::thread_rng().fill(input.as_mut_slice());
         let mut output_ref = vec![0 as u8; 64 * batch]; // 64B (=512b) is the output size of Keccak512,
         let mut output_main = vec![0 as u8; 64 * batch];
 
@@ -60,7 +60,7 @@ mod tests {
         let batch = 11;
 
         let mut input = vec![0 as u8; single_hash_input_size * batch];
-        rand::thread_rng().fill(&mut input[..]);
+        rand::thread_rng().fill(input.as_mut_slice());
         let mut output_ref = vec![0 as u8; 32 * batch]; // 32B (=256b) is the output size of blake2s
         let mut output_main = vec![0 as u8; 32 * batch];
 
@@ -85,7 +85,7 @@ mod tests {
         let batch = 11;
 
         let mut input = vec![0 as u8; single_hash_input_size * batch];
-        rand::thread_rng().fill(&mut input[..]);
+        rand::thread_rng().fill(input.as_mut_slice());
         let mut output_ref = vec![0 as u8; 32 * batch]; // 32B (=256b) is the output size of blake3
         let mut output_main = vec![0 as u8; 32 * batch];
 
@@ -136,7 +136,7 @@ mod tests {
     fn sha3_hashing() {
         initialize();
         let mut input = vec![0 as u8; 1153];
-        rand::thread_rng().fill(&mut input[..]);
+        rand::thread_rng().fill(input.as_mut_slice());
         let mut output_main = vec![0 as u8; 32];
         let mut output_ref = vec![0 as u8; 32];
 
@@ -183,7 +183,7 @@ mod tests {
 
         // Create a vector of random bytes efficiently
         let mut input: Vec<u8> = vec![0; leaf_element_size as usize * num_elements];
-        rand::thread_rng().fill(&mut input[..]); // Fill the vector with random data
+        rand::thread_rng().fill(input.as_mut_slice()); // Fill the vector with random data
 
         merkle_tree
             .build(input.into_slice(), &MerkleTreeConfig::default())

--- a/wrappers/rust/icicle-hash/src/tests.rs
+++ b/wrappers/rust/icicle-hash/src/tests.rs
@@ -167,7 +167,7 @@ mod tests {
             let hasher_l0 = Keccak256::new(2 * leaf_element_size /*input chunk size*/).unwrap();
             let hasher_l1 = Sha3_256::new(2 * 32 /*input chunk size*/).unwrap();
             let layer_hashes = [&hasher_l0, &hasher_l1];
-            let _merkle_tree = MerkleTree::new(&layer_hashes[..], leaf_element_size as u64, 0).unwrap();
+            let _merkle_tree = MerkleTree::new(layer_hashes.as_slice(), leaf_element_size as u64, 0).unwrap();
         }
 
         // or any way that ends up with &[&Hashers]
@@ -179,7 +179,7 @@ mod tests {
         let layer_hashes: Vec<&Hasher> = (0..nof_layers)
             .map(|_| &hasher)
             .collect();
-        let merkle_tree = MerkleTree::new(&layer_hashes[..], leaf_element_size as u64, 0).unwrap();
+        let merkle_tree = MerkleTree::new(layer_hashes.as_slice(), leaf_element_size as u64, 0).unwrap();
 
         // Create a vector of random bytes efficiently
         let mut input: Vec<u8> = vec![0; leaf_element_size as usize * num_elements];
@@ -215,7 +215,7 @@ mod tests {
         let layer_hashes: Vec<&Hasher> = (0..nof_layers)
             .map(|_| &hasher)
             .collect();
-        let merkle_tree = MerkleTree::new(&layer_hashes[..], leaf_element_size as u64, 0).unwrap();
+        let merkle_tree = MerkleTree::new(layer_hashes.as_slice(), leaf_element_size as u64, 0).unwrap();
         merkle_tree
             .build(input.into_slice(), &MerkleTreeConfig::default())
             .unwrap();

--- a/wrappers/rust/icicle-hash/src/tests.rs
+++ b/wrappers/rust/icicle-hash/src/tests.rs
@@ -12,7 +12,11 @@ mod tests {
         hash::{HashConfig, Hasher},
         merkle::{MerkleProof, MerkleTree, MerkleTreeConfig},
     };
-    use icicle_runtime::{eIcicleError, memory::HostSlice, test_utilities};
+    use icicle_runtime::{
+        eIcicleError,
+        memory::{IntoIcicleSlice, IntoIcicleSliceMut},
+        test_utilities,
+    };
     use rand::Rng;
     use std::sync::Once;
 
@@ -38,21 +42,13 @@ mod tests {
         test_utilities::test_set_ref_device();
         let keccak_hasher = Keccak512::new(0 /*default chunk size */).unwrap();
         keccak_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_ref),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_ref.into_slice_mut())
             .unwrap();
 
         test_utilities::test_set_main_device();
         let keccak_hasher = Keccak512::new(0 /*default chunk size */).unwrap();
         keccak_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_main),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_main.into_slice_mut())
             .unwrap();
         assert_eq!(output_ref, output_main);
     }
@@ -71,21 +67,13 @@ mod tests {
         test_utilities::test_set_ref_device();
         let blake2s_hasher = Blake2s::new(0 /*default chunk size */).unwrap();
         blake2s_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_ref),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_ref.into_slice_mut())
             .unwrap();
 
         test_utilities::test_set_main_device();
         let blake2s_hasher = Blake2s::new(0 /*default chunk size */).unwrap();
         blake2s_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_main),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_main.into_slice_mut())
             .unwrap();
         assert_eq!(output_ref, output_main);
     }
@@ -104,21 +92,13 @@ mod tests {
         test_utilities::test_set_ref_device();
         let blake3_hasher = Blake3::new(0 /*default chunk size */).unwrap();
         blake3_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_ref),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_ref.into_slice_mut())
             .unwrap();
 
         test_utilities::test_set_main_device();
         let blake3_hasher = Blake3::new(0 /*default chunk size */).unwrap();
         blake3_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_main),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_main.into_slice_mut())
             .unwrap();
         assert_eq!(output_ref, output_main);
     }
@@ -135,11 +115,7 @@ mod tests {
         test_utilities::test_set_ref_device();
         let blake3_hasher = Blake3::new(0 /*default chunk size */).unwrap();
         blake3_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_ref),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_ref.into_slice_mut())
             .unwrap();
 
         // Convert output_ref to hex for comparison
@@ -167,21 +143,13 @@ mod tests {
         test_utilities::test_set_ref_device();
         let sha3_hasher = Sha3_256::new(0 /*default chunk size */).unwrap();
         sha3_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_ref),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_ref.into_slice_mut())
             .unwrap();
 
         test_utilities::test_set_main_device();
         let sha3_hasher = Sha3_256::new(0 /*default chunk size */).unwrap();
         sha3_hasher
-            .hash(
-                HostSlice::from_slice(&input),
-                &HashConfig::default(),
-                HostSlice::from_mut_slice(&mut output_main),
-            )
+            .hash(input.into_slice(), &HashConfig::default(), output_main.into_slice_mut())
             .unwrap();
 
         assert_eq!(output_ref, output_main);
@@ -218,12 +186,12 @@ mod tests {
         rand::thread_rng().fill(&mut input[..]); // Fill the vector with random data
 
         merkle_tree
-            .build(HostSlice::from_slice(&input), &MerkleTreeConfig::default())
+            .build(input.into_slice(), &MerkleTreeConfig::default())
             .unwrap();
 
         let merkle_proof: MerkleProof = merkle_tree
             .get_proof(
-                HostSlice::from_slice(&input),
+                input.into_slice(),
                 1,
                 false, /*=pruned*/
                 &MerkleTreeConfig::default(),
@@ -249,12 +217,12 @@ mod tests {
             .collect();
         let merkle_tree = MerkleTree::new(&layer_hashes[..], leaf_element_size as u64, 0).unwrap();
         merkle_tree
-            .build(HostSlice::from_slice(&input), &MerkleTreeConfig::default())
+            .build(input.into_slice(), &MerkleTreeConfig::default())
             .unwrap();
 
         let merkle_proof: MerkleProof = merkle_tree
             .get_proof(
-                HostSlice::from_slice(&input),
+                input.into_slice(),
                 1,
                 false, /*=pruned*/
                 &MerkleTreeConfig::default(),
@@ -286,7 +254,7 @@ mod tests {
         let input: [u8; 32] = [20; 32];
         let golden_nonce: u64 = 40825909;
         let golden_hash: u64 = 364385878471;
-        let input_host = HostSlice::from_slice(&input);
+        let input_host = input.into_slice();
         let cfg = PowConfig::default();
 
         let mut gpu_found = false;
@@ -367,7 +335,7 @@ mod tests {
         const BITS: u8 = 25;
         let input: [u8; 21] = [20; 21];
 
-        let input_host = HostSlice::from_slice(&input);
+        let input_host = input.into_slice();
         let mut cfg = PowConfig::default();
         cfg.padding_size = 3;
 

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/ring.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/ring.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 use std::ops::{Add, Mul, Sub};
 
 use icicle_runtime::errors::eIcicleError;
-use icicle_runtime::memory::HostOrDeviceSlice;
+use icicle_runtime::memory::{HostOrDeviceSlice, IntoIcicleSliceMut};
 use icicle_runtime::stream::IcicleStream;
 
 pub(crate) const SCALAR_LIMBS: usize = 2;

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -349,7 +349,7 @@ impl<T> DeviceSlice<T> {
 }
 
 impl<T> DeviceVec<T> {
-    pub fn device_malloc(count: usize) -> Result<Self, eIcicleError> {
+    fn device_malloc(count: usize) -> Result<Self, eIcicleError> {
         let size = count
             .checked_mul(size_of::<T>())
             .unwrap_or(0);
@@ -577,64 +577,58 @@ impl<T> DerefMut for DeviceVec<T> {
 
 // =============================================================================================
 // Adapter traits to turn common buffer types into `HostOrDeviceSlice`s with minimal boilerplate.
-// These are public so downstream crates (examples, wrappers, etc.) can import them.
 // =============================================================================================
 
-/// Immutable adapter – converts a variety of host/device buffers into something that implements
-/// `HostOrDeviceSlice`, removing the need for manual `HostSlice::from_slice` conversions.
 pub trait IntoIcicleSlice<'a, T: 'a> {
     type Out: HostOrDeviceSlice<T> + ?Sized + 'a;
-    fn into_icicle_slice(self) -> &'a Self::Out;
+    fn into_slice(self) -> &'a Self::Out;
 }
 
-/// Mutable adapter counterpart.
 pub trait IntoIcicleSliceMut<'a, T: 'a> {
     type Out: HostOrDeviceSlice<T> + ?Sized + 'a;
-    fn into_icicle_slice_mut(self) -> &'a mut Self::Out;
+    fn into_slice_mut(self) -> &'a mut Self::Out;
 }
 
-// ----------------------------------- Host buffers -------------------------------------------
-
+// Host buffer implementations
 impl<'a, T> IntoIcicleSlice<'a, T> for &'a [T] {
     type Out = HostSlice<T>;
-    fn into_icicle_slice(self) -> &'a HostSlice<T> {
+    fn into_slice(self) -> &'a HostSlice<T> {
         HostSlice::from_slice(self)
     }
 }
 
 impl<'a, T> IntoIcicleSlice<'a, T> for &'a Vec<T> {
     type Out = HostSlice<T>;
-    fn into_icicle_slice(self) -> &'a HostSlice<T> {
+    fn into_slice(self) -> &'a HostSlice<T> {
         HostSlice::from_slice(self.as_slice())
     }
 }
 
 impl<'a, T> IntoIcicleSliceMut<'a, T> for &'a mut [T] {
     type Out = HostSlice<T>;
-    fn into_icicle_slice_mut(self) -> &'a mut HostSlice<T> {
+    fn into_slice_mut(self) -> &'a mut HostSlice<T> {
         HostSlice::from_mut_slice(self)
     }
 }
 
 impl<'a, T> IntoIcicleSliceMut<'a, T> for &'a mut Vec<T> {
     type Out = HostSlice<T>;
-    fn into_icicle_slice_mut(self) -> &'a mut HostSlice<T> {
+    fn into_slice_mut(self) -> &'a mut HostSlice<T> {
         HostSlice::from_mut_slice(self.as_mut_slice())
     }
 }
 
-// ----------------------------------- Device buffers -----------------------------------------
-
+// Device buffer implementations
 impl<'a, T> IntoIcicleSlice<'a, T> for &'a DeviceVec<T> {
     type Out = DeviceSlice<T>;
-    fn into_icicle_slice(self) -> &'a DeviceSlice<T> {
+    fn into_slice(self) -> &'a DeviceSlice<T> {
         &**self
     }
 }
 
 impl<'a, T> IntoIcicleSliceMut<'a, T> for &'a mut DeviceVec<T> {
     type Out = DeviceSlice<T>;
-    fn into_icicle_slice_mut(self) -> &'a mut DeviceSlice<T> {
+    fn into_slice_mut(self) -> &'a mut DeviceSlice<T> {
         &mut **self
     }
 }

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -346,6 +346,21 @@ impl<T> DeviceSlice<T> {
             .wrap()
         }
     }
+
+    /// Copy the contents of the device slice back to the host and return them as `Vec<T>`.
+    /// Convenience method to avoid the boilerplate of allocating a host buffer and calling
+    /// `copy_to_host` manually. Requires `T: Copy + Default` so that we can cheaply create a
+    /// zero-initialised host vector.
+    pub fn to_host_vec(&self) -> Vec<T>
+    where
+        T: Copy + Default,
+    {
+        let mut host_vec = vec![T::default(); self.len()];
+        let host_slice = HostSlice::from_mut_slice(&mut host_vec);
+        self.copy_to_host(host_slice)
+            .unwrap();
+        host_vec
+    }
 }
 
 impl<T> DeviceVec<T> {

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -447,6 +447,7 @@ impl<T> DeviceVec<T> {
     ///
     /// Example:
     /// ```
+    /// use icicle_runtime::memory::{DeviceVec, HostSlice};
     /// let host_data = vec![1u32, 2, 3, 4];
     /// let device_buf = DeviceVec::<u32>::from_host_slice(&host_data);
     /// ```

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -364,7 +364,7 @@ impl<T> DeviceSlice<T> {
 }
 
 impl<T> DeviceVec<T> {
-    fn device_malloc(count: usize) -> Result<Self, eIcicleError> {
+    pub fn device_malloc(count: usize) -> Result<Self, eIcicleError> {
         let size = count
             .checked_mul(size_of::<T>())
             .unwrap_or(0);

--- a/wrappers/rust/icicle-runtime/src/memory.rs
+++ b/wrappers/rust/icicle-runtime/src/memory.rs
@@ -448,9 +448,9 @@ impl<T> DeviceVec<T> {
     /// Example:
     /// ```
     /// let host_data = vec![1u32, 2, 3, 4];
-    /// let device_buf = DeviceVec::<u32>::from_host_vec(&host_data);
+    /// let device_buf = DeviceVec::<u32>::from_host_slice(&host_data);
     /// ```
-    pub fn from_host_vec(src: &[T]) -> Self
+    pub fn from_host_slice(src: &[T]) -> Self
     where
         T: Copy,
     {

--- a/wrappers/rust/icicle-runtime/src/tests.rs
+++ b/wrappers/rust/icicle-runtime/src/tests.rs
@@ -142,23 +142,21 @@ mod tests {
                 .copy(&d_mem1)
                 .unwrap();
 
-            {
-                let h_output = output.into_slice_mut();
-                h_output
-                    .copy(&d_mem2[0..input.len()])
-                    .unwrap();
-            }
+            let h_output = output.into_slice_mut();
+            h_output
+                .copy(&d_mem2[0..input.len()])
+                .unwrap();
+
             assert_eq!(input, output);
         }
 
         // H -> H
         {
-            {
-                let h_output = output.into_slice_mut();
-                h_output
-                    .copy(h_input2)
-                    .unwrap();
-            }
+            let h_output = output.into_slice_mut();
+            h_output
+                .copy(h_input2)
+                .unwrap();
+
             assert_eq!(input2, output);
         }
     }

--- a/wrappers/rust/icicle-runtime/src/tests.rs
+++ b/wrappers/rust/icicle-runtime/src/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::config::ConfigExtension;
-    use crate::memory::{DeviceVec, HostOrDeviceSlice, HostSlice, IntoIcicleSlice, IntoIcicleSliceMut};
+    use crate::memory::{DeviceVec, HostOrDeviceSlice, IntoIcicleSlice, IntoIcicleSliceMut};
     use crate::stream::IcicleStream;
     use crate::test_utilities;
     use crate::*;

--- a/wrappers/rust/icicle-runtime/src/tests.rs
+++ b/wrappers/rust/icicle-runtime/src/tests.rs
@@ -85,7 +85,7 @@ mod tests {
         assert_ne!(input, output);
 
         // copy from input_host -> device --> output_host and compare
-        let mut d_mem = DeviceVec::device_malloc(input.len()).unwrap();
+        let mut d_mem = DeviceVec::<u8>::malloc(input.len());
         d_mem
             .copy_from_host(HostSlice::from_slice(&input))
             .unwrap();
@@ -107,7 +107,7 @@ mod tests {
         // ASYNC copy from input_host -> device --> output_host and compare
         let mut stream = IcicleStream::create().unwrap();
 
-        let mut d_mem = DeviceVec::device_malloc_async(input.len(), &stream).unwrap();
+        let mut d_mem = DeviceVec::<u8>::device_malloc_async(input.len(), &stream).unwrap();
         d_mem
             .copy_from_host_async(HostSlice::from_slice(&input), &stream)
             .unwrap();
@@ -139,12 +139,12 @@ mod tests {
         {
             let h_output = HostSlice::from_mut_slice(&mut output);
 
-            let mut d_mem1 = DeviceVec::device_malloc(input.len()).unwrap();
+            let mut d_mem1 = DeviceVec::<u8>::malloc(input.len());
             d_mem1
                 .copy(h_input)
                 .unwrap();
 
-            let mut d_mem2 = DeviceVec::device_malloc(input.len() * 5).unwrap();
+            let mut d_mem2 = DeviceVec::<u8>::malloc(input.len() * 5);
             d_mem2
                 .copy(&d_mem1)
                 .unwrap();
@@ -182,12 +182,12 @@ mod tests {
             let mut stream = IcicleStream::create().unwrap();
             let h_output = HostSlice::from_mut_slice(&mut output);
 
-            let mut d_mem1 = DeviceVec::device_malloc(input.len()).unwrap();
+            let mut d_mem1 = DeviceVec::<u8>::malloc(input.len());
             d_mem1
                 .copy_async(h_input, &stream)
                 .unwrap();
 
-            let mut d_mem2 = DeviceVec::device_malloc(input.len() * 5).unwrap();
+            let mut d_mem2 = DeviceVec::<u8>::malloc(input.len() * 5);
             d_mem2
                 .copy_async(&d_mem1, &stream)
                 .unwrap();
@@ -256,7 +256,7 @@ mod tests {
         let size = 1 << 10;
         let val = 42;
         let expected = vec![val; size];
-        let mut device_vec = DeviceVec::<u8>::device_malloc(size).unwrap();
+        let mut device_vec = DeviceVec::<u8>::malloc(size);
         device_vec
             .memset(val, size)
             .unwrap();
@@ -278,7 +278,7 @@ mod tests {
         let val = 42;
         let expected = vec![val; size >> 1];
         let stream = IcicleStream::create().unwrap();
-        let mut device_vec = DeviceVec::<u8>::device_malloc(size).unwrap();
+        let mut device_vec = DeviceVec::<u8>::malloc(size);
         device_vec.as_mut_slice()[1..size >> 1] // set only part of the slice
             .memset_async(val, (size >> 1) - 1, &stream)
             .unwrap();

--- a/wrappers/rust/icicle-runtime/src/tests.rs
+++ b/wrappers/rust/icicle-runtime/src/tests.rs
@@ -132,6 +132,7 @@ mod tests {
 
         // H -> D -> D -> H
         {
+            let h_output = output.into_slice_mut();
             let mut d_mem1 = DeviceVec::<u8>::malloc(input.len());
             d_mem1
                 .copy(h_input)
@@ -142,11 +143,9 @@ mod tests {
                 .copy(&d_mem1)
                 .unwrap();
 
-            let h_output = output.into_slice_mut();
             h_output
                 .copy(&d_mem2[0..input.len()])
                 .unwrap();
-
             assert_eq!(input, output);
         }
 
@@ -156,7 +155,6 @@ mod tests {
             h_output
                 .copy(h_input2)
                 .unwrap();
-
             assert_eq!(input2, output);
         }
     }


### PR DESCRIPTION
## 📌 Describe the Changes

This early draft PR introduces the following improvements:

1. **NTT Example Consistency**  
   Aligns the `ntt` example file behavior with the README instructions to ensure it behaves exactly as documented.

2. **Simplified Rust API for `HostOrDeviceSlice`**  
   Makes the Rust `HostOrDeviceSlice` API less verbose by avoiding advanced Rust syntax like `&mut scalars[..]`.  
   Uses simpler method calls like `.func_name()` instead.

3. **Improved Allocation Syntax**  
   Replaces verbose allocation like `DeviceVec::device_malloc().unwrap()` with cleaner `DeviceVec::malloc()`.  
   This makes it visually clear that the memory is allocated on the **device**, not the host — avoiding repetition like `device_malloc()` on a `DeviceVec`.

---

## 💡 Describe the Rationale

### Why is this change necessary?

- The current memory management API in Rust has long been a candidate for simplification and clarity improvements.
- This PR cleans up commonly used code blocks.
- Helps avoid cases [like this](https://github.com/ingonyama-zk/icicle/compare/develop/vhnat/rust-mem-api?expand=1#:~:text=let%20merkle_tree_min_layer_to_store%20%3D%200%3B), where memory is allocated and data copied to device, but actually is **unused**.

### Does this improve performance?

- No — this is purely for **ergonomic** and **readability** purposes.

### Scope

- Rust wrapper 

---

## 🤔 Suggestions / Open Questions

- **Rename `HostOrDeviceSlice` to `IcicleSlice`?**  
  A shorter, branded, and more intuitive name might improve ergonomics.

- **Confusing Behavior in Default Config**  
  The default config assumes all inputs are on the **host**.  
  However, when supplying a `DeviceVec` to a Rust function:
  - A **failsafe mechanism** overrides the config to: _inputs on device, outputs on device_.
  - As a result, outputs are unexpectedly placed on the device, even if the config specified host outputs.

  This implicit override is **confusing** and potentially error-prone.

### Possible Alternatives

- Respect user-defined config and enforce checks on input location.
- Emit warnings if the actual data doesn't match expectations.
- Provide **explicit wrappers** or helper methods:
  - Accepting `DeviceVec` or `HostSlice` directly.
  - Avoiding the use of dynamic `HostOrDeviceSlice` trait objects.

---

## 🔀 Backend Branches

- **CUDA Backend Branch:** `main` at [`2f6bbdb7`](https://github.com/ingonyama-zk/icicle-cuda-backend/commit/2f6bbdb781e0e7c6ebf0198fd25b845108707ef5)
- **Metal Backend Branch:** _Not specified_

