### PR TITLE
[FEAT] Remove force inline from mul_wide

### DIFF
--- a/icicle/include/icicle/fields/complex_extension.h
+++ b/icicle/include/icicle/fields/complex_extension.h
@@ -199,7 +199,7 @@ public:
     }
   }
 
-  constexpr HOST_DEVICE_INLINE Wide mul_wide(const ComplexExtensionField& ys) const
+  constexpr HOST_DEVICE Wide mul_wide(const ComplexExtensionField& ys) const
   {
 #ifdef __CUDA_ARCH__
     constexpr bool do_karatsuba = FF::TLC >= 8; // The basic multiplier size is 1 limb, Karatsuba is more efficient when

--- a/icicle/include/icicle/fields/cubic_extension.h
+++ b/icicle/include/icicle/fields/cubic_extension.h
@@ -193,7 +193,7 @@ public:
     }
   }
 
-  constexpr HOST_DEVICE_INLINE Wide mul_wide(const CubicExtensionField& ys) const
+  constexpr HOST_DEVICE Wide mul_wide(const CubicExtensionField& ys) const
   {
     FWide c0_prod = c0.mul_wide(ys.c0);
     FWide c1_prod = c1.mul_wide(ys.c1);

--- a/icicle/include/icicle/fields/quartic_extension.h
+++ b/icicle/include/icicle/fields/quartic_extension.h
@@ -171,7 +171,7 @@ public:
     return *this;
   }
 
-  constexpr HOST_DEVICE_INLINE Wide mul_wide(const QuarticExtensionField& ys) const
+  constexpr HOST_DEVICE Wide mul_wide(const QuarticExtensionField& ys) const
   {
     if (CONFIG::nonresidue_is_negative)
       return Wide{


### PR DESCRIPTION
## Describe the changes

This PR removes the INLINE directive from the mul_wide methods in field extension classes (complex, cubic, and quartic). This change optimizes the build process by allowing the compiler to make better decisions about inlining these functions.

## Describe the rational

Reduce compile time as the compiler doesn't need to inline large functions at every call site

## Backend branches

cuda-backend-branch: main

metal-backend-branch: main
