### PR TITLE
refactor(tests): simplify HostSlice conversion in ecntt test

### DIFF
--- a/wrappers/rust/icicle-core/src/ecntt/tests.rs
+++ b/wrappers/rust/icicle-core/src/ecntt/tests.rs
@@ -69,9 +69,7 @@ where
                 let one_ntt_result = slice.into_slice_mut();
                 for i in 0..batch_size {
                     ecntt(
-                        icicle_runtime::memory::HostSlice::from_slice(
-                            &points[i * test_size..(i + 1) * test_size].as_slice(),
-                        ), //TODO: simplify this
+                        points[i * test_size..(i + 1) * test_size].into_slice(),
                         is_inverse,
                         &config,
                         one_ntt_result,


### PR DESCRIPTION
## Describe the changes

This PR simplifies the call to ecntt in tests.rs by removing an unnecessary conversion using HostSlice::from_slice(...). The slice is now passed directly using .into_slice().

## Describe the rational

The change reduces code complexity by eliminating redundant wrapping of the slice. The simplified call improves readability and makes the test code easier to maintain.

## Backend branches

Replace "main" with the branch this PR should work with

cuda-backend-branch: main

metal-backend-branch: main
