### PR TITLE
fix(balanced_decomposition): reconstruct modulus from limbs

### DIFF
--- a/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
+++ b/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
@@ -7,6 +7,7 @@
 #include <taskflow/core/taskflow.hpp>
 
 static_assert(field_t::TLC == 2, "Decomposition assumes q ~64b");
+static_assert(sizeof(((::storage<field_t::TLC>*)nullptr)->limbs[0]) == 4, "Balanced decomposition assumes 32-bit limbs");
 
 // extract the number of threads to run from config
 int get_nof_workers(const VecOpsConfig& config); // defined in cpu_vec_ops.cpp
@@ -39,8 +40,9 @@ template <typename T>
 int64_t get_q()
 {
   constexpr auto q_storage = T::get_modulus();
-  const int64_t q = *(const int64_t*)&q_storage;
-  return q;
+  const uint64_t q_u = (static_cast<uint64_t>(q_storage.limbs[0])) |
+                       (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
+  return static_cast<int64_t>(q_u);
 }
 
 template <typename T>

--- a/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
+++ b/icicle/backend/cpu/src/ring/cpu_balanced_decomposition.cpp
@@ -7,7 +7,8 @@
 #include <taskflow/core/taskflow.hpp>
 
 static_assert(field_t::TLC == 2, "Decomposition assumes q ~64b");
-static_assert(sizeof(((::storage<field_t::TLC>*)nullptr)->limbs[0]) == 4, "Balanced decomposition assumes 32-bit limbs");
+static_assert(
+  sizeof(((::storage<field_t::TLC>*)nullptr)->limbs[0]) == 4, "Balanced decomposition assumes 32-bit limbs");
 
 // extract the number of threads to run from config
 int get_nof_workers(const VecOpsConfig& config); // defined in cpu_vec_ops.cpp
@@ -40,8 +41,7 @@ template <typename T>
 int64_t get_q()
 {
   constexpr auto q_storage = T::get_modulus();
-  const uint64_t q_u = (static_cast<uint64_t>(q_storage.limbs[0])) |
-                       (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
+  const uint64_t q_u = (static_cast<uint64_t>(q_storage.limbs[0])) | (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
   return static_cast<int64_t>(q_u);
 }
 

--- a/icicle/include/icicle/balanced_decomposition.h
+++ b/icicle/include/icicle/balanced_decomposition.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "icicle/vec_ops.h" // For VecOpsConfig
+#include <cmath>
 
 namespace icicle {
   namespace balanced_decomposition {
@@ -36,10 +37,11 @@ namespace icicle {
       static_assert(T::TLC == 2, "Balanced decomposition assumes q ~64-bit");
 
       constexpr auto q_storage = T::get_modulus();
-      const int64_t q = *(const int64_t*)&q_storage;
-      ICICLE_ASSERT(q > 0) << "Expecting at least one slack bit to use int64 arithmetic";
+      const uint64_t q_u = (static_cast<uint64_t>(q_storage.limbs[0])) |
+                           (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
+      ICICLE_ASSERT(q_u > 0) << "Expecting at least one slack bit to use 64-bit arithmetic";
 
-      const double log2_q = std::log2(static_cast<double>(q));
+      const double log2_q = std::log2(static_cast<double>(q_u));
       const double log2_b = std::log2(static_cast<double>(base));
       const uint32_t digits = static_cast<uint32_t>(std::ceil(log2_q / log2_b));
 

--- a/icicle/include/icicle/balanced_decomposition.h
+++ b/icicle/include/icicle/balanced_decomposition.h
@@ -35,11 +35,12 @@ namespace icicle {
     static constexpr inline uint32_t compute_nof_digits(uint32_t base)
     {
       static_assert(T::TLC == 2, "Balanced decomposition assumes q ~64-bit");
-      static_assert(sizeof(((::storage<T::TLC>*)nullptr)->limbs[0]) == 4, "Balanced decomposition assumes 32-bit limbs");
+      static_assert(
+        sizeof(((::storage<T::TLC>*)nullptr)->limbs[0]) == 4, "Balanced decomposition assumes 32-bit limbs");
 
       constexpr auto q_storage = T::get_modulus();
-      const uint64_t q_u = (static_cast<uint64_t>(q_storage.limbs[0])) |
-                           (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
+      const uint64_t q_u =
+        (static_cast<uint64_t>(q_storage.limbs[0])) | (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
       ICICLE_ASSERT(q_u < (1ull << 63)) << "Expecting at least one slack bit (q < 2^63) for int64 arithmetic";
 
       const double log2_q = std::log2(static_cast<double>(q_u));

--- a/icicle/include/icicle/balanced_decomposition.h
+++ b/icicle/include/icicle/balanced_decomposition.h
@@ -35,11 +35,12 @@ namespace icicle {
     static constexpr inline uint32_t compute_nof_digits(uint32_t base)
     {
       static_assert(T::TLC == 2, "Balanced decomposition assumes q ~64-bit");
+      static_assert(sizeof(((::storage<T::TLC>*)nullptr)->limbs[0]) == 4, "Balanced decomposition assumes 32-bit limbs");
 
       constexpr auto q_storage = T::get_modulus();
       const uint64_t q_u = (static_cast<uint64_t>(q_storage.limbs[0])) |
                            (static_cast<uint64_t>(q_storage.limbs[1]) << 32);
-      ICICLE_ASSERT(q_u > 0) << "Expecting at least one slack bit to use 64-bit arithmetic";
+      ICICLE_ASSERT(q_u < (1ull << 63)) << "Expecting at least one slack bit (q < 2^63) for int64 arithmetic";
 
       const double log2_q = std::log2(static_cast<double>(q_u));
       const double log2_b = std::log2(static_cast<double>(base));


### PR DESCRIPTION
- Replace pointer-punning of modulus (*(const int64_t*)&q_storage) with portable 64-bit reconstruction from 32-bit limbs.
- Eliminates strict-aliasing UB and endianness dependence; keeps behavior unchanged on little-endian targets.
- Add <cmath> include for std::log2/std::ceil usage.
- Update assert message to reference 64-bit arithmetic expectations.