### PR TITLE
fix: incorrect comment about transmute function behavior

### DIFF
--- a/examples/rust/arkworks-icicle-conversions/src/main.rs
+++ b/examples/rust/arkworks-icicle-conversions/src/main.rs
@@ -248,7 +248,7 @@ fn main() {
     //============================================================================================//
     //========================= Part 2: or transmute ark scalars in-place ========================//
     //============================================================================================//
-    let mut ark_scalars_copy = ark_scalars.clone(); // copy since transmute modifies the scalars in-place
+    let mut ark_scalars_copy = ark_scalars.clone(); // copy since we need mutable access for transmute
     let start = Instant::now();
     let _icicle_transumated_scalars: &mut [ScalarField] = transmute_ark_to_icicle_scalars(&mut ark_scalars_copy);
     let duration = start.elapsed();


### PR DESCRIPTION
Update comment on line 217 to accurately describe why we clone the scalars.
The previous comment incorrectly stated that transmute_ark_to_icicle_scalars 
modifies data in-place, when it actually returns a new slice. The cloning is 
needed to provide mutable access for the transmute operation, not because the 
function modifies the original data.

- Change: "copy since transmute modifies the scalars in-place" 
- To: "copy since we need mutable access for transmute"