### PR TITLE
fix: replace reduce_from_bytes with from in FFI function for proper modular reduction

### DIFF
--- a/icicle/include/icicle/fields/externs.h
+++ b/icicle/include/icicle/fields/externs.h
@@ -43,5 +43,5 @@
   extern "C" void ICICLE_FFI_EXPAND_AND_CONCAT3(ICICLE_FFI_PREFIX, PREFIX, _from_bytes_le)(                            \
     uint8_t* bytes, TYPE* result)                                                                                      \
   {                                                                                                                    \
-    *result = TYPE::reduce_from_bytes((std::byte*)bytes);                                                              \
+    *result = TYPE::from((std::byte*)bytes, TYPE::TLC * 4);                                                            \
   }


### PR DESCRIPTION
## Problem
`FieldImpl::from_bytes_le()` sometimes produces incorrect results when converting random bytes to field elements, leading to arithmetic inconsistencies and failed polynomial evaluations.

## Root Cause
FFI function `_from_bytes_le` uses `TYPE::reduce_from_bytes()` which doesn't properly handle values larger than the field modulus.

## Solution
Replace `TYPE::reduce_from_bytes()` with `TYPE::from()` which uses a robust reduction algorithm with precomputed values and Barrett reduction.

Fixes #997