### PR TITLE
Rust transpose refactoring

### DIFF
--- a/icicle/src/matrix_ops.cpp
+++ b/icicle/src/matrix_ops.cpp
@@ -120,7 +120,7 @@ namespace icicle {
   // Poly ring matrix transpose
   ICICLE_DISPATCHER_INST(ringPolyMatrixTransposeDispatcher, poly_ring_matrix_transpose, ringPolyRingMatrixOpImpl);
 
-  extern "C" eIcicleError CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_matrix_transpose)(
+  extern "C" eIcicleError CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_ring_matrix_transpose)(
     const PolyRing* mat_in, uint32_t nof_rows, uint32_t nof_cols, const VecOpsConfig* config, PolyRing* mat_out)
   {
     return ringPolyMatrixTransposeDispatcher::execute(mat_in, nof_rows, nof_cols, *config, mat_out);
@@ -130,7 +130,7 @@ namespace icicle {
   eIcicleError matrix_transpose(
     const PolyRing* mat_in, uint32_t nof_rows, uint32_t nof_cols, const VecOpsConfig& config, PolyRing* mat_out)
   {
-    return CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_matrix_transpose)(mat_in, nof_rows, nof_cols, &config, mat_out);
+    return CONCAT_EXPAND(ICICLE_FFI_PREFIX, poly_ring_matrix_transpose)(mat_in, nof_rows, nof_cols, &config, mat_out);
   }
 
 #endif // RING

--- a/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
@@ -1,23 +1,33 @@
+//! Matrix operations over data stored in host or device memory.
+//!
+//! This module defines a trait [`MatrixOps`] and convenience functions for
+//! performing matrix computations such as multiplication and transposition
+//! across heterogeneous memory backends (CPU or GPU).
+//!
+//! ## Supported Operations
+//!
+//! - Matrix multiplication (`matmul`)
+//! - Matrix transpose (`matrix_transpose`)
+//!
+//! All functions are backend-agnostic and dispatched using [`VecOpsConfig`].
+
 use crate::vec_ops::VecOpsConfig;
 use icicle_runtime::{eIcicleError, memory::HostOrDeviceSlice};
 
 pub mod tests;
 
-/// Trait defining matrix operations for types stored in host or device memory.
-///
-/// ### Supported Operations
-/// - **Matrix multiplication (`matmul`)**  
-///   Multiplies two matrices `a` and `b`, both stored in **row-major** (rows-first) order,
-///   and writes the result to `result`, also in row-major order.
-///
-///   Dimensions must satisfy:
-///   - `a` is of shape `(a_rows × a_cols)`
-///   - `b` is of shape `(b_rows × b_cols)`
-///   - `a_cols == b_rows`
-///   - `result` must be sized to hold `(a_rows × b_cols)` elements
-///
-///   Memory for all inputs and the result can reside on either the host or device.
+/// Trait defining matrix operations over row-major matrices stored in host or device memory.
 pub trait MatrixOps<T> {
+    /// Performs matrix multiplication: `result = a × b`
+    ///
+    /// - `a`: shape `(a_rows × a_cols)` (row-major)
+    /// - `b`: shape `(b_rows × b_cols)` (row-major)
+    /// - `result`: shape `(a_rows × b_cols)` (row-major, must be preallocated)
+    ///
+    /// Requirements:
+    /// - `a_cols == b_rows`
+    /// - All buffers may reside in host or device memory
+    ///
     fn matmul(
         a: &(impl HostOrDeviceSlice<T> + ?Sized),
         a_rows: u32,
@@ -28,8 +38,25 @@ pub trait MatrixOps<T> {
         cfg: &VecOpsConfig,
         result: &mut (impl HostOrDeviceSlice<T> + ?Sized),
     ) -> Result<(), eIcicleError>;
+
+    /// Computes the transpose of a matrix in row-major order.
+    ///
+    /// - `input`: shape `(nof_rows × nof_cols)`
+    /// - `output`: shape `(nof_cols × nof_rows)` (must be preallocated)
+    ///
+    /// Both input and output can reside on host or device memory.
+    fn matrix_transpose(
+        input: &(impl HostOrDeviceSlice<T> + ?Sized),
+        nof_rows: u32,
+        nof_cols: u32,
+        cfg: &VecOpsConfig,
+        output: &mut (impl HostOrDeviceSlice<T> + ?Sized),
+    ) -> Result<(), eIcicleError>;
 }
 
+/// Dispatches [`MatrixOps::matmul`] using the type `T`.
+///
+/// All matrices are expected to be in row-major order.
 pub fn matmul<T>(
     a: &(impl HostOrDeviceSlice<T> + ?Sized),
     a_rows: u32,
@@ -46,10 +73,26 @@ where
     T::matmul(a, a_rows, a_cols, b, b_rows, b_cols, cfg, result)
 }
 
-/// Implements matrix multiplication over polynomial rings via FFI
+/// Dispatches [`MatrixOps::matrix_transpose`] using the type `T`.
+///
+/// All matrices are assumed to be in row-major order.
+pub fn matrix_transpose<T>(
+    input: &(impl HostOrDeviceSlice<T> + ?Sized),
+    nof_rows: u32,
+    nof_cols: u32,
+    cfg: &VecOpsConfig,
+    output: &mut (impl HostOrDeviceSlice<T> + ?Sized),
+) -> Result<(), eIcicleError>
+where
+    T: MatrixOps<T>,
+{
+    T::matrix_transpose(input, nof_rows, nof_cols, cfg, output)
+}
+
+/// Implements matrix Ops any type via FFI
 #[macro_export]
-macro_rules! impl_matmul {
-    ($prefix: literal, $poly_type: ty) => {
+macro_rules! impl_matrix_ops {
+    ($prefix: literal, $element_type: ty) => {
         mod labrador {
             use crate::matrix_ops::labrador;
             use icicle_core::{matrix_ops::MatrixOps, vec_ops::VecOpsConfig};
@@ -59,27 +102,37 @@ macro_rules! impl_matmul {
             extern "C" {
                 #[link_name = concat!($prefix, "_matmul")]
                 pub(crate) fn matmul_ffi(
-                    a: *const $poly_type,
+                    a: *const $element_type,
                     a_rows: u32,
                     a_cols: u32,
-                    b: *const $poly_type,
+                    b: *const $element_type,
                     b_rows: u32,
                     b_cols: u32,
                     cfg: *const VecOpsConfig,
-                    result: *mut $poly_type,
+                    result: *mut $element_type,
                 ) -> eIcicleError;
+
+                #[link_name = concat!($prefix, "_matrix_transpose")]
+                pub(crate) fn matrix_transpose_ffi(
+                    input: *const $element_type,
+                    nof_ows: u32,
+                    nof_cols: u32,
+                    cfg: *const VecOpsConfig,
+                    output: *mut $element_type,
+                ) -> eIcicleError;
+
             }
 
-            impl MatrixOps<$poly_type> for $poly_type {
+            impl MatrixOps<$element_type> for $element_type {
                 fn matmul(
-                    a: &(impl HostOrDeviceSlice<$poly_type> + ?Sized),
+                    a: &(impl HostOrDeviceSlice<$element_type> + ?Sized),
                     nof_rows_a: u32,
                     nof_cols_a: u32,
-                    b: &(impl HostOrDeviceSlice<$poly_type> + ?Sized),
+                    b: &(impl HostOrDeviceSlice<$element_type> + ?Sized),
                     nof_rows_b: u32,
                     nof_cols_b: u32,
                     cfg: &VecOpsConfig,
-                    result: &mut (impl HostOrDeviceSlice<$poly_type> + ?Sized),
+                    result: &mut (impl HostOrDeviceSlice<$element_type> + ?Sized),
                 ) -> Result<(), eIcicleError> {
                     if a.len() as u32 != nof_rows_a * nof_cols_a {
                         eprintln!(
@@ -148,30 +201,82 @@ macro_rules! impl_matmul {
                         .wrap()
                     }
                 }
+
+                fn matrix_transpose(
+                    input: &(impl HostOrDeviceSlice<$element_type> + ?Sized),
+                    nof_rows: u32,
+                    nof_cols: u32,
+                    cfg: &VecOpsConfig,
+                    output: &mut (impl HostOrDeviceSlice<$element_type> + ?Sized),
+                ) -> Result<(), eIcicleError> {
+                    if input.len() as u32 != nof_rows * nof_cols {
+                        eprintln!(
+                            "Matrix A has invalid size: got {}, expected {} ({} × {})",
+                            input.len(),
+                            nof_rows * nof_cols,
+                            nof_rows,
+                            nof_cols
+                        );
+                        return Err(eIcicleError::InvalidArgument);
+                    }
+
+                    if output.len() != input.len() {
+                        eprintln!("Output matrix has invalid size",);
+                        return Err(eIcicleError::InvalidArgument);
+                    }
+
+                    if input.is_on_device() && !input.is_on_active_device() {
+                        eprintln!("Input a is on an inactive device");
+                        return Err(eIcicleError::InvalidArgument);
+                    }
+
+                    if output.is_on_device() && !output.is_on_active_device() {
+                        eprintln!("Result matrix is on an inactive device");
+                        return Err(eIcicleError::InvalidArgument);
+                    }
+
+                    let mut cfg_clone = cfg.clone();
+                    cfg_clone.is_a_on_device = input.is_on_device();
+                    cfg_clone.is_b_on_device = false;
+                    cfg_clone.is_result_on_device = output.is_on_device();
+
+                    unsafe {
+                        labrador::matrix_transpose_ffi(
+                            input.as_ptr(),
+                            nof_rows,
+                            nof_cols,
+                            &cfg_clone,
+                            output.as_mut_ptr(),
+                        )
+                        .wrap()
+                    }
+                }
             }
         }
     };
 }
 
 #[macro_export]
-macro_rules! impl_matmul_device_tests {
-    ($poly:ty) => {
-        #[cfg(test)]
-        mod test_matmul_device_memory {
+macro_rules! impl_matrix_ops_tests {
+    ($test_mod_name:ident, $element_type:ty) => {
+        use icicle_core::matrix_ops::tests::*;
+        use icicle_runtime::test_utilities;
 
-            use icicle_core::matrix_ops::tests::*;
-            use icicle_runtime::test_utilities;
+        pub fn initialize() {
+            test_utilities::test_load_and_init_devices();
+            test_utilities::test_set_main_device();
+        }
 
-            pub fn initialize() {
-                test_utilities::test_load_and_init_devices();
-                test_utilities::test_set_main_device();
-            }
+        #[test]
+        fn test_matmul_device_memory() {
+            initialize();
+            check_matmul_device_memory::<$element_type>();
+        }
 
-            #[test]
-            fn test_matmul_device_memory() {
-                initialize();
-                check_matmul_device_memory::<$poly>();
-            }
+        #[test]
+        fn test_matrix_transpose() {
+            initialize();
+            check_matrix_transpose_device_memory::<$element_type>();
         }
     };
 }

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -109,14 +109,6 @@ pub trait VecOps<F> {
         cfg: &VecOpsConfig,
     ) -> Result<(), eIcicleError>;
 
-    fn transpose(
-        input: &(impl HostOrDeviceSlice<F> + ?Sized),
-        nof_rows: u32,
-        nof_cols: u32,
-        output: &mut (impl HostOrDeviceSlice<F> + ?Sized),
-        cfg: &VecOpsConfig,
-    ) -> Result<(), eIcicleError>;
-
     fn bit_reverse(
         input: &(impl HostOrDeviceSlice<F> + ?Sized),
         cfg: &VecOpsConfig,
@@ -447,21 +439,6 @@ where
 {
     let cfg = check_vec_ops_args_scalar_ops(a, b, result, cfg);
     <<F as FieldImpl>::Config as VecOps<F>>::scalar_mul(a, b, result, &cfg)
-}
-
-pub fn transpose_matrix<F>(
-    input: &(impl HostOrDeviceSlice<F> + ?Sized),
-    nof_rows: u32,
-    nof_cols: u32,
-    output: &mut (impl HostOrDeviceSlice<F> + ?Sized),
-    cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>
-where
-    F: FieldImpl,
-    <F as FieldImpl>::Config: VecOps<F>,
-{
-    let cfg = check_vec_ops_args_transpose(input, nof_rows, nof_cols, output, cfg);
-    <<F as FieldImpl>::Config as VecOps<F>>::transpose(input, nof_rows, nof_cols, output, &cfg)
 }
 
 pub fn bit_reverse<F>(
@@ -837,25 +814,6 @@ macro_rules! impl_vec_ops_field {
                 }
             }
 
-            fn transpose(
-                input: &(impl HostOrDeviceSlice<$field> + ?Sized),
-                nof_rows: u32,
-                nof_cols: u32,
-                output: &mut (impl HostOrDeviceSlice<$field> + ?Sized),
-                cfg: &VecOpsConfig,
-            ) -> Result<(), eIcicleError> {
-                unsafe {
-                    $field_prefix_ident::matrix_transpose_ffi(
-                        input.as_ptr(),
-                        nof_rows,
-                        nof_cols,
-                        cfg as *const VecOpsConfig,
-                        output.as_mut_ptr(),
-                    )
-                    .wrap()
-                }
-            }
-
             fn bit_reverse(
                 input: &(impl HostOrDeviceSlice<$field> + ?Sized),
                 cfg: &VecOpsConfig,
@@ -1056,11 +1014,7 @@ macro_rules! impl_vec_ops_tests {
                 check_vec_ops_scalars_inv::<$field>(test_size);
             }
 
-            #[test]
-            pub fn test_matrix_transpose() {
-                initialize();
-                check_matrix_transpose::<$field>()
-            }
+
 
             #[test]
             pub fn test_bit_reverse() {

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -192,31 +192,7 @@ fn check_vec_ops_args_reduction_ops<F>(
     setup_config(input, input, result, cfg, batch_size)
 }
 
-fn check_vec_ops_args_transpose<F>(
-    input: &(impl HostOrDeviceSlice<F> + ?Sized),
-    nof_rows: u32,
-    nof_cols: u32,
-    output: &(impl HostOrDeviceSlice<F> + ?Sized),
-    cfg: &VecOpsConfig,
-) -> VecOpsConfig {
-    if input.len() != output.len() {
-        panic!(
-            "Input size, and output size do not match {} != {}",
-            input.len(),
-            output.len()
-        );
-    }
-    if input.len() as u32 % (nof_rows * nof_cols) != 0 {
-        panic!(
-            "Input size is not a whole multiple of matrix size (#rows * #cols), {} % ({} * {}) != 0",
-            input.len(),
-            nof_rows,
-            nof_cols,
-        );
-    }
-    let batch_size = input.len() / (nof_rows * nof_cols) as usize;
-    setup_config(input, input, output, cfg, batch_size)
-}
+
 
 fn check_vec_ops_args_slice<F>(
     input: &(impl HostOrDeviceSlice<F> + ?Sized),

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 use crate::field::FieldArithmetic;
+use crate::matrix_ops::{matrix_transpose, MatrixOps};
 use crate::polynomial_ring::PolynomialRing;
 use crate::program::{Instruction, PreDefinedProgram, Program, ReturningValueProgram};
 use crate::symbol::Symbol;
@@ -8,7 +9,7 @@ use crate::vec_ops::poly_vecops::{polyvec_add, polyvec_mul, polyvec_mul_by_scala
 use crate::vec_ops::{
     accumulate_scalars, add_scalars, bit_reverse, bit_reverse_inplace, div_scalars, inv_scalars, mixed_mul_scalars,
     mul_scalars, product_scalars, scalar_add, scalar_mul, scalar_sub, slice, sub_scalars, sum_scalars,
-    transpose_matrix, FieldImpl, MixedVecOps, VecOps, VecOpsConfig,
+    FieldImpl, MixedVecOps, VecOps, VecOpsConfig,
 };
 use icicle_runtime::device::Device;
 use icicle_runtime::memory::{DeviceVec, HostOrDeviceSlice, HostSlice};
@@ -329,42 +330,7 @@ where
     assert_eq!(a_clone_slice.as_slice(), a_main_slice.as_slice());
 }
 
-pub fn check_matrix_transpose<F: FieldImpl>()
-where
-    <F as FieldImpl>::Config: VecOps<F> + GenerateRandom<F>,
-{
-    let cfg = VecOpsConfig::default();
-    let batch_size = 3;
 
-    let (r, c): (u32, u32) = (1u32 << 10, 1u32 << 4);
-    let test_size = (r * c * batch_size) as usize;
-
-    let input_matrix = F::Config::generate_random(test_size);
-    let mut result_main = vec![F::zero(); test_size];
-    let mut result_ref = vec![F::zero(); test_size];
-
-    test_utilities::test_set_main_device();
-    transpose_matrix(
-        HostSlice::from_slice(&input_matrix),
-        r,
-        c,
-        HostSlice::from_mut_slice(&mut result_main),
-        &cfg,
-    )
-    .unwrap();
-
-    test_utilities::test_set_ref_device();
-    transpose_matrix(
-        HostSlice::from_slice(&input_matrix),
-        r,
-        c,
-        HostSlice::from_mut_slice(&mut result_ref),
-        &cfg,
-    )
-    .unwrap();
-
-    assert_eq!(result_main, result_ref);
-}
 
 pub fn check_slice<F: FieldImpl>()
 where

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/matrix_ops/mod.rs
@@ -1,0 +1,11 @@
+use crate::curve::{ScalarField, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bls12_377", bls12_377, ScalarField, ScalarCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/matrix_ops/mod.rs
@@ -1,0 +1,11 @@
+use crate::curve::{ScalarField, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bls12_381", bls12_381, ScalarField, ScalarCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/matrix_ops/mod.rs
@@ -1,0 +1,11 @@
+use crate::curve::{ScalarField, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bn254", bn254, ScalarField, ScalarCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/matrix_ops/mod.rs
@@ -1,0 +1,11 @@
+use crate::curve::{ScalarField, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bw6_761", bw6_761, ScalarField, ScalarCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/src/matrix_ops/mod.rs
@@ -1,0 +1,11 @@
+use crate::curve::{ScalarField, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("grumpkin", grumpkin, ScalarField, ScalarCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::curve::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+} 

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
@@ -1,0 +1,18 @@
+use crate::field::{ExtensionField, ScalarField, ExtensionCfg, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("babybear", babybear, ScalarField, ScalarCfg);
+impl_matrix_ops!("babybear_extension", babybear_extension, ExtensionField, ExtensionCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::field::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+
+    mod extension {
+        use crate::field::ExtensionField;
+        use icicle_core::impl_matrix_ops_tests;
+        impl_matrix_ops_tests!(ExtensionField);
+    }
+} 

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
@@ -10,9 +10,9 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(ScalarField);
 
-    mod extension {
-        use crate::field::ExtensionField;
-        use icicle_core::impl_matrix_ops_tests;
-        impl_matrix_ops_tests!(ExtensionField);
-    }
+    // mod extension { // TODO: add babybear extension matrix tests ?
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
 } 

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "ntt")]
 pub mod ntt;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
@@ -10,9 +10,9 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(ScalarField);
 
-    mod extension {
-        use crate::field::ExtensionField;
-        use icicle_core::impl_matrix_ops_tests;
-        impl_matrix_ops_tests!(ExtensionField);
-    }
+    // mod extension { // TODO: add goldilocks extension matrix tests ?
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
 } 

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
@@ -1,0 +1,18 @@
+use crate::field::{ExtensionField, ScalarField, ExtensionCfg, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("goldilocks", goldilocks, ScalarField, ScalarCfg);
+impl_matrix_ops!("goldilocks_extension", goldilocks_extension, ExtensionField, ExtensionCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::field::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+
+    mod extension {
+        use crate::field::ExtensionField;
+        use icicle_core::impl_matrix_ops_tests;
+        impl_matrix_ops_tests!(ExtensionField);
+    }
+} 

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
@@ -10,9 +10,9 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(ScalarField);
 
-    mod extension {
-        use crate::field::ExtensionField;
-        use icicle_core::impl_matrix_ops_tests;
-        impl_matrix_ops_tests!(ExtensionField);
-    }
+    // mod extension { // TODO: add koalabear extension matrix tests ?
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
 } 

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
@@ -1,0 +1,18 @@
+use crate::field::{ExtensionField, ScalarField, ExtensionCfg, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("koalabear", koalabear, ScalarField, ScalarCfg);
+impl_matrix_ops!("koalabear_extension", koalabear_extension, ExtensionField, ExtensionCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::field::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+
+    mod extension {
+        use crate::field::ExtensionField;
+        use icicle_core::impl_matrix_ops_tests;
+        impl_matrix_ops_tests!(ExtensionField);
+    }
+} 

--- a/wrappers/rust/icicle-fields/icicle-m31/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "poseidon")]
 pub mod poseidon;
 #[cfg(feature = "poseidon2")]

--- a/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
@@ -10,9 +10,9 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(ScalarField);
 
-    mod extension {
-        use crate::field::ExtensionField;
-        use icicle_core::impl_matrix_ops_tests;
-        impl_matrix_ops_tests!(ExtensionField);
-    }
+    // mod extension {
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
 } 

--- a/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
@@ -1,0 +1,18 @@
+use crate::field::{ExtensionField, ScalarField, ExtensionCfg, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("m31", m31, ScalarField, ScalarCfg);
+impl_matrix_ops!("m31_extension", m31_extension, ExtensionField, ExtensionCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::field::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+
+    mod extension {
+        use crate::field::ExtensionField;
+        use icicle_core::impl_matrix_ops_tests;
+        impl_matrix_ops_tests!(ExtensionField);
+    }
+} 

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/matrix_ops/mod.rs
@@ -1,0 +1,11 @@
+use crate::field::{ScalarField, ScalarCfg};
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("stark252", stark252, ScalarField, ScalarCfg);
+
+#[cfg(test)]
+mod tests {
+    use crate::field::ScalarField;
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(ScalarField);
+} 

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -1,4 +1,10 @@
-use icicle_core::{impl_matmul, impl_matmul_device_tests};
+use icicle_core::impl_matrix_ops;
 
-impl_matmul!("labrador_poly_ring", crate::polynomial_ring::PolyRing);
-impl_matmul_device_tests!(crate::polynomial_ring::PolyRing);
+impl_matrix_ops!("labrador_poly_ring", crate::polynomial_ring::PolyRing);
+
+#[cfg(test)]
+mod test_polyring_matrix_ops {
+    use icicle_core::impl_matrix_ops_tests;
+
+    impl_matrix_ops_tests!(test_polyring_matrix_ops, crate::polynomial_ring::PolyRing);
+}

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -1,10 +1,12 @@
+use crate::polynomial_ring::PolyRing;
 use icicle_core::impl_matrix_ops;
 
-impl_matrix_ops!("labrador_poly_ring", crate::polynomial_ring::PolyRing);
+impl_matrix_ops!("labrador_poly_ring", labrador_poly_ring, PolyRing, PolyRing);
 
 #[cfg(test)]
-mod test_polyring_matrix_ops {
+mod tests {
+    use crate::polynomial_ring::PolyRing;
     use icicle_core::impl_matrix_ops_tests;
-
-    impl_matrix_ops_tests!(test_polyring_matrix_ops, crate::polynomial_ring::PolyRing);
+    
+    impl_matrix_ops_tests!(PolyRing);
 }

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -1,12 +1,113 @@
 use crate::polynomial_ring::PolyRing;
+use crate::ring::{ScalarCfg, ScalarCfgRns, ScalarRing, ScalarRingRns};
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("labrador_poly_ring", labrador_poly_ring, PolyRing, PolyRing);
+impl_matrix_ops!("labrador", labrador, ScalarRing, ScalarCfg);
+impl_matrix_ops!("labrador_rns", labrador_rns, ScalarRingRns, ScalarCfgRns);
 
 #[cfg(test)]
 mod tests {
     use crate::polynomial_ring::PolyRing;
+    use crate::ring::ScalarRing;
     use icicle_core::impl_matrix_ops_tests;
+    use icicle_core::matrix_ops::MatrixOps;
+    use icicle_core::polynomial_ring::PolynomialRing;
+    use icicle_core::traits::GenerateRandom;
+    use icicle_core::vec_ops::VecOpsConfig;
+    use icicle_runtime::memory::HostSlice;
+    // use icicle_runtime::test_utilities;
     
-    impl_matrix_ops_tests!(PolyRing);
+    impl_matrix_ops_tests!(ScalarRing);
+    
+    // mod rns { // TODO: add RNS tests ?
+    //     use super::*;
+    //     impl_matrix_ops_tests!(ScalarRingRns);
+    // }
+    
+    mod poly_ring {
+        use super::*;
+        
+        fn initialize() {
+            test_utilities::test_load_and_init_devices();
+            test_utilities::test_set_main_device();
+        }
+        
+        #[test]
+        fn test_polyring_matmul_device_memory() {
+            initialize();
+            check_polyring_matmul_device_memory();
+        }
+        
+        #[test]
+        fn test_polyring_matrix_transpose() {
+            initialize();
+            check_polyring_matrix_transpose_device_memory();
+        }
+        
+        fn check_polyring_matmul_device_memory() {
+            let cfg = VecOpsConfig::default();
+            let n = 1 << 3; // Smaller size for polynomial rings
+            let m = 1 << 4;
+            let k = 1 << 2;
+            let out_size = n * k;
+            let input_a = PolyRing::generate_random(n * m);
+            let input_b = PolyRing::generate_random(m * k);
+            
+            let mut output = vec![PolyRing::zero(); out_size];
+            
+            // Use the specific MatrixOps implementation for PolyRing
+            PolyRing::matmul(
+                HostSlice::from_slice(&input_a),
+                n as u32,
+                m as u32,
+                HostSlice::from_slice(&input_b),
+                m as u32,
+                k as u32,
+                &cfg,
+                HostSlice::from_mut_slice(&mut output),
+            )
+            .expect("PolyRing matmul failed");
+            
+            // Basic check that output is not all zeros
+            let has_non_zero = output.iter().any(|p| p != &PolyRing::zero());
+            assert!(has_non_zero, "PolyRing matmul produced all zeros");
+        }
+        
+        fn check_polyring_matrix_transpose_device_memory() {
+            let cfg = VecOpsConfig::default();
+            let nof_rows = 1 << 3;
+            let nof_cols = 1 << 4;
+            let matrix_size = nof_rows * nof_cols;
+            
+            let input_matrix = PolyRing::generate_random(matrix_size);
+            let mut output_matrix = vec![PolyRing::zero(); matrix_size];
+            
+            // Use the specific MatrixOps implementation for PolyRing
+            PolyRing::matrix_transpose(
+                HostSlice::from_slice(&input_matrix),
+                nof_rows as u32,
+                nof_cols as u32,
+                &cfg,
+                HostSlice::from_mut_slice(&mut output_matrix),
+            )
+            .expect("PolyRing matrix transpose failed");
+            
+            // Basic check that transpose changed the data
+            assert_ne!(input_matrix, output_matrix, "PolyRing transpose should modify data");
+            
+            // Transpose back and check we get original
+            let mut restored_matrix = vec![PolyRing::zero(); matrix_size];
+            PolyRing::matrix_transpose(
+                HostSlice::from_slice(&output_matrix),
+                nof_cols as u32,
+                nof_rows as u32,
+                &cfg,
+                HostSlice::from_mut_slice(&mut restored_matrix),
+            )
+            .expect("PolyRing matrix transpose back failed");
+            
+            assert_eq!(input_matrix, restored_matrix, "Double transpose should restore original");
+        }
+    }
 }


### PR DESCRIPTION
## Describe the changes

This PR refactors the Rust transpose func:
- Improves code structure

## Describe the rational

Why is this change necessary?  
To improve code structure by moving transpose to MatrixOps.

Does it increase performance?  
 - No.

## Backend branches

cuda-backend-branch: main
metal-backend-branch: main
