### PR TITLE
[FIX] Unify Zq and Rq Balanced Base-b Decomposition Using Digit-Major Layout

### DIFF
--- a/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
+++ b/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
@@ -110,7 +110,7 @@ static eIcicleError cpu_decompose_balanced_digits(
   tf::Executor executor(get_nof_workers(config));
 
   const size_t total_size = input_size * config.batch_size;
-  constexpr size_t task_size = 256; // Seems to be working better
+  constexpr size_t task_size = 256; // Seems to perform well
   const size_t nof_tasks = (total_size + task_size - 1) / task_size;
 
   for (int task_idx = 0; task_idx < nof_tasks; ++task_idx) {
@@ -181,7 +181,7 @@ static eIcicleError cpu_recompose_from_balanced_digits(
   tf::Executor executor(get_nof_workers(config));
 
   const size_t total_size = output_size * config.batch_size;
-  constexpr size_t task_size = 256; // Seems to work well
+  constexpr size_t task_size = 256; // Seems to perform well
   const size_t nof_tasks = (total_size + task_size - 1) / task_size;
   for (int task_idx = 0; task_idx < nof_tasks; ++task_idx) {
     const size_t start = task_idx * task_size;

--- a/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
+++ b/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
@@ -73,6 +73,7 @@ static eIcicleError verify_params(
 }
 
 // Decomposes Zq elements into balanced base-b digits.
+// Decompose PolyRing polynomials into balanced base-b digits
 static eIcicleError cpu_decompose_balanced_digits(
   const Device& device,
   const field_t* input,
@@ -82,68 +83,79 @@ static eIcicleError cpu_decompose_balanced_digits(
   field_t* output,
   size_t output_size)
 {
-  auto params_valid = verify_params<field_t>(input, input_size, base, config, output, output_size);
+  auto params_valid = verify_params<field_t>(
+    input, input_size, base, config, output, output_size);
   if (eIcicleError::SUCCESS != params_valid) { return params_valid; }
 
   auto q = get_q<field_t>();
 
-  const size_t digits_per_element = balanced_decomposition::compute_nof_digits<field_t>(base);
-  if (output_size < input_size * digits_per_element) {
-    ICICLE_LOG_ERROR << "Output buffer too small for balanced decomposition.";
+  // Check that the sizes make sense and that we have enough digits.
+  // Note that not enough digits might be an issue but treated as warning.
+  const size_t digits_per_element = output_size / input_size;
+  if (output_size % input_size != 0) {
+    ICICLE_LOG_ERROR << "Balanced decomposition: output size must divide input size.";
     return eIcicleError::INVALID_ARGUMENT;
   }
 
-  const int64_t* input_i64 = reinterpret_cast<const int64_t*>(input);
-  int64_t* output_i64 = reinterpret_cast<int64_t*>(output);
+  const size_t expected_digits_per_element = balanced_decomposition::compute_nof_digits<field_t>(base);
+  if (digits_per_element < expected_digits_per_element) {
+    ICICLE_LOG_WARNING << "Balanced Decomposition: Output buffer may be too small to decompose input polynomials. "
+                          "Decomposition will stop after "
+                       << digits_per_element << "digits, based on output size.";
+  }
 
   const auto base_div2 = base / 2;
   const auto q_div2 = q / 2;
 
-  tf::Taskflow taskflow;
-  tf::Executor executor;
-  const uint64_t total_nof_operations = input_size * config.batch_size;
-  const int nof_workers = get_nof_workers(config);
-  const uint64_t worker_task_size = (total_nof_operations + nof_workers - 1) / nof_workers; // round up
+  tf::Taskflow tasks;
+  tf::Executor executor(get_nof_workers(config));
 
-  std::atomic<bool> error = false;
-  for (uint64_t start_idx = 0; start_idx < total_nof_operations; start_idx += worker_task_size) {
-    taskflow.emplace([=, &error]() {
-      const uint64_t end_idx = std::min(start_idx + worker_task_size, total_nof_operations);
-      for (uint64_t idx = start_idx; idx < end_idx; ++idx) {
-        int64_t val = input_i64[idx];
-        int64_t digit = 0;
-        // we need to handle case where val>q/2 by subtracting q (only for base>2)
-        if (base > 2 && val > q_div2) { val = val - q; }
+  // To decompose PolyRing polynomials into balanced digits, we decompose all d coefficients, in num_digits steps,
+  // creating a polynomial on each step.
+  const size_t total_size = input_size * config.batch_size;
+  constexpr size_t task_size = 64; // TODO Yuval - why? is it a good value
+  const size_t nof_tasks = (total_size + task_size - 1) / task_size;
+  for (int task_idx = 0; task_idx < nof_tasks; ++task_idx) {
+    tasks.emplace([=] {      
+      const int64_t* input_data_i64 = reinterpret_cast<const int64_t*>(input + task_idx*task_size);
 
-        for (size_t digit_idx = 0; digit_idx < digits_per_element; ++digit_idx) {
+      // Temporary buffer to hold intermediate remainders during decomposition.
+      
+      int64_t remainder[task_size];
+      std::memcpy(remainder, input_data_i64, sizeof(remainder));
+
+      for (int digit_idx = 0; digit_idx < digits_per_element; ++digit_idx) {
+        int64_t* output_data_task = reinterpret_cast<int64_t*>(output + digit_idx * total_size + task_idx*task_size);        
+
+        for (int i = 0; i < task_size; ++i) {
+          int64_t val = remainder[i];
+          int64_t digit = 0;
+
+          // we need to handle case where val>q/2 by subtracting q (only for base>2)
+          if (base > 2 && val > q_div2) { val -= q; }
+
           std::tie(val, digit) = divmod(val, base);
-
           // Shift into balanced digit range [-b/2, b/2)
           if (digit > base_div2) {
             digit -= base;
             ++val;
           }
 
-          // Wrap negative digits to [0, q) for representation in field_t
-          output_i64[idx * digits_per_element + digit_idx] = digit < 0 ? digit + q : digit;
-        }
-        if (val != 0) {
-          if (error) { return; } // stop processing if another thread already failed
-          ICICLE_LOG_ERROR << "Balanced decomposition failed: input value too large.";
-          error.store(true, std::memory_order_relaxed); // mark failure
-          return;
+          remainder[i] = val;
+          *(output_data_task + i) = digit < 0 ? digit + q : digit;
         }
       }
     });
   }
 
-  executor.run(taskflow).wait();
-  taskflow.clear();
+  executor.run(tasks).wait();
+  tasks.clear();
 
-  return error ? eIcicleError::INVALID_ARGUMENT : eIcicleError::SUCCESS;
+  return eIcicleError::SUCCESS;
 }
 
-// Recompose Zq elements from balanced base-b digits.
+
+// Recompose PolyRing polynomials from balanced base-b digits
 static eIcicleError cpu_recompose_from_balanced_digits(
   const Device& device,
   const field_t* input,
@@ -162,157 +174,27 @@ static eIcicleError cpu_recompose_from_balanced_digits(
     return eIcicleError::INVALID_ARGUMENT;
   }
 
-  field_t base_as_field = field_t::from(base);
-
-  tf::Taskflow taskflow;
-  tf::Executor executor;
-  const uint64_t total_nof_operations = output_size * config.batch_size;
-  const int nof_workers = get_nof_workers(config);
-  const uint64_t worker_task_size = (total_nof_operations + nof_workers - 1) / nof_workers; // round up
-
-  for (uint64_t start_idx = 0; start_idx < total_nof_operations; start_idx += worker_task_size) {
-    taskflow.emplace([=]() {
-      const uint64_t end_idx = std::min(start_idx + worker_task_size, total_nof_operations);
-      for (uint64_t out_idx = start_idx; out_idx < end_idx; ++out_idx) {
-        field_t acc = field_t::zero();
-        // computing 'x ≡ ∑ r_i * b^i mod q' in field_t
-        for (int digit_idx = digits_per_element - 1; digit_idx >= 0; --digit_idx) {
-          auto digit = input[out_idx * digits_per_element + digit_idx];
-          acc = acc * base_as_field + digit;
-        }
-        output[out_idx] = acc;
-      }
-    });
-  }
-
-  executor.run(taskflow).wait();
-  taskflow.clear();
-
-  return eIcicleError::SUCCESS;
-}
-
-REGISTER_BALANCED_DECOMPOSITION_BACKEND("CPU", cpu_decompose_balanced_digits, cpu_recompose_from_balanced_digits);
-
-// Decompose PolyRing polynomials into balanced base-b digits
-static eIcicleError cpu_decompose_balanced_digits_PolyRing(
-  const Device& device,
-  const PolyRing* input,
-  size_t input_size,
-  uint32_t base,
-  const VecOpsConfig& config,
-  PolyRing* output,
-  size_t output_size)
-{
-  auto params_valid = verify_params<PolyRing::Base>(
-    (PolyRing::Base*)input, input_size, base, config, (PolyRing::Base*)output, output_size);
-  if (eIcicleError::SUCCESS != params_valid) { return params_valid; }
-
-  auto q = get_q<PolyRing::Base>();
-
-  // Check that the sizes make sense and that we have enough digits.
-  // Note that not enough digits might be an issue but treated as warning.
-  const size_t digits_per_element = output_size / input_size;
-  if (output_size % input_size != 0) {
-    ICICLE_LOG_ERROR << "Balanced decomposition: output size must divide input size.";
-    return eIcicleError::INVALID_ARGUMENT;
-  }
-
-  const size_t expected_digits_per_element = balanced_decomposition::compute_nof_digits<PolyRing::Base>(base);
-  if (digits_per_element < expected_digits_per_element) {
-    ICICLE_LOG_WARNING << "Balanced Decomposition: Output buffer may be too small to decompose input polynomials. "
-                          "Decomposition will stop after "
-                       << digits_per_element << "digits, based on output size.";
-  }
-
-  const auto base_div2 = base / 2;
-  const auto q_div2 = q / 2;
-
-  tf::Taskflow tasks;
-  tf::Executor executor(get_nof_workers(config));
-
-  // To decompose PolyRing polynomials into balanced digits, we decompose all d coefficients, in num_digits steps,
-  // creating a polynomial on each step.
-  const size_t total_size = input_size * config.batch_size;
-  for (int poly_idx = 0; poly_idx < total_size; ++poly_idx) {
-    tasks.emplace([=] {
-      const PolyRing& input_poly = input[poly_idx];
-      const int64_t* input_coeffs = reinterpret_cast<const int64_t*>(input_poly.values);
-
-      // Temporary buffer to hold intermediate remainders during decomposition.
-      int64_t remainder[PolyRing::d];
-      std::memcpy(remainder, input_coeffs, sizeof(remainder));
-
-      for (int digit_idx = 0; digit_idx < digits_per_element; ++digit_idx) {
-        PolyRing& output_poly = output[digit_idx * total_size + poly_idx];
-        int64_t* output_coeffs = reinterpret_cast<int64_t*>(output_poly.values);
-
-        for (int coeff_idx = 0; coeff_idx < PolyRing::d; ++coeff_idx) {
-          int64_t val = remainder[coeff_idx];
-          int64_t digit = 0;
-
-          // we need to handle case where val>q/2 by subtracting q (only for base>2)
-          if (base > 2 && val > q_div2) { val -= q; }
-
-          std::tie(val, digit) = divmod(val, base);
-          // Shift into balanced digit range [-b/2, b/2)
-          if (digit > base_div2) {
-            digit -= base;
-            ++val;
-          }
-
-          remainder[coeff_idx] = val;
-          output_coeffs[coeff_idx] = digit < 0 ? digit + q : digit;
-        }
-      }
-    });
-  }
-
-  executor.run(tasks).wait();
-  tasks.clear();
-
-  return eIcicleError::SUCCESS;
-}
-
-// Recompose PolyRing polynomials from balanced base-b digits
-static eIcicleError cpu_recompose_from_balanced_digits_PolyRing(
-  const Device& device,
-  const PolyRing* input,
-  size_t input_size,
-  uint32_t base,
-  const VecOpsConfig& config,
-  PolyRing* output,
-  size_t output_size)
-{
-  auto params_valid = verify_params<PolyRing::Base>(
-    (PolyRing::Base*)input, input_size, base, config, (PolyRing::Base*)output, output_size);
-  if (eIcicleError::SUCCESS != params_valid) { return params_valid; }
-
-  const size_t digits_per_element = input_size / output_size;
-  if (input_size % output_size != 0) {
-    ICICLE_LOG_ERROR << "Balanced recomposition: output size must divide input size.";
-    return eIcicleError::INVALID_ARGUMENT;
-  }
-
-  const PolyRing::Base base_as_field = PolyRing::Base::from(base);
+  const field_t base_as_field = field_t::from(base);
 
   tf::Taskflow tasks;
   tf::Executor executor(get_nof_workers(config));
 
   const size_t total_size = output_size * config.batch_size;
-  for (int poly_idx = 0; poly_idx < total_size; ++poly_idx) {
+  constexpr size_t task_size = 64; // TODO Yuval: why?
+  const size_t nof_tasks = (total_size + task_size - 1) / task_size;
+  for (int task_idx = 0; task_idx < nof_tasks; ++task_idx) {
     tasks.emplace([=]() {
-      PolyRing result;
       // Recompose a single output polynomial from its digit-wise components
-      for (int coeff_idx = 0; coeff_idx < PolyRing::d; ++coeff_idx) {
-        PolyRing::Base acc = PolyRing::Base::zero();
+      for (int i = 0; i < task_size; ++i) {
+        field_t acc = field_t::zero();
         // Accumulate from most significant digit to least
         for (int digit_idx = digits_per_element - 1; digit_idx >= 0; --digit_idx) {
-          const PolyRing& input_poly = input[digit_idx * total_size + poly_idx];
-          acc = acc * base_as_field + input_poly.values[coeff_idx];
+          // input is organized digit-major
+          const field_t& val = *(input + digit_idx * total_size + task_idx*task_size + i);
+          acc = acc * base_as_field + val;
         }
-        result.values[coeff_idx] = acc;
+        *(output + task_idx*task_size + i) = acc;
       }
-      output[poly_idx] = result;
     });
   }
 
@@ -322,5 +204,5 @@ static eIcicleError cpu_recompose_from_balanced_digits_PolyRing(
   return eIcicleError::SUCCESS;
 }
 
-REGISTER_BALANCED_DECOMPOSITION_POLYRING_BACKEND(
-  "CPU", cpu_decompose_balanced_digits_PolyRing, cpu_recompose_from_balanced_digits_PolyRing);
+
+REGISTER_BALANCED_DECOMPOSITION_BACKEND("CPU", cpu_decompose_balanced_digits, cpu_recompose_from_balanced_digits);

--- a/icicle/include/icicle/balanced_decomposition.h
+++ b/icicle/include/icicle/balanced_decomposition.h
@@ -6,23 +6,29 @@ namespace icicle {
   namespace balanced_decomposition {
 
     /**
-     * @brief Compute the number of digits required to represent any element
-     *        using balanced base-b decomposition.
+     * @brief Balanced base-b decomposition for elements in Zq or polynomial rings over Zq.
      *
-     * Supports both:
-     *   - Scalar rings (e.g., Zq)
-     *   - Polynomial rings (e.g., Rq = Zq[x]/(X^d + 1), modeled as PolynomialRing<Zq, d>)
+     * Supported types:
+     *   - Scalar rings: Zq
+     *   - Polynomial rings: Rq = Zq[x]/(X^d + 1), modeled as PolynomialRing<Zq, d>
      *
-     * The number of digits is computed per scalar coefficient (Zq), and applies
-     * equally to each coefficient in a polynomial.
+     * In all cases, the layout is **digit-major**:
+     *   - The output is organized as a matrix where each row corresponds to a digit index.
+     *   - Each row contains all elements’ values at that digit position (e.g., r₀, then r₁, etc.).
+     */
+
+    /**
+     * @brief Compute the number of digits required to represent any Zq element using balanced base-b decomposition.
      *
-     * Each Zq element is represented using digits in the range (-b/2, b/2], and
-     * an extra digit is added when base > 2 to handle carry propagation.
+     * The result applies per scalar coefficient and extends naturally to polynomials by applying it to each
+     * coefficient.
      *
-     * @tparam T    Element type. Must define `T::TLC == 2` and `T::get_modulus()`.
-     *              Typically `Zq` or `PolynomialRing<Zq, d>`.
+     * Each Zq element is represented with digits in the range (-b/2, b/2], and an extra digit is added when `base > 2`
+     * to account for possible carry propagation.
+     *
+     * @tparam T    Element type.
      * @param base  Decomposition base b (must be ≥ 2).
-     * @return      Number of balanced digits required to represent any element of type T.
+     * @return      Number of digits required to represent a single Zq element in balanced base-b form.
      */
     template <typename T>
     static constexpr inline uint32_t compute_nof_digits(uint32_t base)
@@ -41,35 +47,38 @@ namespace icicle {
     }
 
     /**
-     * @brief Decomposes elements into balanced base-b digits.
+     * @brief Decompose a vector of elements into balanced base-b digits.
      *
-     * For scalars (T = Zq):
+     * For Zq scalars:
      *   Each element x ∈ Zq is decomposed as:
      *
      *     x ≡ r₀ + b·r₁ + b²·r₂ + ... + b^{t−1}·r_{t−1} mod q
      *
-     *   The output layout is **element-major**, meaning all t digits of the first
-     *   element are stored consecutively, followed by the digits of the second element, and so on.
+     *   The output is digit-major: all r₀ values first, then r₁, and so on.
+     *   This results in a flat array of `t × input_size` Zq values.
      *
-     * For polynomials (T = PolynomialRing<Zq, d>):
-     *   Each coefficient a_j ∈ Zq of a polynomial P(x) is decomposed independently into t digits:
+     * For PolynomialRing<Zq, d>:
+     *   The input is a vector of `input_size` polynomials P(x) = ∑ aᵢ·xⁱ,
+     *   where each coefficient aᵢ ∈ Zq.
      *
-     *     a_j = r_{j,0} + b·r_{j,1} + ... + b^{t−1}·r_{j,t−1}
+     *   Each coefficient is decomposed independently:
      *
-     *   The result is a sequence of t polynomials:
+     *     aᵢ = rᵢ₀ + b·rᵢ₁ + ... + b^{t−1}·rᵢ_{t−1}
      *
-     *     P(x) = P₀(x) + b·P₁(x) + b²·P₂(x) + ... + b^{t−1}·P_{t−1}(x)
+     *   The output is a vector of `t × input_size` polynomials.
+     *   Each group of `input_size` polynomials corresponds to one digit:
+     *     - Rows-0 contains digit-0 polynomials (P₀(x) for all inputs)
+     *     - Rows-1 contains digit-1 polynomials (P₁(x)), etc.
      *
-     *   The output layout is **digit-major**, meaning all first digits of all input polynomials
-     *   come first (as polynomials), followed by all second digits, and so on.
+     *   This layout is **digit-major**, meaning each row encodes the same digit across all input polynomials.
      *
      * @tparam T             Element type (`Zq` or `PolynomialRing<Zq, d>`)
      * @param input          Pointer to input elements.
-     * @param input_size     Number of input elements.
-     * @param base           Decomposition base `b`.
-     * @param config         Vectorization and device configuration.
-     * @param output         Output buffer (must hold input_size × digits elements).
-     * @param output_size    Number of output elements.
+     * @param input_size     Number of input elements (Zq scalars or polynomials).
+     * @param base           Decomposition base `b` (must be ≥ 2).
+     * @param config         Device execution and memory layout settings.
+     * @param output         Output buffer: must hold `input_size × digits` elements.
+     * @param output_size    Number of output elements (should be `input_size × digits`).
      * @return               eIcicleError indicating success or failure.
      */
     template <typename T>
@@ -77,25 +86,19 @@ namespace icicle {
       const T* input, size_t input_size, uint32_t base, const VecOpsConfig& config, T* output, size_t output_size);
 
     /**
-     * @brief Recomposes elements from balanced base-b digits.
+     * @brief Recompose elements from their balanced base-b digit representation.
      *
-     * For each element x ∈ T, reconstructs:
+     * Reconstructs each element x ∈ T as:
      *
-     *     x = ∑ r_i · b^i mod q
+     *     x = ∑ rᵢ · bⁱ mod q
      *
-     * For PolynomialRing<Zq, d>, this applies to each coefficient independently.
-     *
-     * Input layout expectations:
-     *   - For scalars (Zq): the digits are stored element-major (each element's digits in sequence).
-     *   - For polynomials: the digits are stored digit-major (all P₀(x), then all P₁(x), ...).
-     *
-     * The layout must match that produced by `decompose()`.
+     * Input layout must be digit-major (i.e., match the layout from `decompose()`).
      *
      * @tparam T             Element type (`Zq` or `PolynomialRing<Zq, d>`)
-     * @param input          Pointer to flattened input digits.
-     * @param input_size     Number of input elements (digits × input_size).
-     * @param base           The base `b` used in decomposition.
-     * @param config         Vectorization and device configuration.
+     * @param input          Pointer to input digits (Zq or polynomials), in digit-major order.
+     * @param input_size     Total number of input digits (should be `output_size × digits`).
+     * @param base           Decomposition base `b`.
+     * @param config         Execution configuration.
      * @param output         Output buffer to store recomposed elements.
      * @param output_size    Number of elements to reconstruct.
      * @return               eIcicleError indicating success or failure.

--- a/icicle/src/balanced_decomposition.cpp
+++ b/icicle/src/balanced_decomposition.cpp
@@ -70,19 +70,6 @@ namespace icicle {
   }
 
   /*********************************** BALANCED DECOMPOSITION/RECOMPOSITION PolyRing ************************/
-  ICICLE_DISPATCHER_INST(
-    BalancedDecomposePolyRingDispatcher, decompose_balanced_digits_poly_ring, balancedDecompositionPolyRingImpl);
-
-  extern "C" eIcicleError CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_ring_decompose_balanced_digits)(
-    const PolyRing* input,
-    size_t input_size,
-    uint32_t base,
-    const VecOpsConfig* config,
-    PolyRing* output,
-    size_t output_size)
-  {
-    return BalancedDecomposePolyRingDispatcher::execute(input, input_size, base, *config, output, output_size);
-  }
 
   namespace balanced_decomposition {
     template <>
@@ -94,24 +81,10 @@ namespace icicle {
       PolyRing* output,
       size_t output_size)
     {
-      return CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_ring_decompose_balanced_digits)(
-        input, input_size, base, &config, output, output_size);
+      return CONCAT_EXPAND(ICICLE_FFI_PREFIX, decompose_balanced_digits)((const field_t*)input, input_size * PolyRing::d, base, &config, (field_t*)output, output_size * PolyRing::d);
     }
   } // namespace balanced_decomposition
 
-  ICICLE_DISPATCHER_INST(
-    BalancedRecomposePolyRingDispatcher, recompose_from_balanced_digits_poly_ring, balancedDecompositionPolyRingImpl);
-
-  extern "C" eIcicleError CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_ring_recompose_from_balanced_digits)(
-    const PolyRing* input,
-    size_t input_size,
-    uint32_t base,
-    const VecOpsConfig* config,
-    PolyRing* output,
-    size_t output_size)
-  {
-    return BalancedRecomposePolyRingDispatcher::execute(input, input_size, base, *config, output, output_size);
-  }
 
   namespace balanced_decomposition {
     template <>
@@ -123,8 +96,8 @@ namespace icicle {
       PolyRing* output,
       size_t output_size)
     {
-      return CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_ring_recompose_from_balanced_digits)(
-        input, input_size, base, &config, output, output_size);
+      return CONCAT_EXPAND(ICICLE_FFI_PREFIX, recompose_from_balanced_digits)(
+        (const field_t*)input, input_size * PolyRing::d, base, &config, (field_t*)output, output_size * PolyRing::d);
     }
   } // namespace balanced_decomposition
 } // namespace icicle


### PR DESCRIPTION
This PR changes the balanced base-b decomposition for Zq scalars to use a digit-major layout, consistent with the existing behavior for Rq polynomials. This enables unified and consolidated implementation across scalar and polynomial types.

cuda-backend-branch: yshekel/balanced_decomposition_zq_digit_major
