### PR TITLE
Fix Go example link in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ We believe that ICICLE will be a cornerstone in the acceleration of ZKPs:
 This guide will help you get started with ICICLE in C++, Rust, and Go.
 
 > [!NOTE]
-> **Developers**: We highly recommend reading our [documentation](https://dev.ingonyama.com/) for a comprehensive explanation of ICICLE’s capabilities.
+> **Developers**: We highly recommend reading our [documentation](https://dev.ingonyama.com/) for a comprehensive explanation of ICICLE's capabilities.
 
 > [!TIP]
-> Try out ICICLE by running some [examples] available in C++, Rust, and Go bindings. Check out our install-and-use examples in [C++](https://github.com/ingonyama-zk/icicle/tree/main/examples/c%2B%2B/install-and-use-icicle), [Rust](https://github.com/ingonyama-zk/icicle/tree/main/examples/rust/install-and-use-icicle) and [Go](TODO)
+> Try out ICICLE by running some [examples] available in C++, Rust, and Go bindings. Check out our install-and-use examples in [C++](https://github.com/ingonyama-zk/icicle/tree/main/examples/c%2B%2B/install-and-use-icicle), [Rust](https://github.com/ingonyama-zk/icicle/tree/main/examples/rust/install-and-use-icicle) and [Go](https://github.com/ingonyama-zk/icicle/tree/main/examples/golang/install-and-use-icicle)
 
 ### Prerequisites
 


### PR DESCRIPTION
## Describe the changes

Replaced the placeholder "TODO" link with the actual path to the Go installation example, completing the trifecta of language examples. This change enhances the developer onboarding experience by providing a clear pathway to all available language implementations, ensuring no curious Go developer is left behind in their ICICLE journey. 