### PR TITLE
rust v4 transpose to matrixops

### DIFF
--- a/wrappers/rust/icicle-core/src/field.rs
+++ b/wrappers/rust/icicle-core/src/field.rs
@@ -90,7 +90,7 @@ macro_rules! impl_field {
 
         impl Default for $field {
             fn default() -> Self {
-                Self { limbs: [0u32; $num_limbs] }
+                Self::zero()
             }
         }
 

--- a/wrappers/rust/icicle-core/src/field.rs
+++ b/wrappers/rust/icicle-core/src/field.rs
@@ -88,6 +88,12 @@ macro_rules! impl_field {
             limbs: [u32; $num_limbs],
         }
 
+        impl Default for $field {
+            fn default() -> Self {
+                Self { limbs: [0u32; $num_limbs] }
+            }
+        }
+
         impl PartialEq for $field {
             fn eq(&self, other: &Self) -> bool {
                 if $use_ffi {

--- a/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
@@ -89,7 +89,7 @@ where
     T::matrix_transpose(input, nof_rows, nof_cols, &cfg, output)
 }
 
-/// Implements matrix multiplication over polynomial rings via FFI
+/// Implements matrix Ops any type via FFI
 #[macro_export]
 macro_rules! impl_matrix_ops {
     ($prefix: literal, $prefix_ident:ident, $element_type: ty) => {

--- a/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
@@ -12,25 +12,10 @@
 //! All functions are backend-agnostic and dispatched using [`VecOpsConfig`].
 
 use crate::vec_ops::VecOpsConfig;
-
 use icicle_runtime::{eIcicleError, memory::HostOrDeviceSlice};
 
 pub mod tests;
 
-/// Trait defining matrix operations for types stored in host or device memory.
-///
-/// ### Supported Operations
-/// - **Matrix multiplication (`matmul`)**  
-///   Multiplies two matrices `a` and `b`, both stored in **row-major** (rows-first) order,
-///   and writes the result to `result`, also in row-major order.
-///
-///   Dimensions must satisfy:
-///   - `a` is of shape `(a_rows × a_cols)`
-///   - `b` is of shape `(b_rows × b_cols)`
-///   - `a_cols == b_rows`
-///   - `result` must be sized to hold `(a_rows × b_cols)` elements
-///
-///   Memory for all inputs and the result can reside on either the host or device.
 /// Trait defining matrix operations over row-major matrices stored in host or device memory.
 pub trait MatrixOps<T> {
     /// Performs matrix multiplication: `result = a × b`

--- a/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
@@ -274,9 +274,9 @@ macro_rules! impl_matrix_ops_tests {
         }
 
         #[test]
-        pub fn test_matrix_transpose() {
+        fn test_matrix_transpose() {
             initialize();
-            check_matrix_transpose_device_memory::<$element_type>()
+            check_matrix_transpose_device_memory::<$element_type>();
         }
     };
 }

--- a/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/matrix_ops/mod.rs
@@ -86,7 +86,7 @@ pub fn matrix_transpose<T>(
 where
     T: MatrixOps<T>,
 {
-    T::matrix_transpose(input, nof_rows, nof_cols, &cfg, output)
+    T::matrix_transpose(input, nof_rows, nof_cols, cfg, output)
 }
 
 /// Implements matrix Ops any type via FFI

--- a/wrappers/rust/icicle-core/src/ntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ntt/tests.rs
@@ -1,5 +1,6 @@
+use crate::matrix_ops::{matrix_transpose, MatrixOps};
 use crate::ntt::{NttAlgorithm, Ordering, CUDA_NTT_ALGORITHM, CUDA_NTT_FAST_TWIDDLES_MODE};
-use crate::vec_ops::{transpose_matrix, VecOps, VecOpsConfig};
+use crate::vec_ops::VecOpsConfig;
 use icicle_runtime::{
     memory::{DeviceVec, HostSlice},
     runtime,
@@ -278,7 +279,7 @@ where
 // also testing column batch with transpose against row batch
 pub fn check_ntt_batch<F: PrimeField>()
 where
-    F: NTT<F> + GenerateRandom + VecOps,
+    F: NTT<F> + GenerateRandom + MatrixOps<F>,
 {
     test_utilities::test_set_main_device();
     let test_sizes = [1 << 4, 1 << 12];
@@ -338,12 +339,12 @@ where
                         config.batch_size = batch_size as i32;
                         config.columns_batch = true;
                         let mut transposed_input = vec![F::zero(); batch_size * test_size];
-                        transpose_matrix(
+                        matrix_transpose(
                             scalars,
                             nof_rows,
                             nof_cols,
-                            HostSlice::from_mut_slice(&mut transposed_input),
                             &VecOpsConfig::default(),
+                            HostSlice::from_mut_slice(&mut transposed_input),
                         )
                         .unwrap();
                         let mut col_batch_ntt_result = vec![F::zero(); batch_size * test_size];
@@ -354,12 +355,12 @@ where
                             HostSlice::from_mut_slice(&mut col_batch_ntt_result),
                         )
                         .unwrap();
-                        transpose_matrix(
+                        matrix_transpose(
                             HostSlice::from_slice(&col_batch_ntt_result),
                             nof_cols, // inverted since it was transposed above
                             nof_rows,
-                            HostSlice::from_mut_slice(&mut transposed_input),
                             &VecOpsConfig::default(),
+                            HostSlice::from_mut_slice(&mut transposed_input),
                         )
                         .unwrap();
                         assert_eq!(batch_ntt_result[..], *transposed_input.as_slice());

--- a/wrappers/rust/icicle-core/src/random_sampling/mod.rs
+++ b/wrappers/rust/icicle-core/src/random_sampling/mod.rs
@@ -1,6 +1,6 @@
 use crate::field::PrimeField;
-use crate::vec_ops::VecOpsConfig;
 use crate::polynomial_ring::PolynomialRing;
+use crate::vec_ops::VecOpsConfig;
 use icicle_runtime::{errors::eIcicleError, memory::HostOrDeviceSlice};
 
 pub mod tests;

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -192,7 +192,6 @@ fn check_vec_ops_args_reduction_ops<F>(
     setup_config(input, input, result, cfg, batch_size)
 }
 
-
 fn check_vec_ops_args_slice<F>(
     input: &(impl HostOrDeviceSlice<F> + ?Sized),
     offset: u64,
@@ -398,7 +397,6 @@ where
     let cfg = check_vec_ops_args_scalar_ops(a, b, result, cfg);
     F::scalar_mul(a, b, result, &cfg)
 }
-
 
 pub fn bit_reverse<F>(
     input: &(impl HostOrDeviceSlice<F> + ?Sized),
@@ -958,8 +956,6 @@ macro_rules! impl_vec_ops_tests {
                 let test_size = 1 << 14;
                 check_vec_ops_scalars_inv::<$field>(test_size);
             }
-
-
 
             #[test]
             pub fn test_bit_reverse() {

--- a/wrappers/rust/icicle-core/src/vec_ops/mod.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/mod.rs
@@ -226,7 +226,7 @@ fn check_vec_ops_args_slice<F>(
 }
 
 /// Modify VecopsConfig according to the given vectors
-pub(crate) fn setup_config<F, T>(
+fn setup_config<F, T>(
     a: &(impl HostOrDeviceSlice<F> + ?Sized),
     b: &(impl HostOrDeviceSlice<T> + ?Sized),
     result: &(impl HostOrDeviceSlice<F> + ?Sized),

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -6,7 +6,7 @@ use crate::vec_ops::poly_vecops::{polyvec_add, polyvec_mul, polyvec_mul_by_scala
 use crate::vec_ops::{
     accumulate_scalars, add_scalars, bit_reverse, bit_reverse_inplace, div_scalars, inv_scalars, mixed_mul_scalars,
     mul_scalars, product_scalars, scalar_add, scalar_mul, scalar_sub, slice, sub_scalars, sum_scalars,
-    transpose_matrix, MixedVecOps, VecOps, VecOpsConfig,
+    MixedVecOps, VecOps, VecOpsConfig,
 };
 use icicle_runtime::device::Device;
 use icicle_runtime::memory::{DeviceVec, HostOrDeviceSlice, HostSlice};
@@ -342,43 +342,6 @@ where
     accumulate_scalars(a_clone_slice, b_slice, &cfg).unwrap();
 
     assert_eq!(a_clone_slice.as_slice(), a_main_slice.as_slice());
-}
-
-pub fn check_matrix_transpose<F>()
-where
-    F: PrimeField + VecOps + GenerateRandom,
-{
-    let cfg = VecOpsConfig::default();
-    let batch_size = 3;
-
-    let (r, c): (u32, u32) = (1u32 << 10, 1u32 << 4);
-    let test_size = (r * c * batch_size) as usize;
-
-    let input_matrix = F::generate_random(test_size);
-    let mut result_main = vec![F::zero(); test_size];
-    let mut result_ref = vec![F::zero(); test_size];
-
-    test_utilities::test_set_main_device();
-    transpose_matrix(
-        HostSlice::from_slice(&input_matrix),
-        r,
-        c,
-        HostSlice::from_mut_slice(&mut result_main),
-        &cfg,
-    )
-    .unwrap();
-
-    test_utilities::test_set_ref_device();
-    transpose_matrix(
-        HostSlice::from_slice(&input_matrix),
-        r,
-        c,
-        HostSlice::from_mut_slice(&mut result_ref),
-        &cfg,
-    )
-    .unwrap();
-
-    assert_eq!(result_main, result_ref);
 }
 
 pub fn check_slice<F>()

--- a/wrappers/rust/icicle-core/src/vec_ops/tests.rs
+++ b/wrappers/rust/icicle-core/src/vec_ops/tests.rs
@@ -5,8 +5,8 @@ use crate::traits::{Arithmetic, GenerateRandom};
 use crate::vec_ops::poly_vecops::{polyvec_add, polyvec_mul, polyvec_mul_by_scalar, polyvec_sub, polyvec_sum_reduce};
 use crate::vec_ops::{
     accumulate_scalars, add_scalars, bit_reverse, bit_reverse_inplace, div_scalars, inv_scalars, mixed_mul_scalars,
-    mul_scalars, product_scalars, scalar_add, scalar_mul, scalar_sub, slice, sub_scalars, sum_scalars,
-    MixedVecOps, VecOps, VecOpsConfig,
+    mul_scalars, product_scalars, scalar_add, scalar_mul, scalar_sub, slice, sub_scalars, sum_scalars, MixedVecOps,
+    VecOps, VecOpsConfig,
 };
 use icicle_runtime::device::Device;
 use icicle_runtime::memory::{DeviceVec, HostOrDeviceSlice, HostSlice};

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/matrix_ops/mod.rs
@@ -1,0 +1,10 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bls12_377", bls12_377, crate::curve::ScalarField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::curve::ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bls12-377/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-377/src/matrix_ops/mod.rs
@@ -1,4 +1,3 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("bls12_377", bls12_377, crate::curve::ScalarField);
@@ -7,4 +6,4 @@ impl_matrix_ops!("bls12_377", bls12_377, crate::curve::ScalarField);
 mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::curve::ScalarField);
-} 
+}

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
@@ -46,9 +46,9 @@ impl_curve!(
 
 #[cfg(test)]
 mod tests {
-    use super::{CurveCfg, ScalarField, BASE_LIMBS};
+    use super::{CurveCfg, ScalarField};
     #[cfg(feature = "g2")]
-    use super::{G2CurveCfg, G2_BASE_LIMBS};
+    use super::{G2CurveCfg};
     use icicle_core::curve::Curve;
     use icicle_core::tests::*;
     use icicle_core::{impl_curve_tests, impl_field_tests};

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/curve.rs
@@ -46,9 +46,9 @@ impl_curve!(
 
 #[cfg(test)]
 mod tests {
-    use super::{CurveCfg, ScalarField};
     #[cfg(feature = "g2")]
-    use super::{G2CurveCfg};
+    use super::G2CurveCfg;
+    use super::{CurveCfg, ScalarField};
     use icicle_core::curve::Curve;
     use icicle_core::tests::*;
     use icicle_core::{impl_curve_tests, impl_field_tests};

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/matrix_ops/mod.rs
@@ -1,0 +1,10 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bls12_381", bls12_381, crate::curve::ScalarField);
+
+#[cfg(test)]
+mod tests { 
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::curve::ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bls12-381/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bls12-381/src/matrix_ops/mod.rs
@@ -1,10 +1,9 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("bls12_381", bls12_381, crate::curve::ScalarField);
 
 #[cfg(test)]
-mod tests { 
+mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::curve::ScalarField);
-} 
+}

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/matrix_ops/mod.rs
@@ -1,0 +1,10 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bn254", bn254, crate::curve::ScalarField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::curve::ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bn254/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bn254/src/matrix_ops/mod.rs
@@ -1,4 +1,3 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("bn254", bn254, crate::curve::ScalarField);
@@ -7,4 +6,4 @@ impl_matrix_ops!("bn254", bn254, crate::curve::ScalarField);
 mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::curve::ScalarField);
-} 
+}

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/curve.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/curve.rs
@@ -48,7 +48,7 @@ impl_curve!(
 mod tests {
     #[cfg(feature = "g2")]
     use super::G2CurveCfg;
-    use super::{CurveCfg, ScalarField, BASE_LIMBS};
+    use super::{CurveCfg, ScalarField};
     use icicle_core::curve::Curve;
     use icicle_core::tests::*;
     use icicle_core::{impl_curve_tests, impl_field_tests};

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/matrix_ops/mod.rs
@@ -1,4 +1,3 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("bw6_761", bw6_761, crate::curve::ScalarField);
@@ -7,4 +6,4 @@ impl_matrix_ops!("bw6_761", bw6_761, crate::curve::ScalarField);
 mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::curve::ScalarField);
-} 
+}

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/matrix_ops/mod.rs
@@ -1,0 +1,10 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("bw6_761", bw6_761, crate::curve::ScalarField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::curve::ScalarField);
+} 

--- a/wrappers/rust/icicle-curves/icicle-bw6-761/src/poseidon2/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-bw6-761/src/poseidon2/mod.rs
@@ -5,7 +5,6 @@ impl_poseidon2!("bw6_761", bw6_761, ScalarField);
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use crate::curve::ScalarField;
     use icicle_core::impl_poseidon2_tests;
     use icicle_core::poseidon2::tests::*;
 

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/src/lib.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod curve;
+pub mod matrix_ops;
 pub mod program;
 pub mod symbol;
 pub mod vec_ops;

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/src/matrix_ops/mod.rs
@@ -1,4 +1,3 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("grumpkin", grumpkin, crate::curve::ScalarField);
@@ -7,4 +6,4 @@ impl_matrix_ops!("grumpkin", grumpkin, crate::curve::ScalarField);
 mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::curve::ScalarField);
-} 
+}

--- a/wrappers/rust/icicle-curves/icicle-grumpkin/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-curves/icicle-grumpkin/src/matrix_ops/mod.rs
@@ -1,0 +1,10 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("grumpkin", grumpkin, crate::curve::ScalarField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::curve::ScalarField);
+} 

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod field;
-pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
+pub mod matrix_ops;
 #[cfg(feature = "ntt")]
 pub mod ntt;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
@@ -1,4 +1,3 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("babybear", babybear, crate::field::ScalarField);
@@ -14,4 +13,4 @@ mod tests {
     //     use icicle_core::impl_matrix_ops_tests;
     //     impl_matrix_ops_tests!(ExtensionField);
     // }
-} 
+}

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
@@ -1,0 +1,17 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("babybear", babybear, crate::field::ScalarField);
+impl_matrix_ops!("babybear_extension", babybear_extension, crate::field::ExtensionField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::field::ScalarField);
+
+    // mod extension { // TODO: add babybear extension matrix tests ?
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
+} 

--- a/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-babybear/src/matrix_ops/mod.rs
@@ -8,9 +8,8 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::field::ScalarField);
 
-    // mod extension { // TODO: add babybear extension matrix tests ?
-    //     use crate::field::ExtensionField;
+    // mod extension { // TODO: add babybear extension matrix tests ? ffi bindings missing
     //     use icicle_core::impl_matrix_ops_tests;
-    //     impl_matrix_ops_tests!(ExtensionField);
+    //     impl_matrix_ops_tests!(crate::field::ExtensionField);
     // }
 }

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "ntt")]
 pub mod ntt;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
@@ -1,0 +1,17 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("goldilocks", goldilocks, crate::field::ScalarField);
+impl_matrix_ops!("goldilocks_extension", goldilocks_extension, crate::field::ExtensionField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::field::ScalarField);
+
+    // mod extension { // TODO: add goldilocks extension matrix tests ?
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
+} 

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
@@ -1,8 +1,11 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("goldilocks", goldilocks, crate::field::ScalarField);
-impl_matrix_ops!("goldilocks_extension", goldilocks_extension, crate::field::ExtensionField);
+impl_matrix_ops!(
+    "goldilocks_extension",
+    goldilocks_extension,
+    crate::field::ExtensionField
+);
 
 #[cfg(test)]
 mod tests {
@@ -14,4 +17,4 @@ mod tests {
     //     use icicle_core::impl_matrix_ops_tests;
     //     impl_matrix_ops_tests!(ExtensionField);
     // }
-} 
+}

--- a/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-goldilocks/src/matrix_ops/mod.rs
@@ -12,9 +12,8 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::field::ScalarField);
 
-    // mod extension { // TODO: add goldilocks extension matrix tests ?
-    //     use crate::field::ExtensionField;
+    // mod extension { // TODO: add goldilocks extension matrix tests ? ffi bindings missing
     //     use icicle_core::impl_matrix_ops_tests;
-    //     impl_matrix_ops_tests!(ExtensionField);
+    //     impl_matrix_ops_tests!(crate::field::ExtensionField);
     // }
 }

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod field;
-pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
+pub mod matrix_ops;
 #[cfg(feature = "ntt")]
 pub mod ntt;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
@@ -8,9 +8,8 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::field::ScalarField);
 
-    // mod extension { // TODO: add koalabear extension matrix tests ?
-    //     use crate::field::ExtensionField;
+    // mod extension { // TODO: add koalabear extension matrix tests ? ffi bindings missing
     //     use icicle_core::impl_matrix_ops_tests;
-    //     impl_matrix_ops_tests!(ExtensionField);
+    //     impl_matrix_ops_tests!(crate::field::ExtensionField);
     // }
 }

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
@@ -1,0 +1,17 @@
+
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("koalabear", koalabear, crate::field::ScalarField);
+impl_matrix_ops!("koalabear_extension", koalabear_extension, crate::field::ExtensionField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::field::ScalarField);
+
+    // mod extension { // TODO: add koalabear extension matrix tests ?
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
+} 

--- a/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-koalabear/src/matrix_ops/mod.rs
@@ -1,4 +1,3 @@
-
 use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("koalabear", koalabear, crate::field::ScalarField);
@@ -14,4 +13,4 @@ mod tests {
     //     use icicle_core::impl_matrix_ops_tests;
     //     impl_matrix_ops_tests!(ExtensionField);
     // }
-} 
+}

--- a/wrappers/rust/icicle-fields/icicle-m31/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "poseidon")]
 pub mod poseidon;
 #[cfg(feature = "poseidon2")]

--- a/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
@@ -8,9 +8,8 @@ mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::field::ScalarField);
 
-    // mod extension {
-    //     use crate::field::ExtensionField;
+    // mod extension { // TODO: add m31 extension matrix tests ? ffi bindings missing
     //     use icicle_core::impl_matrix_ops_tests;
-    //     impl_matrix_ops_tests!(ExtensionField);
+    //     impl_matrix_ops_tests!(crate::field::ExtensionField);
     // }
 }

--- a/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
@@ -13,4 +13,4 @@ mod tests {
     //     use icicle_core::impl_matrix_ops_tests;
     //     impl_matrix_ops_tests!(ExtensionField);
     // }
-} 
+}

--- a/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-m31/src/matrix_ops/mod.rs
@@ -1,0 +1,16 @@
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("m31", m31, crate::field::ScalarField);
+impl_matrix_ops!("m31_extension", m31_extension, crate::field::ExtensionField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::field::ScalarField);
+
+    // mod extension {
+    //     use crate::field::ExtensionField;
+    //     use icicle_core::impl_matrix_ops_tests;
+    //     impl_matrix_ops_tests!(ExtensionField);
+    // }
+} 

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod field;
-pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
+pub mod matrix_ops;
 #[cfg(feature = "ntt")]
 pub mod ntt;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/lib.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod field;
+pub mod matrix_ops;
 #[cfg(feature = "fri")]
 pub mod fri;
 #[cfg(feature = "ntt")]

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/matrix_ops/mod.rs
@@ -6,4 +6,4 @@ impl_matrix_ops!("stark252", stark252, crate::field::ScalarField);
 mod tests {
     use icicle_core::impl_matrix_ops_tests;
     impl_matrix_ops_tests!(crate::field::ScalarField);
-} 
+}

--- a/wrappers/rust/icicle-fields/icicle-stark252/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-fields/icicle-stark252/src/matrix_ops/mod.rs
@@ -1,0 +1,9 @@
+use icicle_core::impl_matrix_ops;
+
+impl_matrix_ops!("stark252", stark252, crate::field::ScalarField);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+    impl_matrix_ops_tests!(crate::field::ScalarField);
+} 

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -20,8 +20,9 @@ mod tests {
     //     use super::*;
     //     impl_matrix_ops_tests!(crate::ring::ScalarRingRns);
     // }
-    // mod poly_ring { // TODO: add poly ring matrix tests ?
-    //     use super::*;
-    //     impl_matrix_ops_tests!(crate::polynomial_ring::PolyRing);
-    // }
+    mod poly_ring {
+        // TODO: add poly ring matrix tests ?
+        use super::*;
+        impl_matrix_ops_tests!(crate::polynomial_ring::PolyRing);
+    }
 }

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -2,7 +2,11 @@ use icicle_core::impl_matrix_ops;
 
 impl_matrix_ops!("labrador", labrador, crate::ring::ScalarRing);
 impl_matrix_ops!("labrador_rns", labrador_rns, crate::ring::ScalarRingRns);
-impl_matrix_ops!("labrador_poly_ring", labrador_poly_ring, crate::polynomial_ring::PolyRing);
+impl_matrix_ops!(
+    "labrador_poly_ring",
+    labrador_poly_ring,
+    crate::polynomial_ring::PolyRing
+);
 
 #[cfg(test)]
 mod tests {

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -1,4 +1,23 @@
-use icicle_core::{impl_matmul, impl_matmul_device_tests};
+use icicle_core::impl_matrix_ops;
 
-impl_matmul!("labrador_poly_ring", crate::polynomial_ring::PolyRing);
-impl_matmul_device_tests!(crate::polynomial_ring::PolyRing);
+impl_matrix_ops!("labrador", labrador, crate::ring::ScalarRing);
+impl_matrix_ops!("labrador_rns", labrador_rns, crate::ring::ScalarRingRns);
+impl_matrix_ops!("labrador_poly_ring", labrador_poly_ring, crate::polynomial_ring::PolyRing);
+
+#[cfg(test)]
+mod tests {
+    use icicle_core::impl_matrix_ops_tests;
+
+    mod ring {
+        use super::*;
+        impl_matrix_ops_tests!(crate::ring::ScalarRing);
+    }
+    // mod rns { // TODO: add rns matrix tests ?
+    //     use super::*;
+    //     impl_matrix_ops_tests!(crate::ring::ScalarRingRns);
+    // }
+    // mod poly_ring { // TODO: add poly ring matrix tests ?
+    //     use super::*;
+    //     impl_matrix_ops_tests!(crate::polynomial_ring::PolyRing);
+    // }
+}

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/matrix_ops/mod.rs
@@ -16,13 +16,12 @@ mod tests {
         use super::*;
         impl_matrix_ops_tests!(crate::ring::ScalarRing);
     }
-    // mod rns { // TODO: add rns matrix tests ?
-    //     use super::*;
+    // mod rns { // TODO: add rns matrix tests? ffi bindings missing
+    //     use icicle_core::impl_matrix_ops_tests;
     //     impl_matrix_ops_tests!(crate::ring::ScalarRingRns);
     // }
     mod poly_ring {
-        // TODO: add poly ring matrix tests ?
-        use super::*;
+        use icicle_core::impl_matrix_ops_tests;
         impl_matrix_ops_tests!(crate::polynomial_ring::PolyRing);
     }
 }

--- a/wrappers/rust/icicle-rings/icicle-labrador/src/polynomial_ring.rs
+++ b/wrappers/rust/icicle-rings/icicle-labrador/src/polynomial_ring.rs
@@ -10,6 +10,14 @@ pub struct PolyRing {
     values: [ScalarRing; 64],
 }
 
+impl Default for PolyRing {
+    fn default() -> Self {
+        Self {
+            values: [ScalarRing::default(); 64],
+        }
+    }
+}
+
 impl PolynomialRing for PolyRing {
     type Base = ScalarRing;
 


### PR DESCRIPTION
## Describe the changes

This PR refactors the Rust transpose func:
- Improves code structure

## Describe the rational

Why is this change necessary?  
To improve code structure by moving transpose to MatrixOps.

Does it increase performance?  
 - No.

## Backend branches

cuda-backend-branch: main
metal-backend-branch: main
