### PR TITLE
ICICLE V4 documentation update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
           BUILD_TAGS="-tags=${{ steps.feature_flags.outputs.GO_TEST_BUILD_TAGS }}"
         else
           # NOTE: Include ntt tag inorder to use the tests that initialize the NTT domain
-          if [[ "${{ contains(matrix.field.go-supported-features, 'ntt') }}" = "true" ]]; then
+          if [[ "${{ contains(matrix.curve.go-supported-features, 'ntt') }}" = "true" ]]; then
             BUILD_TAGS="-tags=ntt"
           fi
         fi

--- a/docs/docs/api/cpp/matrix_ops.md
+++ b/docs/docs/api/cpp/matrix_ops.md
@@ -1,0 +1,127 @@
+# Matrix Operations (C++ API)
+
+ICICLE provides efficient, flexible matrix operations for cryptographic and scientific computing, supporting both CPU and GPU backends. The API is designed for high performance, batch processing, and seamless device/host memory management.
+
+---
+## Configuration: `MatMulConfig`
+
+All matrix operations are controlled via the `MatMulConfig` struct, which allows you to specify device placement, batching, transposition, and more.
+
+```cpp
+struct MatMulConfig {
+    icicleStreamHandle stream = nullptr; // Stream for asynchronous execution (e.g., CUDA stream)
+    bool is_a_on_device = false;         // True if input A is on device (GPU), false for host
+    bool is_b_on_device = false;         // True if input B is on device (GPU), false for host
+    bool is_result_on_device = false;    // True if output should be on device, false for host
+    bool is_async = false;               // If true, operation is non-blocking (async)
+    int batch_size = 1;                  // Number of matrices to process in a batch
+    bool columns_batch = false;          // If true, batched matrices are stored as separate 3D arrays
+    bool a_transposed = false;           // If true, input A is transposed
+    bool b_transposed = false;           // If true, input B is transposed
+    bool result_transposed = false;      // If true, output is transposed
+    ConfigExtension* ext = nullptr;      // Backend-specific extension (optional)
+};
+```
+
+- Use `default_mat_mul_config()` to get a default config for standard (single, synchronous, host) operation.
+- For most users, set `is_a_on_device`, `is_b_on_device`, and `is_result_on_device` to match your memory locations.
+- Set `is_async = true` for non-blocking GPU execution (requires explicit synchronization).
+- Use batching for high throughput on large workloads.
+
+---
+## Matrix Multiplication API
+
+```cpp
+template <typename T>
+eIcicleError matmul(
+    const T* mat_a,
+    uint32_t nof_rows_a,
+    uint32_t nof_cols_a,
+    const T* mat_b,
+    uint32_t nof_rows_b,
+    uint32_t nof_cols_b,
+    const MatMulConfig& config,
+    T* mat_out);
+```
+
+- **Inputs:**
+  - `mat_a`, `mat_b`: Pointers to input matrices (row-major order)
+  - `nof_rows_a`, `nof_cols_a`: Dimensions of A
+  - `nof_rows_b`, `nof_cols_b`: Dimensions of B
+  - `config`: Matrix operation configuration (see above)
+  - `mat_out`: Pointer to output matrix (row-major, must be preallocated)
+- **Requirements:**
+  - `nof_cols_a == nof_rows_b`
+  - All pointers must be valid and point to memory on the correct device (host or GPU)
+  - For batching, input/output pointers must be sized appropriately
+- **Returns:** `eIcicleError` indicating success or failure
+- **Notes:**
+  - Supports both host and device memory (see config)
+  - Supports batching and transposed inputs/outputs
+  - Asynchronous execution is available via `is_async` and `stream`
+
+---
+## Example: Multiply Two Matrices on the GPU
+
+```cpp
+#include "icicle/mat_ops.h"
+#include <vector>
+
+using namespace icicle;
+
+int main() {
+    const uint32_t N = 512;
+    std::vector<float> a(N * N), b(N * N), c(N * N);
+    // ... fill a and b with data ...
+
+    // Move data to device (if needed) using your preferred memory management
+    // For this example, assume pointers a_dev, b_dev, c_dev are on device
+
+    MatMulConfig cfg = default_mat_mul_config();
+    cfg.is_a_on_device = true;
+    cfg.is_b_on_device = true;
+    cfg.is_result_on_device = true;
+
+    eIcicleError err = matmul(
+        a_dev, N, N,
+        b_dev, N, N,
+        cfg,
+        c_dev
+    );
+    // ... check err, copy c_dev back to host if needed ...
+}
+```
+
+---
+## Backend Registration (Advanced)
+
+ICICLE allows you to register custom matrix multiplication backends for new devices or types:
+
+```cpp
+using scalarBinaryMatrixOpImpl = std::function<eIcicleError(
+    const Device& device,
+    const scalar_t* mat_a, uint32_t nof_rows_a, uint32_t nof_cols_a,
+    const scalar_t* mat_b, uint32_t nof_rows_b, uint32_t nof_cols_b,
+    const MatMulConfig& config,
+    scalar_t* mat_out)>;
+
+void register_matmul(const std::string& deviceType, scalarBinaryMatrixOpImpl impl);
+
+#define REGISTER_MATMUL_BACKEND(DEVICE_TYPE, FUNC) /* ... */
+```
+
+- Use `register_matmul` or the macro to add new device-specific implementations.
+- See `mat_ops_backend.h` for details.
+
+---
+## Notes
+- All matrices are row-major by default; use the transposition flags for column-major or transposed operations.
+- Batched operations are supported for high throughput.
+- Both CPU and GPU (CUDA) backends are available out of the box.
+- For more advanced usage (polynomial rings, custom types), see the full C++ API and backend headers.
+
+---
+## See Also
+- [Vector Operations (vec_ops.md)](./vec_ops.md)
+- [NTT, MSM, and other primitives](./)
+- [Backend registration and extension (for advanced users)] 

--- a/docs/docs/api/cpp/matrix_ops.md
+++ b/docs/docs/api/cpp/matrix_ops.md
@@ -9,18 +9,16 @@ All matrix operations are controlled via the `MatMulConfig` struct, which allows
 
 ```cpp
 struct MatMulConfig {
-    icicleStreamHandle stream = nullptr; // Stream for asynchronous execution (e.g., CUDA stream)
-    bool is_a_on_device = false;         // True if input A is on device (GPU), false for host
-    bool is_b_on_device = false;         // True if input B is on device (GPU), false for host
-    bool is_result_on_device = false;    // True if output should be on device, false for host
-    bool is_async = false;               // If true, operation is non-blocking (async)
-    int batch_size = 1;                  // Number of matrices to process in a batch
-    bool columns_batch = false;          // If true, batched matrices are stored as separate 3D arrays
-    bool a_transposed = false;           // If true, input A is transposed
-    bool b_transposed = false;           // If true, input B is transposed
-    bool result_transposed = false;      // If true, output is transposed
-    ConfigExtension* ext = nullptr;      // Backend-specific extension (optional)
-};
+    icicleStreamHandle stream = nullptr; // stream for async execution.
+    bool is_a_on_device = false;         // True if `a` resides on device memory.
+    bool is_b_on_device = false;         // True if `b` resides on device memory.
+    bool is_result_on_device = false;    // True to keep result on device, else host.
+    bool a_transposed = false;           // True if `a` is pre-transposed.
+    bool b_transposed = false;           // True if `b` is pre-transposed.
+    bool result_transposed = false;      // True to transpose the output.
+    bool is_async = false;               // True for non-blocking call; user must sync stream.
+    ConfigExtension* ext = nullptr;      // Optional backend-specific settings.
+  };
 ```
 
 - Use `default_mat_mul_config()` to get a default config for standard (single, synchronous, host) operation.
@@ -91,27 +89,6 @@ int main() {
     // ... check err, copy c_dev back to host if needed ...
 }
 ```
-
----
-## Backend Registration (Advanced)
-
-ICICLE allows you to register custom matrix multiplication backends for new devices or types:
-
-```cpp
-using scalarBinaryMatrixOpImpl = std::function<eIcicleError(
-    const Device& device,
-    const scalar_t* mat_a, uint32_t nof_rows_a, uint32_t nof_cols_a,
-    const scalar_t* mat_b, uint32_t nof_rows_b, uint32_t nof_cols_b,
-    const MatMulConfig& config,
-    scalar_t* mat_out)>;
-
-void register_matmul(const std::string& deviceType, scalarBinaryMatrixOpImpl impl);
-
-#define REGISTER_MATMUL_BACKEND(DEVICE_TYPE, FUNC) /* ... */
-```
-
-- Use `register_matmul` or the macro to add new device-specific implementations.
-- See `mat_ops_backend.h` for details.
 
 ---
 ## Notes

--- a/docs/docs/api/rust-bindings/ecntt.md
+++ b/docs/docs/api/rust-bindings/ecntt.md
@@ -15,7 +15,7 @@ pub fn ecntt<P: Projective>(
 
 ## Parameters
 
-- **`input`**: The input data as a slice of `Projective`. This represents points on a specific elliptic curve `P`.
+- **`input`**: The input data as a slice of `Projective`. This represents points on a specific elliptic curve.
 - **`dir`**: The direction of the NTT. It can be `NTTDir::kForward` for forward NTT or `NTTDir::kInverse` for inverse NTT.
 - **`cfg`**: The NTT configuration object of type `NTTConfig<C::ScalarField>`. This object specifies parameters for the NTT computation, such as the batch size and algorithm to use.
 - **`output`**: The output buffer to write the results into. This should be a slice of `Projective` with the same size as the input.

--- a/docs/docs/api/rust-bindings/ecntt.md
+++ b/docs/docs/api/rust-bindings/ecntt.md
@@ -5,21 +5,21 @@
 The `ecntt` function computes the Elliptic Curve Number Theoretic Transform (EC-NTT) or its inverse on a batch of points of a curve.
 
 ```rust
-pub fn ecntt<C: Curve>(
-    input: &(impl HostOrDeviceSlice<Projective<C>> + ?Sized),
+pub fn ecntt<P: Projective>(
+    input: &(impl HostOrDeviceSlice<P> + ?Sized),
     dir: NTTDir,
-    cfg: &NTTConfig<C::ScalarField>,
-    output: &mut (impl HostOrDeviceSlice<Projective<C>> + ?Sized),
-) -> Result<(), eIcicleError>
+    cfg: &NTTConfig<P::ScalarField>,
+    output: &mut (impl HostOrDeviceSlice<P> + ?Sized),
+) -> Result<(), IcicleError>
 ```
 
 ## Parameters
 
-- **`input`**: The input data as a slice of `Projective<C>`. This represents points on a specific elliptic curve `C`.
+- **`input`**: The input data as a slice of `Projective`. This represents points on a specific elliptic curve `P`.
 - **`dir`**: The direction of the NTT. It can be `NTTDir::kForward` for forward NTT or `NTTDir::kInverse` for inverse NTT.
 - **`cfg`**: The NTT configuration object of type `NTTConfig<C::ScalarField>`. This object specifies parameters for the NTT computation, such as the batch size and algorithm to use.
-- **`output`**: The output buffer to write the results into. This should be a slice of `Projective<C>` with the same size as the input.
+- **`output`**: The output buffer to write the results into. This should be a slice of `Projective` with the same size as the input.
 
 ## Return Value
 
-- **`Result<(), eIcicleError>`**: This function returns an `eIcicleError` which is a wrapper type that indicates success or failure of the NTT computation. On success, it contains `Ok(())`.
+- **`Result<(), IcicleError>`**: This function returns an `IcicleError` which is a wrapper type that indicates success or failure of the NTT computation. On success, it contains `Ok(())`.

--- a/docs/docs/api/rust-bindings/fri.md
+++ b/docs/docs/api/rust-bindings/fri.md
@@ -32,16 +32,16 @@ FFI configuration structure for the FRI protocol's transcript.
 A structure representing the FRI proof, which includes methods for handling proof data.
 
 ##### **Methods:**
-- **`new() -> Result<Self, eIcicleError>`**:
+- **`new() -> Result<Self, IcicleError>`**:
   Constructs a new instance of the `FriProof`.
 
-- **`create_with_arguments(query_proofs_data, final_poly, pow_nonce) -> Result<Self, eIcicleError>`**:
+- **`create_with_arguments(query_proofs_data, final_poly, pow_nonce) -> Result<Self, IcicleError>`**:
   Creates a new instance of `FriProof` with the given proof data.
 
-- **`get_query_proofs(&self) -> Result<Vec<Vec<MerkleProofData<F>>>, eIcicleError>`**:
+- **`get_query_proofs(&self) -> Result<Vec<Vec<MerkleProofData<F>>>, IcicleError>`**:
   Returns the matrix of Merkle proofs, where each row corresponds to a query and each column corresponds to a round.
 
-- **`get_final_poly(&self) -> Result<Vec<F>, eIcicleError>`**:
+- **`get_final_poly(&self) -> Result<Vec<F>, IcicleError>`**:
   Returns the final polynomial values.
 
 - **`get_pow_nonce(&self) -> Result<u64, eIcicleError>`**:
@@ -78,7 +78,7 @@ const SIZE: u64 = 1 << 10;
 init_domain::<ScalarField>(SIZE, false);
 
 let fri_config = FriConfig::default();
-let scalars = ScalarCfg::generate_random(SIZE as usize);
+let scalars = ScalarField::generate_random(SIZE as usize);
 let transcript_config = FriTranscriptConfig::new_default_labels(&transcript_hash, ScalarField::one());
 let merkle_tree_min_layer_to_store = 0;
 

--- a/docs/docs/api/rust-bindings/fri.md
+++ b/docs/docs/api/rust-bindings/fri.md
@@ -44,7 +44,7 @@ A structure representing the FRI proof, which includes methods for handling proo
 - **`get_final_poly(&self) -> Result<Vec<F>, IcicleError>`**:
   Returns the final polynomial values.
 
-- **`get_pow_nonce(&self) -> Result<u64, eIcicleError>`**:
+- **`get_pow_nonce(&self) -> Result<u64, IcicleError>`**:
   Returns the proof-of-work nonce.
 
 #### `FriConfig`

--- a/docs/docs/api/rust-bindings/hash.md
+++ b/docs/docs/api/rust-bindings/hash.md
@@ -70,7 +70,7 @@ The Poseidon hash is designed for cryptographic field elements and curves, makin
 Poseidon hash using babybear field:
 
 ```rust
-use icicle_babybear::field::{ScalarCfg, ScalarField};
+use icicle_babybear::field::ScalarField;
 use icicle_core::hash::HashConfig;
 use icicle_core::poseidon::{Poseidon, PoseidonHasher};
 use icicle_core::traits::FieldImpl;
@@ -82,7 +82,7 @@ let mut outputs = vec![ScalarField::zero(); batch]; // Output array sized for th
 
 // Case (1): Hashing without a domain tag
 // Generates 'batch * t' random input elements as each hash needs 't' inputs
-let inputs = ScalarCfg::generate_random(batch * t);
+let inputs = ScalarField::generate_random(batch * t);
 let poseidon_hasher = Poseidon::new::<ScalarField>(t as u32, None /*=domain-tag*/).unwrap(); // Instantiate Poseidon without domain tag
 
 poseidon_hasher
@@ -95,7 +95,7 @@ poseidon_hasher
 
 // Case (2): Hashing with a domain tag
 // Generates 'batch * (t - 1)' inputs, as domain tag counts as one input in each hash
-let inputs = ScalarCfg::generate_random(batch * (t - 1));
+let inputs = ScalarField::generate_random(batch * (t - 1));
 let domain_tag = ScalarField::zero(); // Example domain tag (can be any valid field element)
 let poseidon_hasher_with_domain_tag = Poseidon::new::<ScalarField>(t as u32, Some(&domain_tag) /*=domain-tag*/).unwrap();
 

--- a/docs/docs/api/rust-bindings/lattice/pqc-ml-kem.md
+++ b/docs/docs/api/rust-bindings/lattice/pqc-ml-kem.md
@@ -20,7 +20,7 @@ pub fn keygen<P: KyberParams>(
     config: &MlKemConfig,
     public_keys: &mut (impl HostOrDeviceSlice<u8> + ?Sized), // batch_size × PUBLIC_KEY_BYTES
     secret_keys: &mut (impl HostOrDeviceSlice<u8> + ?Sized), // batch_size × SECRET_KEY_BYTES
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 ```
 
 ### Encapsulation
@@ -32,7 +32,7 @@ pub fn encapsulate<P: KyberParams>(
     config: &MlKemConfig,
     ciphertexts: &mut (impl HostOrDeviceSlice<u8> + ?Sized), // batch_size × CIPHERTEXT_BYTES
     shared_secrets: &mut (impl HostOrDeviceSlice<u8> + ?Sized), // batch_size × SHARED_SECRET_BYTES
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 ```
 
 ### Decapsulation
@@ -43,7 +43,7 @@ pub fn decapsulate<P: KyberParams>(
     ciphertexts: &(impl HostOrDeviceSlice<u8> + ?Sized), // batch_size × CIPHERTEXT_BYTES
     config: &MlKemConfig,
     shared_secrets: &mut (impl HostOrDeviceSlice<u8> + ?Sized), // batch_size × SHARED_SECRET_BYTES
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 ```
 
 All buffers may live either on the **host** or on the currently-active **device**.
@@ -140,7 +140,7 @@ The API works identically for Device buffers – allocate input/output `DeviceVe
 
 ## Error handling
 
-All functions return `Result<(), eIcicleError>`.  An error is raised for invalid buffer sizes, mismatched device selection, or when the selected backend is not available.
+All functions return `Result<(), IcicleError>`.  An error is raised for invalid buffer sizes, mismatched device selection, or when the selected backend is not available.
 
 ---
 

--- a/docs/docs/api/rust-bindings/matrix_ops.md
+++ b/docs/docs/api/rust-bindings/matrix_ops.md
@@ -1,0 +1,81 @@
+# Matrix Operations (Rust bindings)
+
+`icicle-core` exposes a small but very useful set of **matrix primitives** that work on data located either in host-memory or on the GPU.  They are implemented on top of – and share the same configuration structure as – the generic vector-operations backend (`VecOps`).
+
+---
+## Trait: `MatrixOps`
+
+```rust
+use icicle_runtime::memory::HostOrDeviceSlice;
+use icicle_core::vec_ops::VecOpsConfig;
+use icicle_runtime::errors::IcicleError;
+
+pub trait MatrixOps<T> {
+    /// Matrix multiplication:  `result = a × b` (row-major inputs / outputs)
+    fn matmul(
+        a: &(impl HostOrDeviceSlice<T> + ?Sized),
+        a_rows: u32,
+        a_cols: u32,
+        b: &(impl HostOrDeviceSlice<T> + ?Sized),
+        b_rows: u32,
+        b_cols: u32,
+        cfg: &VecOpsConfig,
+        result: &mut (impl HostOrDeviceSlice<T> + ?Sized),
+    ) -> Result<(), IcicleError>;
+
+    /// Out-of-place matrix transpose (row-major)
+    fn matrix_transpose(
+        input: &(impl HostOrDeviceSlice<T> + ?Sized),
+        nof_rows: u32,
+        nof_cols: u32,
+        cfg: &VecOpsConfig,
+        output: &mut (impl HostOrDeviceSlice<T> + ?Sized),
+    ) -> Result<(), IcicleError>;
+}
+```
+
+All concrete field / ring crates (for example `icicle_bn254`, `icicle_babybear`, …) re-export blanket implementations for their native scalar type via an internal macro.  Thus **you only need to import the scalar type** – the trait implementation is already in scope.
+
+---
+## Convenience free functions
+
+Instead of calling the trait manually you can use the thin wrappers defined in `icicle_core::matrix_ops`:
+
+```rust
+use icicle_core::matrix_ops::{matmul, matrix_transpose};
+```
+
+They perform the exact same checks and dispatch to the trait implementation.
+
+---
+## Example
+
+Multiply two random BN254 matrices entirely on the GPU and read the result back to the host.
+
+```rust
+use icicle_bn254::field::ScalarField;
+use icicle_core::matrix_ops::{matmul};
+use icicle_core::vec_ops::VecOpsConfig;
+use icicle_runtime::memory::{DeviceVec, HostSlice};
+use icicle_core::traits::GenerateRandom;
+
+const N: usize = 512; // We will compute C = A × B where A,B are N×N
+
+// 1. Generate random data on the host
+let a_host = ScalarField::generate_random(N * N);
+let b_host = ScalarField::generate_random(N * N);
+// 2. Move the data to device memory
+// 3. Allocate the result buffer on the device
+// 4. Perform matmul
+let cfg = VecOpsConfig::default();
+matmul(&a_dev[..], N as u32, N as u32,
+       &b_dev[..], N as u32, N as u32,
+       &cfg, &mut c_dev[..]).unwrap();
+// 5. Copy the result back if needed
+let mut c_host = vec![ScalarField::zero(); N * N];
+c_dev.copy_to_host(HostSlice::from_mut_slice(&mut c_host)).unwrap();
+```
+
+---
+## Error handling
+All functions return `IcicleError`.  The helpers do validity checks (dimension mismatches, device/host placement, …) before dispatching to the backend, guaranteeing early and descriptive error messages. 

--- a/docs/docs/api/rust-bindings/matrix_ops.md
+++ b/docs/docs/api/rust-bindings/matrix_ops.md
@@ -14,17 +14,15 @@ use icicle_runtime::config::ConfigExtension;
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct MatMulConfig {
-    pub stream_handle: IcicleStreamHandle, // CUDA/stream for async execution
-    pub is_a_on_device: bool,
-    pub is_b_on_device: bool,
-    pub is_result_on_device: bool,
-    pub is_async: bool,
-    pub batch_size: i32,
-    pub columns_batch: bool,
-    pub a_is_transposed: bool,
-    pub b_is_transposed: bool,
-    pub result_is_transposed: bool,
-    pub ext: ConfigExtension, // Backend-specific extensions
+    pub stream_handle: IcicleStreamHandle, // Execution stream (e.g., CUDA stream)
+    pub is_a_on_device: bool,              // True if `a` is on device memory
+    pub is_b_on_device: bool,              // True if `b` is on device memory
+    pub is_result_on_device: bool,         // True if result stays on device
+    pub a_transposed: bool,                // Transpose input `a`
+    pub b_transposed: bool,                // Transpose input `b`
+    pub result_transposed: bool,           // Transpose the output
+    pub is_async: bool,                    // Non-blocking execution if true
+    pub ext: ConfigExtension,              // Backend-specific config
 }
 
 impl MatMulConfig {
@@ -139,5 +137,4 @@ All functions return `IcicleError`. The helpers perform validity checks (dimensi
 - The `MatMulConfig` and `VecOpsConfig` structs control backend selection and options.
 
 ---
-## No fused/batched matrix APIs
-As of the current branch, there are **no fused or batched matrix operations** exposed in the Rust bindings. Only `matmul` and `matrix_transpose` are available. 
+As of the current branch, there are **no batched matrix operations** exposed in the Rust bindings. Only `matmul` and `matrix_transpose` are available. 

--- a/docs/docs/api/rust-bindings/matrix_ops.md
+++ b/docs/docs/api/rust-bindings/matrix_ops.md
@@ -71,9 +71,8 @@ let cfg = VecOpsConfig::default();
 matmul(&a_dev[..], N as u32, N as u32,
        &b_dev[..], N as u32, N as u32,
        &cfg, &mut c_dev[..]).unwrap();
+// Result is stored in c_dev for this example
 // 5. Copy the result back if needed
-let mut c_host = vec![ScalarField::zero(); N * N];
-c_dev.copy_to_host(HostSlice::from_mut_slice(&mut c_host)).unwrap();
 ```
 
 ---

--- a/docs/docs/api/rust-bindings/merkle.md
+++ b/docs/docs/api/rust-bindings/merkle.md
@@ -16,12 +16,12 @@ struct MerkleTree{
     /// * `leaf_element_size` - Size of each leaf element.
     /// * `output_store_min_layer` - Minimum layer at which the output is stored.
     ///
-    /// # Returns a new `MerkleTree` instance or eIcicleError.
+    /// # Returns a new `MerkleTree` instance or IcicleError.
     pub fn new(
         layer_hashers: &[&Hasher],
         leaf_element_size: u64,
         output_store_min_layer: u64,
-    ) -> Result<Self, eIcicleError>;
+    ) -> Result<Self, IcicleError>;
 }
 ```
 
@@ -45,7 +45,7 @@ struct MerkleTree{
         &self,
         leaves: &(impl HostOrDeviceSlice<T> + ?Sized),
         cfg: &MerkleTreeConfig,
-    ) -> Result<(), eIcicleError>;
+    ) -> Result<(), IcicleError>;
 }
 ```
 
@@ -150,7 +150,7 @@ struct MerkleTree{
     ///
     /// # Returns
     /// A reference to the root hash.
-    pub fn get_root<T>(&self) -> Result<&[T], eIcicleError>;
+    pub fn get_root<T>(&self) -> Result<&[T], IcicleError>;
 }
 
 let commitment: &[u8] = merkle_tree
@@ -184,14 +184,14 @@ struct MerkleTree{
     /// * `pruned_path` - Whether the proof should be pruned.
     /// * `config` - Configuration for the Merkle tree.
     ///
-    /// # Returns a `MerkleProof` object or eIcicleError
+    /// # Returns a `MerkleProof` object or IcicleError
     pub fn get_proof<T>(
         &self,
         leaves: &(impl HostOrDeviceSlice<T> + ?Sized),
         leaf_idx: u64,
         pruned_path: bool,
         config: &MerkleTreeConfig,
-    ) -> Result<MerkleProof, eIcicleError>;
+    ) -> Result<MerkleProof, IcicleError>;
 }
 ```
 
@@ -223,7 +223,7 @@ struct MerkleTree{
     /// * `proof` - The Merkle proof to verify.
     ///
     /// # Returns a result indicating whether the proof is valid.
-    pub fn verify(&self, proof: &MerkleProof) -> Result<bool, eIcicleError>;
+    pub fn verify(&self, proof: &MerkleProof) -> Result<bool, IcicleError>;
 }
 ```
 

--- a/docs/docs/api/rust-bindings/ntt.md
+++ b/docs/docs/api/rust-bindings/ntt.md
@@ -8,13 +8,13 @@ pub fn ntt<T, F>(
     dir: NTTDir,
     cfg: &NTTConfig<F>,
     output: &mut (impl HostOrDeviceSlice<T> + ?Sized),
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn ntt_inplace<T, F>(
     inout: &mut (impl HostOrDeviceSlice<T> + ?Sized),
     dir: NTTDir,
     cfg: &NTTConfig<F>,
-) -> Result<(), eIcicleError>
+) -> Result<(), IcicleError>
 ```
 
 - **`input`** - buffer to read the inputs of the NTT from.
@@ -27,7 +27,7 @@ The `input` and `output` buffers can be on device or on host. Being on host mean
 ### NTT Config
 
 ```rust
-pub struct NTTConfig<S> {
+pub struct NTTConfig<S: IntegerRing> {
     pub stream_handle: IcicleStreamHandle,
     pub coset_gen: S,
     pub batch_size: i32,
@@ -66,12 +66,12 @@ The `NTTConfig` struct is a configuration object used to specify parameters for 
 ```rust
 // Setting Bn254 points and scalars
 println!("Generating random inputs on host for bn254...");
-let scalars = Bn254ScalarCfg::generate_random(size);
-let mut ntt_results = DeviceVec::<Bn254ScalarField>::device_malloc(size).unwrap();
+let scalars = ScalarField::generate_random(size);
+let mut ntt_results = DeviceVec::<ScalarField>::device_malloc(size).unwrap();
 
 // constructing NTT domain
 initialize_domain(
-    ntt::get_root_of_unity::<Bn254ScalarField>(
+    ntt::get_root_of_unity::<ScalarField>(
         size.try_into()
             .unwrap(),
     ),
@@ -80,7 +80,7 @@ initialize_domain(
 .unwrap();
 
 // Using default config
-let cfg = ntt::NTTConfig::<Bn254ScalarField>::default();
+let cfg = ntt::NTTConfig::<ScalarField>::default();
 
 // Computing NTT
 ntt::ntt(
@@ -99,8 +99,8 @@ In rust, we have the following functions to construct, destruct the domain and r
 
 ```rust
 pub trait NTTDomain<F: FieldImpl> {
-    pub fn initialize_domain<F>(primitive_root: F, config: &NTTInitDomainConfig) -> Result<(), eIcicleError>;
-    pub fn release_domain<F>() -> Result<(), eIcicleError>;
+    pub fn initialize_domain<F>(primitive_root: F, config: &NTTInitDomainConfig) -> Result<(), IcicleError>;
+    pub fn release_domain<F>() -> Result<(), IcicleError>;
     pub fn get_root_of_unity<F>(max_size: u64) -> F;
 }
 ```

--- a/docs/docs/api/rust-bindings/pairing.md
+++ b/docs/docs/api/rust-bindings/pairing.md
@@ -1,0 +1,66 @@
+# Pairings
+
+The pairing interface in `icicle-core` gives you access to efficient bilinear pairings on supported curves (BN254, BLS12-377, BLS12-381, BW6-761, …).  Everything is wrapped in a safe, idiomatic Rust layer that automatically moves data between host and device memory when necessary.
+
+---
+## Trait & helper function
+
+```rust
+use icicle_core::{field::Field, projective::Projective};
+use icicle_runtime::errors::IcicleError;
+
+pub trait Pairing<P1: Projective, P2: Projective, F: Field> {
+    fn pairing(p: &P1::Affine, q: &P2::Affine) -> Result<F, IcicleError>;
+}
+
+/// Convenience free-function that dispatches to the trait implementation
+pub fn pairing<P1, P2, F>(p: &P1::Affine, q: &P2::Affine) -> Result<F, IcicleError>
+where
+    P1: Projective + Pairing<P1, P2, F>,
+    P2: Projective,
+    F: Field,
+{
+    P1::pairing(p, q)
+}
+```
+
+Each curve crate that supports pairings provides the concrete implementation via the `impl_pairing!` macro.  For BN254 (which is equipped with a single‐thread pairing on G1×G2) the types look like:
+
+```rust
+use icicle_bn254::curve::{G1Projective, G2Projective};
+use icicle_bn254::pairing::PairingTargetField; // 12-degree extension field Fₚ¹²
+```
+
+---
+## Example
+
+```rust
+use icicle_bn254::curve::{G1Projective, G2Projective};
+use icicle_core::pairing::pairing; // helper free-function
+use icicle_core::traits::GenerateRandom;
+
+// Generate random points (G1 + G2 live in different groups)
+let p = G1Projective::generate_random(1)[0].to_affine();
+let q = G2Projective::generate_random(1)[0].to_affine();
+// Compute the pairing e(P, Q)
+let gt = pairing::<G1Projective, G2Projective, _>(&p, &q).unwrap();
+println!("e(P, Q) = {:?}", gt);
+```
+
+The return value `gt` lives in the **target field** (e.g. Fₚ¹² for BN254/BLS12 curves).  The exact name of the type depends on the curve crate – consult the module `pairing` inside each crate.
+
+---
+## Testing bilinearity
+
+Most crates also export a helper in `icicle_core::pairing::tests` that you can reuse inside your own unit tests:
+
+```rust
+use icicle_core::pairing::tests::check_pairing_bilinearity;
+use icicle_bn254::curve::{G1Projective, G2Projective};
+use icicle_bn254::pairing::PairingTargetField;
+
+#[test]
+fn bn254_pairing_bilinearity() {
+    check_pairing_bilinearity::<G1Projective, G2Projective, PairingTargetField>();
+}
+``` 

--- a/docs/docs/api/rust-bindings/pairing.md
+++ b/docs/docs/api/rust-bindings/pairing.md
@@ -48,19 +48,3 @@ println!("e(P, Q) = {:?}", gt);
 ```
 
 The return value `gt` lives in the **target field** (e.g. Fₚ¹² for BN254/BLS12 curves).  The exact name of the type depends on the curve crate – consult the module `pairing` inside each crate.
-
----
-## Testing bilinearity
-
-Most crates also export a helper in `icicle_core::pairing::tests` that you can reuse inside your own unit tests:
-
-```rust
-use icicle_core::pairing::tests::check_pairing_bilinearity;
-use icicle_bn254::curve::{G1Projective, G2Projective};
-use icicle_bn254::pairing::PairingTargetField;
-
-#[test]
-fn bn254_pairing_bilinearity() {
-    check_pairing_bilinearity::<G1Projective, G2Projective, PairingTargetField>();
-}
-``` 

--- a/docs/docs/api/rust-bindings/program.md
+++ b/docs/docs/api/rust-bindings/program.md
@@ -27,8 +27,8 @@ pub trait Symbol<F: FieldImpl>:
   for<'a> MulAssign<&'a Self> +
   Clone + Copy + Sized + Handle
 {
-  fn new_input(in_idx: u32) -> Result<Self, eIcicleError>;      // New input symbol for the execution function
-  fn from_constant(constant: F) -> Result<Self, eIcicleError>;  // New symbol from a field element
+  fn new_input(in_idx: u32) -> Result<Self, IcicleError>;      // New input symbol for the execution function
+  fn from_constant(constant: F) -> Result<Self, IcicleError>;  // New symbol from a field element
 
   fn inverse(&self) -> Self; // Field inverse of the symbol
 }
@@ -57,9 +57,9 @@ where
 {
   type ProgSymbol: Symbol<F>;
 
-  fn new(program_func: impl FnOnce(&mut Vec<Self::ProgSymbol>) -> Self::ProgSymbol, nof_parameters: u32) -> Result<Self, eIcicleError>;
+  fn new(program_func: impl FnOnce(&mut Vec<Self::ProgSymbol>) -> Self::ProgSymbol, nof_parameters: u32) -> Result<Self, IcicleError>;
 
-  fn new_predefined(pre_def: PreDefinedProgram) -> Result<Self, eIcicleError>;
+  fn new_predefined(pre_def: PreDefinedProgram) -> Result<Self, IcicleError>;
 }
 ```
 ## `Program` Struct
@@ -109,7 +109,7 @@ pub fn execute_program<F, Prog, Parameter>(
     data: &mut Vec<&Parameter>,
     program: &Prog,
     cfg: &VecOpsConfig
-) -> Result<(), eIcicleError>
+) -> Result<(), IcicleError>
 where
     F: FieldImpl,
     <F as FieldImpl>::Config: VecOps<F>,

--- a/docs/docs/api/rust-bindings/sumcheck.md
+++ b/docs/docs/api/rust-bindings/sumcheck.md
@@ -48,13 +48,13 @@ Defines the main API for SumCheck operations.
 - `Proof: SumcheckProofOps<Self::Field>` - Type representing the proof.
 
 ##### **Methods:**
-- **`new() -> Result<Self, eIcicleError>`**:
+- **`new() -> Result<Self, IcicleError>`**:
   Initializes a new instance.
 
 - **`prove(mle_polys, mle_poly_size, claimed_sum, combine_function, transcript_config, sumcheck_config) -> Self::Proof`**:
   Generates a proof for the polynomial sum over the Boolean hypercube.
 
-- **`verify(proof, claimed_sum, transcript_config) -> Result<bool, eIcicleError>`**:
+- **`verify(proof, claimed_sum, transcript_config) -> Result<bool, IcicleError>`**:
   Verifies the provided proof.
 
 
@@ -62,10 +62,10 @@ Defines the main API for SumCheck operations.
 Operations for handling SumCheck proofs.
 
 ##### **Methods:**
-- **`get_round_polys(&self) -> Result<Vec<Vec<F>>, eIcicleError>`**:
+- **`get_round_polys(&self) -> Result<Vec<Vec<F>>, IcicleError>`**:
   Retrieves the polynomials for each round.
 
-- **`print(&self) -> eIcicleError`**::
+- **`print(&self) -> IcicleError`**::
   Prints the proof.
 
 
@@ -150,9 +150,9 @@ pub trait ReturningValueProgram:
   type Field: FieldImpl;
   type ProgSymbol: Symbol<Self::Field>;
 
-  fn new(program_func: impl FnOnce(&mut Vec<Self::ProgSymbol>) -> Self::ProgSymbol, nof_parameters: u32) -> Result<Self, eIcicleError>;
+  fn new(program_func: impl FnOnce(&mut Vec<Self::ProgSymbol>) -> Self::ProgSymbol, nof_parameters: u32) -> Result<Self, IcicleError>;
 
-  fn new_predefined(pre_def: PreDefinedProgram) -> Result<Self, eIcicleError>;
+  fn new_predefined(pre_def: PreDefinedProgram) -> Result<Self, IcicleError>;
 }
 
 ```

--- a/docs/docs/api/rust-bindings/vec-ops.md
+++ b/docs/docs/api/rust-bindings/vec-ops.md
@@ -67,27 +67,27 @@ pub fn add_scalars<F>(
     b: &(impl HostOrDeviceSlice<F> + ?Sized),
     result: &mut (impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn accumulate_scalars<F>(
     a: &mut (impl HostOrDeviceSlice<F> + ?Sized),
     b: &(impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn sub_scalars<F>(
     a: &(impl HostOrDeviceSlice<F> + ?Sized),
     b: &(impl HostOrDeviceSlice<F> + ?Sized),
     result: &mut (impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn mul_scalars<F>(
     a: &(impl HostOrDeviceSlice<F> + ?Sized),
     b: &(impl HostOrDeviceSlice<F> + ?Sized),
     result: &mut (impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn transpose_matrix<F>(
     input: &(impl HostOrDeviceSlice<F> + ?Sized),
@@ -95,27 +95,16 @@ pub fn transpose_matrix<F>(
     nof_cols: u32,
     output: &mut (impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn bit_reverse<F>(
     input: &(impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
     output: &mut (impl HostOrDeviceSlice<F> + ?Sized),
-) -> Result<(), eIcicleError>;
+) -> Result<(), IcicleError>;
 
 pub fn bit_reverse_inplace<F>(
     input: &mut (impl HostOrDeviceSlice<F> + ?Sized),
     cfg: &VecOpsConfig,
-) -> Result<(), eIcicleError>;
-
-pub fn execute_program<F, Prog, Data>(
-    data: &mut Vec<&Data>,
-    program: &Prog,
-    cfg: &VecOpsConfig
-) -> Result<(), eIcicleError>
-where
-    F: FieldImpl,
-    <F as FieldImpl>::Config: VecOps<F>,
-    Data: HostOrDeviceSlice<F> + ?Sized,
-    Prog: Program<F>;
+) -> Result<(), IcicleError>;
 ```

--- a/docs/docs/start/integration-&-support/migrate_from_v3.md
+++ b/docs/docs/start/integration-&-support/migrate_from_v3.md
@@ -133,13 +133,24 @@ If you still see `FieldImpl` in your codebase, replace it with the minimal set o
 
 In v4, the Program API has been moved from VecOps to a dedicated Program module for better organization and type safety.
 
-| Operation | v3 (VecOps) | v4 (Program) |
-|-----------|-------------|--------------|
-| Create program | `Fr::create_program(|symbols| { ... }, nof_params)?` | `FieldProgram::new(|symbols| { ... }, nof_params)?` |
-| Execute program | `Fr::execute_program(&program, &mut vec_data, &config)?` | `program.execute_program(&mut vec_data, &config)?` |
-| Create returning value program | Not available | `FieldReturningValueProgram::new(|symbols| -> symbol { ... }, nof_params)?` |
-| Create predefined program | `Fr::create_predefined_program(pre_def)?` | `FieldProgram::new_predefined(pre_def)?` |
-| Imports | `use icicle_core::vec_ops::{VecOps, VecOpsConfig};` | `use icicle_core::program::{Program, ReturningValueProgram};` |
+#### Create program
+- **v3 (VecOps):** `Fr::create_program(|symbols| { ... }, nof_params)?`
+- **v4 (Program):** `FieldProgram::new(|symbols| { ... }, nof_params)?`
+
+#### Execute program
+- **v3 (VecOps):** `Fr::execute_program(&program, &mut vec_data, &config)?`
+- **v4 (Program):** `program.execute_program(&mut vec_data, &config)?`
+
+#### Create returning value program
+- **v4:** `ReturningValueProgram::new(|symbols| -> symbol { ... }, nof_params)?`
+
+#### Create predefined program
+- **v3 (VecOps):** `Fr::create_predefined_program(pre_def)?`
+- **v4 (Program):** `FieldProgram::new_predefined(pre_def)?`
+
+#### Imports
+- **v3 (VecOps):** `use icicle_core::vec_ops::{VecOps, VecOpsConfig};`
+- **v4 (Program):** `use icicle_core::program::{Program, ReturningValueProgram};`
 
 ### Example Migration
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -315,6 +315,16 @@ export default {
           label: "Serialization",
           id: "api/rust-bindings/serialization",
         },
+        {
+          type: "doc",
+          label: "Pairings",
+          id: "api/rust-bindings/pairing",
+        },  
+        {
+          type: "doc",
+          label: "Matrix Operations",
+          id: "api/rust-bindings/matrix_ops",
+        },
       ],
     },
   ],

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -186,6 +186,11 @@ export default {
           label: "Serialization",
           id: "api/cpp/serialization",
         },
+        {
+          type: "doc",
+          label: "Matrix Operations",
+          id: "api/cpp/matrix_ops",
+        },
       ],
     },
     {


### PR DESCRIPTION
This PR updates Rust wrapper documentation for ICICLE V4
* Added matrix ops
* Added pairings

## Backend branches

Replace "main" with the branch this PR should work with

cuda-backend-branch: main

metal-backend-branch: main
