### PR TITLE
Fix broken documentation links in Rust API docs

### DIFF
--- a/docs/docs/api/rust-bindings/fri.md
+++ b/docs/docs/api/rust-bindings/fri.md
@@ -106,4 +106,4 @@ assert!(valid);
 
 ## **Links**
 
-For more information on FRI concepts, see [FRI Primitives](../cpp/fri).
+For more information on FRI concepts, see [FRI Primitives](../cpp/fri.md).

--- a/docs/docs/api/rust-bindings/lattice/pqc-ml-kem.md
+++ b/docs/docs/api/rust-bindings/lattice/pqc-ml-kem.md
@@ -134,7 +134,7 @@ fn main() {
 
 ## Device & async execution
 
-The API works identically for Device buffers – allocate input/output `DeviceVec`s, and provide an `IcicleStream` for non-blocking execution. See [`tests.rs`](https://github.com/ingonyama-zk/icicle/blob/main/wrappers/rust/icicle-pqc/icicle-ml-kem/src/tests.rs) in the crate for an end-to-end example.
+The API works identically for Device buffers – allocate input/output `DeviceVec`s, and provide an `IcicleStream` for non-blocking execution. See [`tests.rs`](../../../../../wrappers/rust/icicle-pqc/src/ml_kem/tests.rs) in the crate for an end-to-end example.
 
 ---
 


### PR DESCRIPTION
Corrected outdated or broken links in the Rust API documentation. Updated the FRI documentation to reference the correct FRI Primitives file, and fixed the ML-KEM documentation to point to the correct location of the tests.rs example. These changes improve navigation and prevent 404 errors in the documentation.