### PR TITLE
[FEATURE] Add float32-based operator norm via negacyclic FFT for PolyRing (N=64)

### DIFF
--- a/icicle/include/icicle/complex_fft.h
+++ b/icicle/include/icicle/complex_fft.h
@@ -1,0 +1,96 @@
+#pragma once
+
+/// @file complex_fft.h
+/// @brief Header file for complex FFT operations.
+/// This is actually negacyclic-fft of size N=64 for the PolyRing Zq[X]/(X^N + 1),
+
+// TODO: move this to cpu backend
+
+#include <array>
+#include <complex>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+
+namespace negacyclic_fft_cpu {
+
+  constexpr size_t N = 64;
+  constexpr double PI = 3.14159265358979323846;
+  using Complex = std::complex<double>;
+  using Poly = std::array<uint64_t, N>;
+  using CPoly = std::array<Complex, N>;
+
+  // Return psi^i (pre or post-twist), where psi^2 = root of unity
+  constexpr std::array<Complex, N> compute_twist(bool inverse = false)
+  {
+    std::array<Complex, N> twist{};
+    double angle_unit = PI / N; // 2π/2N = π/N
+    for (size_t i = 0; i < N; ++i) {
+      double angle = angle_unit * i;
+      if (inverse) angle = -angle;
+      twist[i] = Complex(std::cos(angle), std::sin(angle));
+    }
+    return twist;
+  }
+
+  // In-place Cooley-Tukey FFT (radix-2)
+  void fft(CPoly& a, bool inverse = false)
+  {
+    size_t n = a.size();
+    // Bit reversal
+    for (size_t i = 1, j = 0; i < n; ++i) {
+      size_t bit = n >> 1;
+      for (; j & bit; bit >>= 1)
+        j ^= bit;
+      j ^= bit;
+      if (i < j) std::swap(a[i], a[j]);
+    }
+
+    for (size_t len = 2; len <= n; len <<= 1) {
+      double ang = 2 * PI / len * (inverse ? -1 : 1);
+      Complex wlen(std::cos(ang), std::sin(ang));
+      for (size_t i = 0; i < n; i += len) {
+        Complex w = 1;
+        for (size_t j = 0; j < len / 2; ++j) {
+          Complex u = a[i + j];
+          Complex v = a[i + j + len / 2] * w;
+          a[i + j] = u + v;
+          a[i + j + len / 2] = u - v;
+          w *= wlen;
+        }
+      }
+    }
+
+    if (inverse) {
+      for (Complex& x : a)
+        x /= n;
+    }
+  }
+
+  // Entry point: compute operator norm of polynomial a in Zq[X]/(X⁶⁴ + 1)
+  double operator_norm(const Poly& a, uint64_t q)
+  {
+    static const auto twist = compute_twist();
+    static const auto twist_inv = compute_twist(true);
+
+    // Step 1: Convert to Complex, apply pre-twist
+    CPoly complex_a;
+    for (size_t i = 0; i < N; ++i)
+      complex_a[i] = Complex(static_cast<double>(a[i] % q), 0.0) * twist[i];
+
+    // Step 2: Forward FFT
+    fft(complex_a);
+
+    // Step 3: Post-twist
+    for (size_t i = 0; i < N; ++i)
+      complex_a[i] *= twist_inv[i];
+
+    // Step 4: Operator norm = max_i |value_i|
+    double max_norm = 0.0;
+    for (const auto& x : complex_a)
+      max_norm = std::max(max_norm, std::abs(x));
+
+    return max_norm;
+  }
+} // namespace negacyclic_fft_cpu

--- a/icicle/include/icicle/operator_norm.h
+++ b/icicle/include/icicle/operator_norm.h
@@ -18,7 +18,7 @@
 #include <cmath>
 #include <algorithm>
 
-namespace negacyclic_fft_cpu {
+namespace opnorm_cpu {
 
   constexpr size_t N = 64;
   constexpr float PI = 3.14159265358979323846f;
@@ -99,4 +99,4 @@ namespace negacyclic_fft_cpu {
     return static_cast<int64_t>(std::ceil(max_norm));
   }
 
-} // namespace negacyclic_fft_cpu
+} // namespace opnorm_cpu

--- a/icicle/tests/test_ring_api.cpp
+++ b/icicle/tests/test_ring_api.cpp
@@ -1290,7 +1290,7 @@ TEST_F(RingTestBase, RandomSampling)
 #include "icicle/operator_norm.h"
 TEST_F(RingTestBase, ComplexFFT_Simple)
 {
-  using namespace negacyclic_fft_cpu;
+  using namespace opnorm_cpu;
   Poly poly{};
   for (size_t i = 0; i < N; ++i)
     poly[i] = i * 100;
@@ -1302,7 +1302,7 @@ TEST_F(RingTestBase, ComplexFFT_Simple)
 
 TEST_F(RingTestBase, ComplexFFT_Alternating)
 {
-  using namespace negacyclic_fft_cpu;
+  using namespace opnorm_cpu;
   Poly poly{};
   for (size_t i = 0; i < N; ++i)
     poly[i] = (i % 2 == 0) ? 5000 : 0;
@@ -1315,7 +1315,7 @@ TEST_F(RingTestBase, ComplexFFT_Alternating)
 // TODO Roman: make this test pass by balancing [0,q) --> (-q/2,q/2]. See Python for reference
 TEST_F(RingTestBase, ComplexFFT_QMinus2X)
 {
-  using namespace negacyclic_fft_cpu;
+  using namespace opnorm_cpu;
   constexpr uint64_t q = (1ULL << 62) - 57;
 
   Poly poly{};

--- a/icicle/tests/test_ring_api.cpp
+++ b/icicle/tests/test_ring_api.cpp
@@ -1286,3 +1286,30 @@ TEST_F(RingTestBase, RandomSampling)
   test_random_sampling(true);
   test_random_sampling(false);
 }
+
+#include "icicle/complex_fft.h"
+TEST_F(RingTestBase, ComplexFFT_Simple)
+{
+  using namespace negacyclic_fft_cpu;
+  Poly poly{};
+  for (size_t i = 0; i < N; ++i)
+    poly[i] = i * 100;
+
+  uint64_t q = (1ULL << 62) - 57;
+  uint64_t opnorm = operator_norm(poly, q); // returns u64 now
+  ASSERT_LT(opnorm, 152850);                // Match with Python or manually adjust
+  std::cout << "Operator norm (simple): " << opnorm << "\n";
+}
+
+TEST_F(RingTestBase, ComplexFFT_Alternating)
+{
+  using namespace negacyclic_fft_cpu;
+  Poly poly{};
+  for (size_t i = 0; i < N; ++i)
+    poly[i] = (i % 2 == 0) ? 5000 : 0;
+
+  uint64_t q = (1ULL << 62) - 57;
+  uint64_t opnorm = operator_norm(poly, q); // returns u64
+  ASSERT_LT(opnorm, 101901);
+  std::cout << "Operator norm (alternating): " << opnorm << "\n";
+}

--- a/icicle/tests/test_ring_api.cpp
+++ b/icicle/tests/test_ring_api.cpp
@@ -1311,3 +1311,17 @@ TEST_F(RingTestBase, ComplexFFT_Alternating)
   ASSERT_LT(opnorm, 101902);             // Python computed '101900.08' but losing precision with f32
   std::cout << "Operator norm (alternating): " << opnorm << "\n";
 }
+
+// TODO Roman: make this test pass by balancing [0,q) --> (-q/2,q/2]. See Python for reference
+TEST_F(RingTestBase, ComplexFFT_QMinus2X)
+{
+  using namespace negacyclic_fft_cpu;
+  constexpr uint64_t q = (1ULL << 62) - 57;
+
+  Poly poly{};
+  poly[1] = q - 2; // Balanced as -2 in operator_norm()
+
+  uint64_t opnorm = operator_norm(poly);
+  ASSERT_EQ(opnorm, 2.1); // FFT of -2*X has magnitude 2 everywhere
+  std::cout << "Operator norm ((q - 2)*X): " << opnorm << "\n";
+}

--- a/icicle/tests/test_ring_api.cpp
+++ b/icicle/tests/test_ring_api.cpp
@@ -1287,7 +1287,7 @@ TEST_F(RingTestBase, RandomSampling)
   test_random_sampling(false);
 }
 
-#include "icicle/complex_fft.h"
+#include "icicle/operator_norm.h"
 TEST_F(RingTestBase, ComplexFFT_Simple)
 {
   using namespace negacyclic_fft_cpu;
@@ -1295,9 +1295,8 @@ TEST_F(RingTestBase, ComplexFFT_Simple)
   for (size_t i = 0; i < N; ++i)
     poly[i] = i * 100;
 
-  uint64_t q = (1ULL << 62) - 57;
-  uint64_t opnorm = operator_norm(poly, q); // returns u64 now
-  ASSERT_LT(opnorm, 152850);                // Match with Python or manually adjust
+  uint64_t opnorm = operator_norm(poly); // returns u64 now
+  ASSERT_LT(opnorm, 152851);             // Python computed 152849.98 but losing precision with f32
   std::cout << "Operator norm (simple): " << opnorm << "\n";
 }
 
@@ -1308,8 +1307,7 @@ TEST_F(RingTestBase, ComplexFFT_Alternating)
   for (size_t i = 0; i < N; ++i)
     poly[i] = (i % 2 == 0) ? 5000 : 0;
 
-  uint64_t q = (1ULL << 62) - 57;
-  uint64_t opnorm = operator_norm(poly, q); // returns u64
-  ASSERT_LT(opnorm, 101901);
+  uint64_t opnorm = operator_norm(poly); // returns u64
+  ASSERT_LT(opnorm, 101902);             // Python computed '101900.08' but losing precision with f32
   std::cout << "Operator norm (alternating): " << opnorm << "\n";
 }

--- a/scripts/python/operator_norm.py
+++ b/scripts/python/operator_norm.py
@@ -1,0 +1,44 @@
+# Close match: with manual pre/post twist
+import numpy as np
+import unittest
+from math import ceil
+
+def operator_norm(poly, N, q):
+    N = len(poly)
+    psi = np.exp(1j * np.pi / N)
+    indices = np.arange(N)
+    twist = psi ** indices
+    twisted = twist * (np.array(poly) % q)
+    fft_result = np.fft.fft(twisted)
+    untwisted = fft_result * (psi ** -indices)
+    return np.max(np.abs(untwisted))
+
+# --- Tests ---
+class TestOperatorNorm(unittest.TestCase):
+
+    def setUp(self):
+        self.N = 64
+        self.q = 2**62 - 57
+
+    def test_simple_polynomial(self):
+        poly = [i * 100 for i in range(self.N)]
+        norm = operator_norm(poly, self.N, self.q)
+        self.assertGreater(norm, 0.0)
+        self.assertLess(norm, 1e10)  # loose bound
+        print("norm (simple):", norm)
+
+    def test_zero_polynomial(self):
+        poly = [0] * self.N
+        norm = operator_norm(poly, self.N, self.q)
+        self.assertEqual(norm, 0.0)
+        
+    def test_alternating_values(self):
+        # Alternating large/small pattern
+        poly = [(i % 2) * 5000 for i in range(self.N)]
+        norm = operator_norm(poly, self.N, self.q)
+        self.assertGreater(norm, 0.0)
+        self.assertLess(norm, 1e10)  # adjust if needed
+        print("norm (alternating):", norm)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/python/operator_norm.py
+++ b/scripts/python/operator_norm.py
@@ -3,15 +3,25 @@ import numpy as np
 import unittest
 from math import ceil
 
+
+def balance(x, q):
+    reduced= x % q
+    """Convert x in [0, q) to balanced representation (-q/2, q/2]"""
+    return reduced - q if reduced >= (q // 2) else reduced
+
 def operator_norm(poly, N, q):
     N = len(poly)
+    # Convert to balanced form: (-q/2, q/2]
+    balanced = np.array([balance(x,q) for x in poly], dtype=np.float32)
     psi = np.exp(1j * np.pi / N)
     indices = np.arange(N)
     twist = psi ** indices
-    twisted = twist * (np.array(poly) % q)
+    twisted = twist * np.array(balanced)
     fft_result = np.fft.fft(twisted)
-    untwisted = fft_result * (psi ** -indices)
-    return np.max(np.abs(untwisted))
+    return np.max(np.abs(fft_result))
+    # twist is redundant when compute norm
+    # untwisted = fft_result * (psi ** -indices)
+    # return np.max(np.abs(untwisted))
 
 # --- Tests ---
 class TestOperatorNorm(unittest.TestCase):
@@ -23,8 +33,6 @@ class TestOperatorNorm(unittest.TestCase):
     def test_simple_polynomial(self):
         poly = [i * 100 for i in range(self.N)]
         norm = operator_norm(poly, self.N, self.q)
-        self.assertGreater(norm, 0.0)
-        self.assertLess(norm, 1e10)  # loose bound
         print("norm (simple):", norm)
 
     def test_zero_polynomial(self):
@@ -36,9 +44,15 @@ class TestOperatorNorm(unittest.TestCase):
         # Alternating large/small pattern
         poly = [(i % 2) * 5000 for i in range(self.N)]
         norm = operator_norm(poly, self.N, self.q)
-        self.assertGreater(norm, 0.0)
-        self.assertLess(norm, 1e10)  # adjust if needed
         print("norm (alternating):", norm)
+        
+    def test_small_negative_values(self):
+        # Test for a(x) = (q - 2) * X
+        poly = [0] * self.N
+        poly[1] = self.q - 2
+        norm = operator_norm(poly, self.N, self.q)
+        self.assertLess(norm, 2.1) 
+        print("norm (-2x):", norm)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a float32-based implementation of the operator norm for polynomials in Zq[X]/(X^N + 1), where N = 64, using a negacyclic FFT over the complex domain.
This is intended for use in rejection sampling (e.g., LaBRADOR) where the operator norm of sampled polynomials needs to be checked efficiently.

Follow-ups:
- fusion with rejection sampling
- CUDA port using shared memory and block-local sampling and FFT


cuda-backend-branch: main
metal-backend-branch: main
