### PR TITLE
removed outdated TODO comment

### DIFF
--- a/examples/golang/install-and-use-icicle/go.mod
+++ b/examples/golang/install-and-use-icicle/go.mod
@@ -2,9 +2,4 @@ module ingonyama.com/install_and_use_icicle
 
 go 1.22.1
 
-// TODO - When v3 is pushed to main, switch to this
-// require (
-//   github.com/ingonyama-zk/icicle/v3 v3.0.0
-// )
-
 require github.com/ingonyama-zk/icicle/v3 v3.0.0-20240902084701-0e5a616c7ea6


### PR DESCRIPTION
## Describe the changes

The TODO comment is no longer needed as the stable v3.0.0 version of github.com/ingonyama-zk/icicle/v3 has been officially released and is now available on the main branch.